### PR TITLE
use c++ concepts for object-components

### DIFF
--- a/include/vierkant/Mesh.hpp
+++ b/include/vierkant/Mesh.hpp
@@ -328,6 +328,9 @@ struct animated_mesh_t
 
 struct mesh_component_t
 {
+    // object_component concept
+    static constexpr char component_description[] = "mesh-component";
+
     //! handle to a mesh, containing buffers and a list of entries
     vierkant::MeshConstPtr mesh;
 

--- a/include/vierkant/Mesh.hpp
+++ b/include/vierkant/Mesh.hpp
@@ -14,6 +14,7 @@
 #include <vierkant/vertex_attrib.hpp>
 #include <vierkant/transform.hpp>
 #include <vierkant/intersection.hpp>
+#include <vierkant/object_component.hpp>
 
 namespace vierkant
 {
@@ -328,8 +329,7 @@ struct animated_mesh_t
 
 struct mesh_component_t
 {
-    // object_component concept
-    static constexpr char component_description[] = "mesh-component";
+    VIERKANT_ENABLE_AS_COMPONENT();
 
     //! handle to a mesh, containing buffers and a list of entries
     vierkant::MeshConstPtr mesh;

--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -23,7 +23,7 @@ namespace vierkant
 template<class T>
 concept object_component =
         requires() {
-            std::is_same<std::decay_t<decltype(std::remove_pointer_t<T>::component_description)>(), const char *>();
+            std::is_same<decltype(std::remove_pointer_t<T>::component_description), const char *>();
 //            std::is_same<typename T::Type, object_component_trait_t>();
 
         };

--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -14,22 +14,15 @@
 #include <vierkant/animation.hpp>
 #include <vierkant/intersection.hpp>
 #include <vierkant/transform.hpp>
+#include <vierkant/object_component.hpp>
 
 namespace vierkant
 {
 
-//enum class object_component_trait_t{};
-
-template<class T>
-concept object_component =
-        requires() {
-            std::is_same<decltype(std::remove_pointer_t<T>::component_description), const char *>();
-//            std::is_same<typename T::Type, object_component_trait_t>();
-
-        };
-
 struct aabb_component_t
 {
+    VIERKANT_ENABLE_AS_COMPONENT();
+
     // object_component concept
     static constexpr char component_description[] = "AABB component";
 
@@ -50,7 +43,6 @@ DEFINE_CLASS_PTR(Object3D)
 class Object3D : public std::enable_shared_from_this<Object3D>
 {
 public:
-
     static Object3DPtr create(const std::shared_ptr<entt::registry> &registry = {}, std::string name = "");
 
     virtual ~Object3D() noexcept;
@@ -183,8 +175,7 @@ public:
     //! a list of child-objects
     std::list<Object3DPtr> children;
 
-    //! object_component concept
-    static constexpr char component_description[] = "object raw pointer/component";
+    VIERKANT_ENABLE_AS_COMPONENT();
 
 protected:
     explicit Object3D(const std::shared_ptr<entt::registry> &registry, std::string name = "");

--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -183,12 +183,13 @@ public:
     //! a list of child-objects
     std::list<Object3DPtr> children;
 
+    //! object_component concept
+    static constexpr char component_description[] = "object raw pointer/component";
+
 protected:
     explicit Object3D(const std::shared_ptr<entt::registry> &registry, std::string name = "");
 
 private:
-    // object_component concept
-    static constexpr char component_description[] = "object raw pointer/component";
 
     std::weak_ptr<Object3D> m_parent;
 

--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <concepts>
 #include <list>
 #include <optional>
 #include <set>
@@ -17,17 +18,38 @@
 namespace vierkant
 {
 
-DEFINE_CLASS_PTR(Object3D)
+//enum class object_component_trait_t{};
 
-class Object3D : public std::enable_shared_from_this<Object3D>
+template<class T>
+concept object_component =
+        requires() {
+            std::is_same<std::decay_t<decltype(std::remove_pointer_t<T>::component_description)>(), const char *>();
+//            std::is_same<typename T::Type, object_component_trait_t>();
+
+        };
+
+struct aabb_component_t
 {
-public:
+    // object_component concept
+    static constexpr char component_description[] = "AABB component";
+
     //! signature for a function to retrieve a combined AABB
     using aabb_fn_t = std::function<vierkant::AABB(const std::optional<vierkant::animation_state_t> &)>;
 
     //! signature for a function to retrieve all sub-AABBs
     using sub_aabb_fn_t =
             std::function<std::vector<vierkant::AABB>(const std::optional<vierkant::animation_state_t> &)>;
+
+    vierkant::AABB aabb;
+    aabb_fn_t aabb_fn;
+    sub_aabb_fn_t sub_aabb_fn;
+};
+
+DEFINE_CLASS_PTR(Object3D)
+
+class Object3D : public std::enable_shared_from_this<Object3D>
+{
+public:
 
     static Object3DPtr create(const std::shared_ptr<entt::registry> &registry = {}, std::string name = "");
 
@@ -50,29 +72,11 @@ public:
     /**
      * @return the axis-aligned boundingbox (AABB) in object coords.
      */
-    inline AABB aabb() const
-    {
-        auto aabb_fn_ptr = get_component_ptr<aabb_fn_t>();
-        auto animation_state_ptr = get_component_ptr<vierkant::animation_state_t>();
-        if(aabb_fn_ptr)
-        {
-            return (*aabb_fn_ptr)(animation_state_ptr ? *animation_state_ptr
-                                                      : std::optional<vierkant::animation_state_t>());
-        }
-        auto aabb_ptr = get_component_ptr<vierkant::AABB>();
-        return aabb_ptr ? *aabb_ptr : AABB();
-    };
+    AABB aabb() const;
 
     OBB obb() const;
 
-    inline std::vector<AABB> sub_aabbs() const
-    {
-        auto sub_aabb_fn_ptr = get_component_ptr<sub_aabb_fn_t>();
-        auto animation_state_ptr = get_component_ptr<vierkant::animation_state_t>();
-        std::optional<vierkant::animation_state_t> dummy;
-        if(sub_aabb_fn_ptr) { return (*sub_aabb_fn_ptr)(animation_state_ptr ? *animation_state_ptr : dummy); }
-        return {};
-    }
+    std::vector<AABB> sub_aabbs() const;
 
     virtual void accept(class Visitor &theVisitor);
 
@@ -84,6 +88,7 @@ public:
      * @return  a reference for the newly created component.
      */
     template<typename T>
+        requires object_component<T>
     inline T &add_component(const T &component = {})
     {
         if(auto reg = m_registry.lock()) { return reg->template emplace<T>(m_entity, component); }
@@ -97,6 +102,7 @@ public:
      * @return  true, if a component of the provided type exists.
      */
     template<typename T>
+        requires object_component<T>
     inline bool has_component() const
     {
         return get_component_ptr<T>();
@@ -109,6 +115,7 @@ public:
      * @return  a pointer to a component of the provided type, if available. nullptr otherwise.
      */
     template<typename T>
+        requires object_component<T>
     inline T *get_component_ptr()
     {
         auto reg = m_registry.lock();
@@ -122,6 +129,7 @@ public:
      * @return  a pointer to a component of the provided type, if available. nullptr otherwise.
      */
     template<typename T>
+        requires object_component<T>
     inline const T *get_component_ptr() const
     {
         auto reg = m_registry.lock();
@@ -136,6 +144,7 @@ public:
      * @return  a reference to an associated component of the provided type.
      */
     template<typename T>
+        requires object_component<T>
     inline T &get_component()
     {
         auto ptr = get_component_ptr<T>();
@@ -151,6 +160,7 @@ public:
      * @return  a reference to an associated component of the provided type.
      */
     template<typename T>
+        requires object_component<T>
     inline const T &get_component() const
     {
         auto ptr = get_component_ptr<T>();
@@ -177,6 +187,9 @@ protected:
     explicit Object3D(const std::shared_ptr<entt::registry> &registry, std::string name = "");
 
 private:
+    // object_component concept
+    static constexpr char component_description[] = "object raw pointer/component";
+
     std::weak_ptr<Object3D> m_parent;
 
     std::weak_ptr<entt::registry> m_registry;

--- a/include/vierkant/animation.hpp
+++ b/include/vierkant/animation.hpp
@@ -9,6 +9,7 @@
 #include <vector>
 #include <vierkant/math.hpp>
 #include <vierkant/transform.hpp>
+#include <vierkant/object_component.hpp>
 
 namespace vierkant
 {
@@ -66,8 +67,7 @@ template<typename T = float>
     requires std::floating_point<T>
 struct animation_state_t_
 {
-    // object_component concept
-    static constexpr char component_description[] = "animation state";
+    VIERKANT_ENABLE_AS_COMPONENT();
 
     uint32_t index = 0;
     bool playing = true;

--- a/include/vierkant/animation.hpp
+++ b/include/vierkant/animation.hpp
@@ -66,6 +66,9 @@ template<typename T = float>
     requires std::floating_point<T>
 struct animation_state_t_
 {
+    // object_component concept
+    static constexpr char component_description[] = "animation state";
+
     uint32_t index = 0;
     bool playing = true;
     T animation_speed = 1.0;

--- a/include/vierkant/object_component.hpp
+++ b/include/vierkant/object_component.hpp
@@ -1,0 +1,26 @@
+//
+// Created by crocdialer on 08.11.23.
+//
+
+#pragma once
+
+#include <concepts>
+
+namespace vierkant
+{
+
+namespace internal
+{
+struct object_component_guard_t;
+}
+
+//! helper macro to enable arbitrary types to be used as object-components
+#define VIERKANT_ENABLE_AS_COMPONENT() using Guard = vierkant::internal::object_component_guard_t
+
+//! concept definition for an object-component
+template<class T>
+concept object_component =
+        requires() {
+            std::is_same<typename std::remove_pointer_t<T>::Guard, internal::object_component_guard_t>();
+        };
+}// namespace vierkant

--- a/include/vierkant/physical_camera_params.hpp
+++ b/include/vierkant/physical_camera_params.hpp
@@ -5,13 +5,14 @@
 #pragma once
 
 #include <vierkant/math.hpp>
+#include <vierkant/object_component.hpp>
 
 namespace vierkant
 {
 
 struct alignas(16) physical_camera_params_t
 {
-    static constexpr char component_description[] = "physical camera parameters";
+    VIERKANT_ENABLE_AS_COMPONENT();
 
     //! focal length in m
     float focal_length = 0.05f;

--- a/include/vierkant/physical_camera_params.hpp
+++ b/include/vierkant/physical_camera_params.hpp
@@ -11,6 +11,8 @@ namespace vierkant
 
 struct alignas(16) physical_camera_params_t
 {
+    static constexpr char component_description[] = "physical camera parameters";
+
     //! focal length in m
     float focal_length = 0.05f;
 

--- a/samples/CMakeLists.txt
+++ b/samples/CMakeLists.txt
@@ -24,7 +24,7 @@ FOREACH(folderItem ${FOLDER_CONTENT})
                 FILE(GLOB FOLDER_SOURCES ${folderItem}/*.c*)
                 FILE(GLOB FOLDER_HEADERS ${folderItem}/*.h*)
 
-                add_executable(${itemName} ${FOLDER_SOURCES} ${FOLDER_HEADERS} ../include/vierkant/model/wavefront_obj.hpp ../include/vierkant/physical_camera_params.hpp ../include/vierkant/debug_label.hpp)
+                add_executable(${itemName} ${FOLDER_SOURCES} ${FOLDER_HEADERS} ../include/vierkant/model/wavefront_obj.hpp ../include/vierkant/physical_camera_params.hpp ../include/vierkant/debug_label.hpp ../include/vierkant/object_component.hpp)
                 target_link_libraries(${itemName} ${LIBS})
             endif()
         endif()

--- a/shaders/ray/closesthit.rchit
+++ b/shaders/ray/closesthit.rchit
@@ -199,6 +199,13 @@ void main()
         }
     }
 
+    bool sample_surface = !(material.null_surface || sample_medium);
+    if(sample_surface)
+    {
+        // propagate ray-cone
+        payload.cone = propagate(payload.cone, 0.0, gl_HitTEXT);
+    }
+
     // albedo
     if((material.texture_type_flags & TEXTURE_TYPE_COLOR) != 0)
     {
@@ -258,7 +265,6 @@ void main()
     eta += EPS;
 
     payload.ior = payload.transmission ? material.ior : 1.0;
-    bool sample_surface = !(material.null_surface || sample_medium);
 
     if(sample_surface)
     {
@@ -272,9 +278,6 @@ void main()
         rng_state);
         payload.radiance += payload.beta * sun_L;
         #endif
-        
-        // propagate ray-cone
-        payload.cone = propagate(payload.cone, 0.0, gl_HitTEXT);
 
         // take sample from burley/disney BSDF
         bsdf_sample_t bsdf_sample = sample_disney(material, payload.ff_normal, V, eta, rng_state);
@@ -289,7 +292,7 @@ void main()
         payload.transmission = bsdf_sample.transmission ? !payload.transmission : payload.transmission;
 
         // TODO: probably better to offset origin after bounces, instead of biasing ray-tmin!?
-        payload.ray.origin += (bsdf_sample.transmission ? -1.0 : 1.0) * payload.ff_normal * EPS;
+//        payload.ray.origin += (bsdf_sample.transmission ? -1.0 : 1.0) * payload.ff_normal * EPS;
     }
     else
     {

--- a/shaders/ray/raygen.rgen
+++ b/shaders/ray/raygen.rgen
@@ -138,15 +138,9 @@ trace_result_t trace(vec2 coord, vec2 size)
         }
 
         trace_result.radiance += payload.radiance;
-//        trace_result.coverage += payload.depth > 0 ? 1.0 : 0.0;
         trace_result.coverage = max(trace_result.coverage, payload.depth > 0 ? 1.0 : 0.0);
     }
     trace_result.radiance /= float(push_constants.num_samples);
-//    trace_result.coverage /= float(push_constants.num_samples);
-
-    // error on the side of caution!?
-    // TODO: check if that helps with artifacts on older nvidia hardware, i.e. 1060
-//    if(any(isinf(trace_result.radiance)) || any(isnan(trace_result.radiance))){ trace_result.radiance = vec3(0); }
     return trace_result;
 }
 

--- a/src/Object3D.cpp
+++ b/src/Object3D.cpp
@@ -102,6 +102,31 @@ void Object3D::remove_child(const Object3DPtr &child, bool recursive)
     }
 }
 
+AABB Object3D::aabb() const
+{
+    auto aabb_component_ptr = get_component_ptr<aabb_component_t>();
+    auto animation_state_ptr = get_component_ptr<vierkant::animation_state_t>();
+    if(aabb_component_ptr && aabb_component_ptr->aabb_fn)
+    {
+        return aabb_component_ptr->aabb_fn(animation_state_ptr ? *animation_state_ptr
+                                                               : std::optional<vierkant::animation_state_t>());
+    }
+    else if(aabb_component_ptr) { return aabb_component_ptr->aabb; }
+    return {};
+}
+
+std::vector<AABB> Object3D::sub_aabbs() const
+{
+    auto aabb_component_ptr = get_component_ptr<aabb_component_t>();
+    auto animation_state_ptr = get_component_ptr<vierkant::animation_state_t>();
+    if(aabb_component_ptr && aabb_component_ptr->sub_aabb_fn)
+    {
+        return aabb_component_ptr->sub_aabb_fn(animation_state_ptr ? *animation_state_ptr
+                                                                   : std::optional<vierkant::animation_state_t>());
+    }
+    return {};
+}
+
 OBB Object3D::obb() const
 {
     OBB ret(aabb(), glm::mat4(1));

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -18,13 +18,12 @@ vierkant::Object3DPtr create_mesh_object(const std::shared_ptr<entt::registry> &
 {
     auto object = vierkant::Object3D::create(registry);
     object->add_component(mesh_component);
-    vierkant::Object3D::aabb_fn_t aabb_fn;
-    vierkant::Object3D::sub_aabb_fn_t sub_aabb_fn;
     if(!mesh_component.mesh->node_animations.empty()) { object->add_component<vierkant::animation_state_t>(); }
 
     auto weak_obj = vierkant::Object3DWeakPtr(object);
+    auto &aabb_component = object->add_component<vierkant::aabb_component_t>();
 
-    aabb_fn = [weak_obj](const std::optional<vierkant::animation_state_t> &anim_state) {
+    aabb_component.aabb_fn = [weak_obj](const std::optional<vierkant::animation_state_t> &anim_state) {
         vierkant::AABB ret = {};
         auto obj = weak_obj.lock();
 
@@ -58,11 +57,8 @@ vierkant::Object3DPtr create_mesh_object(const std::shared_ptr<entt::registry> &
         }
         return ret;
     };
-    object->add_component(aabb_fn);
-    vierkant::AABB aabb = aabb_fn({});
-    object->add_component(aabb);
 
-    sub_aabb_fn = [weak_obj](const std::optional<vierkant::animation_state_t> &anim_state) {
+    aabb_component.sub_aabb_fn = [weak_obj](const std::optional<vierkant::animation_state_t> &anim_state) {
         std::vector<vierkant::AABB> ret;
 
         auto obj = weak_obj.lock();
@@ -97,7 +93,6 @@ vierkant::Object3DPtr create_mesh_object(const std::shared_ptr<entt::registry> &
         }
         return ret;
     };
-    object->add_component(sub_aabb_fn);
     return object;
 }
 
@@ -107,10 +102,7 @@ void Scene::add_object(const Object3DPtr &object) { m_root->add_child(object); }
 
 void Scene::remove_object(const Object3DPtr &object) { m_root->remove_child(object, true); }
 
-void Scene::clear()
-{
-    m_root = vierkant::Object3D::create(m_registry, "scene root");
-}
+void Scene::clear() { m_root = vierkant::Object3D::create(m_registry, "scene root"); }
 
 void Scene::update(double time_delta)
 {

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -92,11 +92,11 @@ public:
                 // move drawables into cull_result
                 std::move(mesh_drawables.begin(), mesh_drawables.end(), std::back_inserter(m_cull_result.drawables));
             }
-            if(object.has_component<vierkant::model::lightsource_t>())
-            {
-                const auto &lightsource = object.get_component<vierkant::model::lightsource_t>();
-                m_cull_result.lights.push_back(vierkant::convert_light(lightsource));
-            }
+//            if(object.has_component<vierkant::model::lightsource_t>())
+//            {
+//                const auto &lightsource = object.get_component<vierkant::model::lightsource_t>();
+//                m_cull_result.lights.push_back(vierkant::convert_light(lightsource));
+//            }
 
             scoped_stack_push scoped_stack_push(m_transform_stack, m_transform_stack.top() * object.transform);
             for(Object3DPtr &child: object.children) { child->accept(*this); }

--- a/tests/TestObject3D.cpp
+++ b/tests/TestObject3D.cpp
@@ -44,28 +44,16 @@ TEST(Object3D, hierarchy)
     EXPECT_TRUE(glm::vec3(b->global_transform().translation) == glm::vec3(1, 2, 3));
 }
 
-struct foo_component_t
-{
-    //! need to satisfy object_component concept
-    static constexpr char component_description[] = "some foo test-component";
-
-    int a = 0, b = 0;
-};
-
-struct destruction_test_comp_t
-{
-    //! need to satisfy object_component concept
-    static constexpr char component_description[] = "some foo test-component testing component destruction";
-
-    std::function<void()> f;
-
-    ~destruction_test_comp_t(){ if(f){ f(); }}
-};
-
 TEST(Object3D, entity)
 {
     auto registry = std::make_shared<entt::registry>();
     Object3DPtr a(Object3D::create(registry)), b(Object3D::create(registry)), c(Object3D::create(registry));
+
+    struct foo_component_t
+    {
+        VIERKANT_ENABLE_AS_COMPONENT();
+        int a = 0, b = 0;
+    };
 
     // miss-case
     EXPECT_TRUE(!c->has_component<foo_component_t>());
@@ -95,6 +83,15 @@ TEST(Object3D, entity)
     bool destructed = false;
     {
         auto d = Object3D::create(registry);
+
+        struct destruction_test_comp_t
+        {
+            VIERKANT_ENABLE_AS_COMPONENT();
+
+            std::function<void()> f;
+
+            ~destruction_test_comp_t(){ if(f){ f(); }}
+        };
 
         auto &destruct_comp = d->add_component<destruction_test_comp_t>();
         destruct_comp.f = [&destructed](){ destructed = true; };

--- a/tests/TestObject3D.cpp
+++ b/tests/TestObject3D.cpp
@@ -44,15 +44,28 @@ TEST(Object3D, hierarchy)
     EXPECT_TRUE(glm::vec3(b->global_transform().translation) == glm::vec3(1, 2, 3));
 }
 
+struct foo_component_t
+{
+    //! need to satisfy object_component concept
+    static constexpr char component_description[] = "some foo test-component";
+
+    int a = 0, b = 0;
+};
+
+struct destruction_test_comp_t
+{
+    //! need to satisfy object_component concept
+    static constexpr char component_description[] = "some foo test-component testing component destruction";
+
+    std::function<void()> f;
+
+    ~destruction_test_comp_t(){ if(f){ f(); }}
+};
+
 TEST(Object3D, entity)
 {
     auto registry = std::make_shared<entt::registry>();
     Object3DPtr a(Object3D::create(registry)), b(Object3D::create(registry)), c(Object3D::create(registry));
-
-    struct foo_component_t
-    {
-        int a = 0, b = 0;
-    };
 
     // miss-case
     EXPECT_TRUE(!c->has_component<foo_component_t>());
@@ -82,13 +95,6 @@ TEST(Object3D, entity)
     bool destructed = false;
     {
         auto d = Object3D::create(registry);
-
-        struct destruction_test_comp_t
-        {
-            std::function<void()> f;
-
-            ~destruction_test_comp_t(){ if(f){ f(); }}
-        };
 
         auto &destruct_comp = d->add_component<destruction_test_comp_t>();
         destruct_comp.f = [&destructed](){ destructed = true; };


### PR DESCRIPTION
- first draft using c++ concepts to restrict range of template-parameters for entity-components.

- rewrote aabb handling using a new wrapper-component instead of adhoc std::function used as components