### PR TITLE
add support for object-ids buffer to path-tracer

### DIFF
--- a/include/vierkant/PBRPathTracer.hpp
+++ b/include/vierkant/PBRPathTracer.hpp
@@ -272,6 +272,7 @@ private:
     {
         vierkant::ImagePtr radiance;
         vierkant::ImagePtr normals;
+        vierkant::ImagePtr object_ids;
     } m_storage_images;
 
     //! owns raytracing pipelines and shader-bindingtables

--- a/include/vierkant/SceneRenderer.hpp
+++ b/include/vierkant/SceneRenderer.hpp
@@ -25,6 +25,7 @@ public:
         uint32_t num_frustum_culled = 0;
         uint32_t num_occlusion_culled = 0;
         uint32_t num_distance_culled = 0;
+        vierkant::ImagePtr object_ids;
         std::vector<semaphore_submit_info_t> semaphore_infos;
     };
 

--- a/shaders/ray/closesthit.rchit
+++ b/shaders/ray/closesthit.rchit
@@ -28,16 +28,16 @@ layout(push_constant) uniform PushConstants
 layout(binding = 0, set = 0) uniform accelerationStructureEXT topLevelAS;
 
 // array of vertex-buffers
-layout(binding = 3, set = 0, scalar) readonly buffer Vertices { packed_vertex_t v[]; } vertices[];
+layout(binding = 4, set = 0, scalar) readonly buffer Vertices { packed_vertex_t v[]; } vertices[];
 
 // array of index-buffers
-layout(binding = 4, set = 0) readonly buffer Indices { uint i[]; } indices[];
+layout(binding = 5, set = 0) readonly buffer Indices { uint i[]; } indices[];
 
-layout(binding = 5, set = 0) readonly buffer Entries { entry_t entries[]; };
+layout(binding = 6, set = 0) readonly buffer Entries { entry_t entries[]; };
 
-layout(binding = 6, set = 0) readonly buffer Materials{ material_t materials[]; };
+layout(binding = 7, set = 0) readonly buffer Materials{ material_t materials[]; };
 
-layout(binding = 7) uniform sampler2D u_textures[];
+layout(binding = 8) uniform sampler2D u_textures[];
 
 // the ray-payload written here
 layout(location = MISS_INDEX_DEFAULT) rayPayloadInEXT payload_t payload;
@@ -151,6 +151,7 @@ void main()
     vec3 V = -gl_WorldRayDirectionEXT;
     float NoV = abs(dot(V, payload.normal));
 
+    payload.entity_index = gl_InstanceCustomIndexEXT;
     payload.position = v.position;
     payload.normal = v.normal;
 

--- a/shaders/ray/miss.rmiss
+++ b/shaders/ray/miss.rmiss
@@ -8,7 +8,7 @@
 
 layout(location = 0) rayPayloadInEXT payload_t payload;
 
-layout(std140, binding = 8) uniform ubo_t
+layout(std140, binding = 9) uniform ubo_t
 {
     float environment_factor;
 } ubo;

--- a/shaders/ray/miss_environment.rmiss
+++ b/shaders/ray/miss_environment.rmiss
@@ -4,12 +4,12 @@
 
 #include "ray_common.glsl"
 
-layout(std140, binding = 8) uniform ubo_t
+layout(std140, binding = 9) uniform ubo_t
 {
     float environment_factor;
 } ubo;
 
-layout(binding = 9) uniform samplerCube u_sampler_cube;
+layout(binding = 10) uniform samplerCube u_sampler_cube;
 
 layout(location = 0) rayPayloadInEXT payload_t payload;
 

--- a/shaders/ray/ray_common.glsl
+++ b/shaders/ray/ray_common.glsl
@@ -59,6 +59,9 @@ struct payload_t
     // spectral attenuation per unit-length (sigma_s + sigma_a)
     vec3 sigma_t;
 
+    // object/entity
+    uint entity_index;
+
     bool transmission;
 };
 

--- a/shaders/ray/raygen.rgen
+++ b/shaders/ray/raygen.rgen
@@ -153,16 +153,13 @@ void main()
     trace_result_t trace_result = trace(gl_LaunchIDEXT.xy, gl_LaunchSizeEXT.xy);
     vec4 accumulated_radiance = vec4(trace_result.radiance, smoothstep(0, 1, trace_result.coverage));
 
-    if(push_constants.batch_index == 0)
-    {
-        imageStore(out_images[NORMALS], ivec2(gl_LaunchIDEXT.xy), vec4(trace_result.normal, 0.0));
-        imageStore(out_object_ids, ivec2(gl_LaunchIDEXT.xy), uvec4(MAX_UINT16 - trace_result.entity_index));
-    }
-    else
+    if(push_constants.batch_index != 0)
     {
         uint size = push_constants.batch_index;
         accumulated_radiance += size * imageLoad(out_images[RADIANCE], ivec2(gl_LaunchIDEXT.xy));
         accumulated_radiance /= size + 1;
     }
     imageStore(out_images[RADIANCE], ivec2(gl_LaunchIDEXT.xy), accumulated_radiance);
+    imageStore(out_images[NORMALS], ivec2(gl_LaunchIDEXT.xy), vec4(trace_result.normal, 0.0));
+    imageStore(out_object_ids, ivec2(gl_LaunchIDEXT.xy), uvec4(MAX_UINT16 - trace_result.entity_index));
 }

--- a/shaders/ray/raygen.rgen
+++ b/shaders/ray/raygen.rgen
@@ -14,7 +14,9 @@ layout(binding = 0, set = 0) uniform accelerationStructureEXT topLevelAS;
 
 layout(binding = 1, set = 0, rgba32f) uniform image2D out_images[2];
 
-layout(binding = 2, set = 0) uniform CameraProperties
+layout(binding = 2, r16ui) writeonly uniform uimage2D out_object_ids;
+
+layout(binding = 3, set = 0) uniform CameraProperties
 {
     camera_ubo_t cam;
 };
@@ -32,6 +34,7 @@ struct trace_result_t
     float coverage;
     vec3 normal;
     vec3 position;
+    uint entity_index;
 };
 
 trace_result_t trace(vec2 coord, vec2 size)
@@ -129,6 +132,7 @@ trace_result_t trace(vec2 coord, vec2 size)
 
             if(i == 0)
             {
+                trace_result.entity_index = payload.entity_index;
                 trace_result.normal = payload.normal;
                 trace_result.position = payload.position;
             }
@@ -149,12 +153,16 @@ void main()
     trace_result_t trace_result = trace(gl_LaunchIDEXT.xy, gl_LaunchSizeEXT.xy);
     vec4 accumulated_radiance = vec4(trace_result.radiance, smoothstep(0, 1, trace_result.coverage));
 
-    if (push_constants.batch_index != 0)
+    if(push_constants.batch_index == 0)
+    {
+        imageStore(out_images[NORMALS], ivec2(gl_LaunchIDEXT.xy), vec4(trace_result.normal, 0.0));
+        imageStore(out_object_ids, ivec2(gl_LaunchIDEXT.xy), uvec4(MAX_UINT16 - trace_result.entity_index));
+    }
+    else
     {
         uint size = push_constants.batch_index;
         accumulated_radiance += size * imageLoad(out_images[RADIANCE], ivec2(gl_LaunchIDEXT.xy));
         accumulated_radiance /= size + 1;
     }
     imageStore(out_images[RADIANCE], ivec2(gl_LaunchIDEXT.xy), accumulated_radiance);
-    imageStore(out_images[NORMALS], ivec2(gl_LaunchIDEXT.xy), vec4(trace_result.normal, 0.0));
 }

--- a/shaders/ray/raygen.rgen
+++ b/shaders/ray/raygen.rgen
@@ -106,6 +106,7 @@ trace_result_t trace(vec2 coord, vec2 size)
             payload.transmission = transmission;
             payload.ray = ray;
             payload.cone = cone;
+            payload.entity_index = MAX_UINT16;
 
             const uint ray_flags = gl_RayFlagsOpaqueEXT | (transmission ? 0 : gl_RayFlagsCullBackFacingTrianglesEXT);
 

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -464,6 +464,7 @@ SceneRenderer::render_result_t PBRDeferred::render_scene(Rasterizer &renderer, c
     ret.num_frustum_culled = frame_asset.stats.draw_cull_result.num_frustum_culled;
     ret.num_occlusion_culled = frame_asset.stats.draw_cull_result.num_occlusion_culled;
     ret.num_distance_culled = frame_asset.stats.draw_cull_result.num_distance_culled;
+    ret.object_ids = frame_asset.internal_images.object_ids;
 
     vierkant::semaphore_submit_info_t semaphore_submit_info = {};
     semaphore_submit_info.semaphore = frame_asset.timeline.handle();


### PR DESCRIPTION
- add an object-id buffer to PBRPathTracer shaders/pipeline
- add object_id image to SceneRenderer:;render_result_t, unifiying picking for all subclasses