### PR TITLE
brush up API for pipeline-specialization

### DIFF
--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -238,6 +238,11 @@ public:
 
     [[nodiscard]] const vierkant::DevicePtr &device() const { return m_device; }
 
+    [[nodiscard]] const VkPhysicalDeviceMeshShaderPropertiesEXT &mesh_shader_properties() const
+    {
+        return m_mesh_shader_properties;
+    }
+
     friend void swap(Rasterizer &lhs, Rasterizer &rhs) noexcept;
 
 private:

--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -125,7 +125,6 @@ public:
         VkSampleCountFlagBits sample_count = VK_SAMPLE_COUNT_1_BIT;
         bool indirect_draw = false;
         bool enable_mesh_shader = false;
-        uint32_t mesh_task_count = 32;
         vierkant::PipelineCachePtr pipeline_cache = nullptr;
         vierkant::CommandPoolPtr command_pool = nullptr;
         vierkant::DescriptorPoolPtr descriptor_pool = nullptr;

--- a/include/vierkant/SceneRenderer.hpp
+++ b/include/vierkant/SceneRenderer.hpp
@@ -8,7 +8,6 @@
 #include "vierkant/Rasterizer.hpp"
 #include "vierkant/Scene.hpp"
 #include "vierkant/Semaphore.hpp"
-#include "vierkant/culling.hpp"
 
 namespace vierkant
 {

--- a/include/vierkant/pipeline_formats.hpp
+++ b/include/vierkant/pipeline_formats.hpp
@@ -68,12 +68,11 @@ enum class ShaderType
 shader_stage_map_t create_shader_stages(const DevicePtr &device, ShaderType t);
 
 /**
- * @brief   pipeline_specialization is used to handle shader/pipeline specialization-constants.
+ * @brief   specialization is used to handle shader/pipeline specialization-constants.
  */
 class pipeline_specialization
 {
 public:
-
     std::map<uint32_t, std::vector<uint8_t>> constant_blobs;
 
     const VkSpecializationInfo *info()
@@ -202,7 +201,8 @@ struct graphics_pipeline_info_t
     VkPipeline base_pipeline = VK_NULL_HANDLE;
     int32_t base_pipeline_index = -1;
 
-    std::optional<vierkant::pipeline_specialization> pipeline_specialization;
+    // optionally provide specialization-constants
+    std::optional<vierkant::pipeline_specialization> specialization;
 
     VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
     std::vector<VkDynamicState> dynamic_states = {VK_DYNAMIC_STATE_VIEWPORT};
@@ -232,7 +232,7 @@ struct raytracing_pipeline_info_t
     std::vector<VkDescriptorSetLayout> descriptor_set_layouts;
     std::vector<VkPushConstantRange> push_constant_ranges;
 
-    const VkSpecializationInfo *specialization_info = nullptr;
+    std::optional<vierkant::pipeline_specialization> specialization;
 
     bool operator==(const raytracing_pipeline_info_t &other) const;
 
@@ -252,7 +252,7 @@ struct compute_pipeline_info_t
     std::vector<VkDescriptorSetLayout> descriptor_set_layouts;
     std::vector<VkPushConstantRange> push_constant_ranges;
 
-    const VkSpecializationInfo *specialization_info = nullptr;
+    std::optional<vierkant::pipeline_specialization> specialization;
 
     bool operator==(const compute_pipeline_info_t &other) const;
 

--- a/include/vierkant/pipeline_formats.hpp
+++ b/include/vierkant/pipeline_formats.hpp
@@ -4,8 +4,9 @@
 
 #pragma once
 
-#include "vierkant/Device.hpp"
-#include "vierkant/math.hpp"
+#include <optional>
+#include <vierkant/Device.hpp>
+#include <vierkant/math.hpp>
 
 namespace vierkant
 {
@@ -29,15 +30,11 @@ using raytracing_shader_map_t = std::multimap<VkShaderStageFlagBits, ShaderModul
  *
  * @return  a newly constructed, shared VkShaderModule
  */
-ShaderModulePtr create_shader_module(const DevicePtr &device,
-                                     const void *spirv_code,
-                                     size_t num_bytes,
+ShaderModulePtr create_shader_module(const DevicePtr &device, const void *spirv_code, size_t num_bytes,
                                      glm::uvec3 *group_count);
 
 template<typename T>
-ShaderModulePtr create_shader_module(const DevicePtr &device,
-                                     const T &array,
-                                     glm::uvec3 *group_count = nullptr)
+ShaderModulePtr create_shader_module(const DevicePtr &device, const T &array, glm::uvec3 *group_count = nullptr)
 {
     return create_shader_module(device, array.data(), sizeof(typename T::value_type) * array.size(), group_count);
 }
@@ -71,6 +68,56 @@ enum class ShaderType
 shader_stage_map_t create_shader_stages(const DevicePtr &device, ShaderType t);
 
 /**
+ * @brief   pipeline_specialization is used to handle shader/pipeline specialization-constants.
+ */
+class pipeline_specialization
+{
+public:
+
+    std::map<uint32_t, std::vector<uint8_t>> constant_blobs;
+
+    const VkSpecializationInfo *info()
+    {
+        m_map_entries.clear();
+        m_data.clear();
+
+        for(const auto &[constant_id, blob]: constant_blobs)
+        {
+            VkSpecializationMapEntry map_entry = {};
+            map_entry.constantID = constant_id;
+            map_entry.offset = m_data.size();
+            map_entry.size = blob.size();
+
+            m_map_entries.push_back(map_entry);
+            m_data.insert(m_data.end(), blob.begin(), blob.end());
+        }
+        m_info.mapEntryCount = m_map_entries.size();
+        m_info.pMapEntries = m_map_entries.data();
+        m_info.dataSize = m_data.size();
+        m_info.pData = m_data.data();
+        return &m_info;
+    }
+
+    void set(uint32_t constant_id, const auto &data)
+    {
+        auto ptr = (uint8_t *) &data;
+        auto end = ptr + sizeof(data);
+        constant_blobs[constant_id] = {ptr, end};
+    }
+
+    inline bool operator==(const pipeline_specialization &other) const
+    {
+        return constant_blobs == other.constant_blobs;
+    }
+    inline bool operator!=(const pipeline_specialization &other) const { return !(*this == other); };
+
+private:
+    VkSpecializationInfo m_info;
+    std::vector<VkSpecializationMapEntry> m_map_entries;
+    std::vector<uint8_t> m_data;
+};
+
+/**
  * @brief   graphics_pipeline_info_t groups all sort of information for a graphics pipeline.
  *          graphics_pipeline_info_t is default-constructable, copyable, compare- and hashable.
  *          Can be used as key in std::unordered_map.
@@ -98,8 +145,7 @@ struct graphics_pipeline_info_t
     VkCullModeFlagBits cull_mode = VK_CULL_MODE_BACK_BIT;
 
     VkViewport viewport = {0.f, 0.f, 0.f, 0.f, 0.f, 1.f};
-    VkRect2D scissor = {{0, 0},
-                        {0, 0}};
+    VkRect2D scissor = {{0, 0}, {0, 0}};
 
     //! disable rasterizer
     bool rasterizer_discard = false;
@@ -138,9 +184,8 @@ struct graphics_pipeline_info_t
             .alphaBlendOp = VK_BLEND_OP_ADD,
 
             // color mask
-            .colorWriteMask =  VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT |
-                               VK_COLOR_COMPONENT_B_BIT | VK_COLOR_COMPONENT_A_BIT
-    };
+            .colorWriteMask = VK_COLOR_COMPONENT_R_BIT | VK_COLOR_COMPONENT_G_BIT | VK_COLOR_COMPONENT_B_BIT |
+                              VK_COLOR_COMPONENT_A_BIT};
 
     // optional attachment-specific blendStates (will override global state if present)
     std::vector<VkPipelineColorBlendAttachmentState> attachment_blend_states;
@@ -157,7 +202,7 @@ struct graphics_pipeline_info_t
     VkPipeline base_pipeline = VK_NULL_HANDLE;
     int32_t base_pipeline_index = -1;
 
-    const VkSpecializationInfo *specialization_info = nullptr;
+    std::optional<vierkant::pipeline_specialization> pipeline_specialization;
 
     VkPipelineCache pipeline_cache = VK_NULL_HANDLE;
     std::vector<VkDynamicState> dynamic_states = {VK_DYNAMIC_STATE_VIEWPORT};
@@ -168,7 +213,7 @@ struct graphics_pipeline_info_t
 
     bool operator==(const graphics_pipeline_info_t &other) const;
 
-    bool operator!=(const graphics_pipeline_info_t &other) const{ return !(*this == other); };
+    bool operator!=(const graphics_pipeline_info_t &other) const { return !(*this == other); };
 };
 
 /**
@@ -191,7 +236,7 @@ struct raytracing_pipeline_info_t
 
     bool operator==(const raytracing_pipeline_info_t &other) const;
 
-    bool operator!=(const raytracing_pipeline_info_t &other) const{ return !(*this == other); };
+    bool operator!=(const raytracing_pipeline_info_t &other) const { return !(*this == other); };
 };
 
 /**
@@ -211,7 +256,7 @@ struct compute_pipeline_info_t
 
     bool operator==(const compute_pipeline_info_t &other) const;
 
-    bool operator!=(const compute_pipeline_info_t &other) const{ return !(*this == other); };
+    bool operator!=(const compute_pipeline_info_t &other) const { return !(*this == other); };
 };
 
 }// namespace vierkant
@@ -219,6 +264,12 @@ struct compute_pipeline_info_t
 // template specializations for hashing
 namespace std
 {
+template<>
+struct hash<vierkant::pipeline_specialization>
+{
+    size_t operator()(vierkant::pipeline_specialization const &ps) const;
+};
+
 template<>
 struct hash<vierkant::graphics_pipeline_info_t>
 {
@@ -236,4 +287,4 @@ struct hash<vierkant::compute_pipeline_info_t>
 {
     size_t operator()(vierkant::compute_pipeline_info_t const &fmt) const;
 };
-}
+}// namespace std

--- a/include/vierkant/pipeline_formats.hpp
+++ b/include/vierkant/pipeline_formats.hpp
@@ -68,7 +68,7 @@ enum class ShaderType
 shader_stage_map_t create_shader_stages(const DevicePtr &device, ShaderType t);
 
 /**
- * @brief   specialization is used to handle shader/pipeline specialization-constants.
+ * @brief   pipeline_specialization is used to handle shader/pipeline specialization-constants.
  */
 class pipeline_specialization
 {

--- a/shaders/pbr/cull_meshlets.task
+++ b/shaders/pbr/cull_meshlets.task
@@ -35,9 +35,8 @@ layout(push_constant) uniform PushConstants
 
 taskPayloadSharedEXT mesh_task_payload_t task_payload;
 
-// local_size_x via specialization-constant
+// NOTE: local_size_x_id coming from specialization-constant
 layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
-//layout(local_size_x = TASK_WORKGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 bool cone_cull(vec3 center, float radius, vec3 cone_axis, float cone_cutoff, vec3 camera_position)
 {

--- a/shaders/pbr/cull_meshlets.task
+++ b/shaders/pbr/cull_meshlets.task
@@ -35,7 +35,9 @@ layout(push_constant) uniform PushConstants
 
 taskPayloadSharedEXT mesh_task_payload_t task_payload;
 
-layout(local_size_x = TASK_WORKGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
+// local_size_x via specialization-constant
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+//layout(local_size_x = TASK_WORKGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 
 bool cone_cull(vec3 center, float radius, vec3 cone_axis, float cone_cutoff, vec3 camera_position)
 {

--- a/shaders/pbr/g_buffer.mesh
+++ b/shaders/pbr/g_buffer.mesh
@@ -14,7 +14,8 @@
 #include "../utils/camera.glsl"
 #include "../utils/packed_vertex.glsl"
 
-layout(local_size_x = MESH_WORKGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
+layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
+//layout(local_size_x = MESH_WORKGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 layout(triangles, max_vertices = 64, max_primitives = 64) out;
 
 #define CULLING 0

--- a/shaders/pbr/g_buffer.mesh
+++ b/shaders/pbr/g_buffer.mesh
@@ -15,7 +15,6 @@
 #include "../utils/packed_vertex.glsl"
 
 layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
-//layout(local_size_x = MESH_WORKGROUP_SIZE, local_size_y = 1, local_size_z = 1) in;
 layout(triangles, max_vertices = 64, max_primitives = 64) out;
 
 #define CULLING 0

--- a/shaders/pbr/g_buffer.mesh
+++ b/shaders/pbr/g_buffer.mesh
@@ -14,6 +14,8 @@
 #include "../utils/camera.glsl"
 #include "../utils/packed_vertex.glsl"
 
+
+// NOTE: local_size_x_id coming from specialization-constant
 layout(local_size_x_id = 0, local_size_y = 1, local_size_z = 1) in;
 layout(triangles, max_vertices = 64, max_primitives = 64) out;
 

--- a/shaders/renderer/mesh_task_payload.glsl
+++ b/shaders/renderer/mesh_task_payload.glsl
@@ -3,7 +3,7 @@
 
 #extension GL_EXT_shader_explicit_arithmetic_types_int8: require
 
-//! these mesh/task workgroup sizes are still vendor-specific (NV -> 32, AMD -> 64)
+//! TODO: these mesh/task workgroup sizes are still vendor-specific (NV -> 32, AMD -> 64)
 #define MESH_WORKGROUP_SIZE 32
 #define TASK_WORKGROUP_SIZE 32
 

--- a/src/Bloom.cpp
+++ b/src/Bloom.cpp
@@ -68,18 +68,9 @@ Bloom::Bloom(const DevicePtr &device, const Bloom::create_info_t &create_info)
     m_drawable.pipeline_format.primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
     // set the specialization info
-    m_specialization_entry[0].constantID = 0;
-    m_specialization_entry[0].offset = 0;
-    m_specialization_entry[0].size = sizeof(float);
-    m_specialization_entry[1].constantID = 1;
-    m_specialization_entry[1].offset = offsetof(glm::vec2, y);
-    m_specialization_entry[1].size = sizeof(float);
-
-    m_specialization_info.mapEntryCount = 2;
-    m_specialization_info.pMapEntries = m_specialization_entry.data();
-    m_specialization_info.pData = glm::value_ptr(m_brightness_thresh);
-    m_specialization_info.dataSize = sizeof(glm::vec2);
-    m_drawable.pipeline_format.specialization_info = &m_specialization_info;
+    vierkant::pipeline_specialization pipeline_specialization;
+    pipeline_specialization.set(0, m_brightness_thresh.x);
+    pipeline_specialization.set(0, m_brightness_thresh.y);
 
     // descriptor
     vierkant::descriptor_t desc_texture = {};

--- a/src/GaussianBlur.cpp
+++ b/src/GaussianBlur.cpp
@@ -145,7 +145,7 @@ GaussianBlur_<NUM_TAPS>::GaussianBlur_(const DevicePtr &device, const create_inf
         // set the specialization info
         vierkant::pipeline_specialization pipeline_specialization;
         pipeline_specialization.set(0, num_taps);
-        fmt.pipeline_specialization = std::move(pipeline_specialization);
+        fmt.specialization = std::move(pipeline_specialization);
 
         // descriptor
         vierkant::descriptor_t desc_texture = {};

--- a/src/GaussianBlur.cpp
+++ b/src/GaussianBlur.cpp
@@ -130,15 +130,6 @@ GaussianBlur_<NUM_TAPS>::GaussianBlur_(const DevicePtr &device, const create_inf
 
     // create drawable for post-fx-pass
     {
-        m_specialization_entry.constantID = 0;
-        m_specialization_entry.offset = 0;
-        m_specialization_entry.size = sizeof(num_taps);
-
-        m_specialization_info.mapEntryCount = 1;
-        m_specialization_info.pMapEntries = &m_specialization_entry;
-        m_specialization_info.pData = &num_taps;
-        m_specialization_info.dataSize = sizeof(num_taps);
-
         vierkant::drawable_t drawable = {};
 
         graphics_pipeline_info_t fmt = {};
@@ -152,7 +143,9 @@ GaussianBlur_<NUM_TAPS>::GaussianBlur_(const DevicePtr &device, const create_inf
         fmt.primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
         // set the specialization info
-        fmt.specialization_info = &m_specialization_info;
+        vierkant::pipeline_specialization pipeline_specialization;
+        pipeline_specialization.set(0, num_taps);
+        fmt.pipeline_specialization = std::move(pipeline_specialization);
 
         // descriptor
         vierkant::descriptor_t desc_texture = {};

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -166,26 +166,22 @@ PBRDeferred::PBRDeferred(const DevicePtr &device, const create_info_t &create_in
         fmt.primitive_topology = VK_PRIMITIVE_TOPOLOGY_TRIANGLE_LIST;
 
         // descriptors
-        vierkant::descriptor_t desc_ubo = {};
+        vierkant::descriptor_t &desc_ubo = m_drawable_lighting_env.descriptors[0];
         desc_ubo.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         desc_ubo.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-        vierkant::descriptor_t desc_texture = {};
+        vierkant::descriptor_t &desc_texture = m_drawable_lighting_env.descriptors[1];
         desc_texture.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
         desc_texture.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-        vierkant::descriptor_t desc_cubes = {};
+        vierkant::descriptor_t &desc_cubes = m_drawable_lighting_env.descriptors[2];
         desc_cubes.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
         desc_cubes.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-        vierkant::descriptor_t desc_lights = {};
+        vierkant::descriptor_t &desc_lights = m_drawable_lighting_env.descriptors[3];
         desc_lights.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
         desc_lights.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
 
-        m_drawable_lighting_env.descriptors[0] = desc_ubo;
-        m_drawable_lighting_env.descriptors[1] = desc_texture;
-        m_drawable_lighting_env.descriptors[2] = desc_cubes;
-        m_drawable_lighting_env.descriptors[3] = desc_lights;
         m_drawable_lighting_env.num_vertices = 3;
         m_drawable_lighting_env.pipeline_format = fmt;
         m_drawable_lighting_env.use_own_buffers = true;
@@ -235,15 +231,13 @@ PBRDeferred::PBRDeferred(const DevicePtr &device, const create_info_t &create_in
         m_drawable_dof.pipeline_format.shader_stages[VK_SHADER_STAGE_FRAGMENT_BIT] =
                 vierkant::create_shader_module(device, vierkant::shaders::fullscreen::dof_frag);
 
-        // TODO: depth-of-field settings uniform-buffer
-        vierkant::descriptor_t desc_dof_ubo = {};
+        // depth-of-field settings uniform-buffer
+        vierkant::descriptor_t &desc_dof_ubo =  m_drawable_dof.descriptors[1];
         desc_dof_ubo.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
         desc_dof_ubo.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
         desc_dof_ubo.buffers = {vierkant::Buffer::create(
                 m_device, nullptr, sizeof(depth_of_field_params_t),
                 VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_DST_BIT, VMA_MEMORY_USAGE_GPU_ONLY)};
-
-        m_drawable_dof.descriptors[1] = std::move(desc_dof_ubo);
 
         // bloom
         m_drawable_bloom = fullscreen_drawable;
@@ -700,6 +694,19 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             {
                 shader_flags |= PROP_MESHLETS;
                 camera_desc.stage_flags |= VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
+
+                VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_props = {};
+                mesh_shader_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT;
+
+                VkPhysicalDeviceProperties2 device_props = {};
+                device_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+                device_props.pNext = &mesh_shader_props;
+                vkGetPhysicalDeviceProperties2(m_device->physical_device(), &device_props);
+
+                vierkant::pipeline_specialization pipeline_specialization;
+
+                pipeline_specialization.set(0, mesh_shader_props. maxPreferredTaskWorkGroupInvocations);
+                drawable.pipeline_format.pipeline_specialization = std::move(pipeline_specialization);
             }
 
             // check if morph-targets are available

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -695,18 +695,10 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
                 shader_flags |= PROP_MESHLETS;
                 camera_desc.stage_flags |= VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
 
-                VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader_props = {};
-                mesh_shader_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT;
-
-                VkPhysicalDeviceProperties2 device_props = {};
-                device_props.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-                device_props.pNext = &mesh_shader_props;
-                vkGetPhysicalDeviceProperties2(m_device->physical_device(), &device_props);
-
+                auto &mesh_shader_props = m_g_renderer_main.mesh_shader_properties();
                 vierkant::pipeline_specialization pipeline_specialization;
-
-                pipeline_specialization.set(0, mesh_shader_props. maxPreferredTaskWorkGroupInvocations);
-                drawable.pipeline_format.pipeline_specialization = std::move(pipeline_specialization);
+                pipeline_specialization.set(0, mesh_shader_props.maxPreferredTaskWorkGroupInvocations);
+                drawable.pipeline_format.specialization = std::move(pipeline_specialization);
             }
 
             // check if morph-targets are available

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -41,7 +41,7 @@ PipelinePtr Pipeline::create(DevicePtr device, graphics_pipeline_info_t format)
 
     // our shader stages
     const VkSpecializationInfo *specialization_info =
-            format.pipeline_specialization ? format.pipeline_specialization->info() : nullptr;
+            format.specialization ? format.specialization->info() : nullptr;
     auto stage_create_infos = shader_stage_create_infos(format.shader_stages, specialization_info);
 
     VkPipelineVertexInputStateCreateInfo vertex_input_info = {};
@@ -207,8 +207,9 @@ PipelinePtr Pipeline::create(DevicePtr device, vierkant::raytracing_pipeline_inf
     if(!vkCreateRayTracingPipelinesKHR) { return nullptr; }
 
     // shader stages
-    auto stage_create_infos =
-            shader_stage_create_infos(raytracing_info.shader_stages, raytracing_info.specialization_info);
+    auto specialization_info =
+            raytracing_info.specialization ? raytracing_info.specialization->info() : nullptr;
+    auto stage_create_infos = shader_stage_create_infos(raytracing_info.shader_stages, specialization_info);
 
     // shader groups
     auto group_create_infos = raytracing_shader_groups(raytracing_info.shader_stages);
@@ -263,7 +264,8 @@ PipelinePtr Pipeline::create(DevicePtr device, vierkant::compute_pipeline_info_t
     vierkant::shader_stage_map_t shader_map;
     shader_map[VK_SHADER_STAGE_COMPUTE_BIT] = compute_info.shader_stage;
 
-    auto stage_create_infos = shader_stage_create_infos(shader_map, compute_info.specialization_info);
+    auto specialization = compute_info.specialization ? compute_info.specialization->info() : nullptr;
+    auto stage_create_infos = shader_stage_create_infos(shader_map, specialization);
 
     VkComputePipelineCreateInfo pipeline_create_info = {};
     pipeline_create_info.sType = VK_STRUCTURE_TYPE_COMPUTE_PIPELINE_CREATE_INFO;

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -13,8 +13,7 @@ namespace vierkant
 // shader stages from map/multimap
 template<typename ShaderMap_T>
 std::vector<VkPipelineShaderStageCreateInfo>
-shader_stage_create_infos(const ShaderMap_T &shader_stages,
-                          const VkSpecializationInfo *specialization_info = nullptr)
+shader_stage_create_infos(const ShaderMap_T &shader_stages, const VkSpecializationInfo *specialization_info = nullptr)
 {
     std::vector<VkPipelineShaderStageCreateInfo> ret;
 
@@ -41,7 +40,9 @@ PipelinePtr Pipeline::create(DevicePtr device, graphics_pipeline_info_t format)
     }
 
     // our shader stages
-    auto stage_create_infos = shader_stage_create_infos(format.shader_stages, format.specialization_info);
+    const VkSpecializationInfo *specialization_info =
+            format.pipeline_specialization ? format.pipeline_specialization->info() : nullptr;
+    auto stage_create_infos = shader_stage_create_infos(format.shader_stages, specialization_info);
 
     VkPipelineVertexInputStateCreateInfo vertex_input_info = {};
     vertex_input_info.sType = VK_STRUCTURE_TYPE_PIPELINE_VERTEX_INPUT_STATE_CREATE_INFO;
@@ -190,8 +191,7 @@ PipelinePtr Pipeline::create(DevicePtr device, graphics_pipeline_info_t format)
     pipeline_info.pNext = direct_rendering ? &rendering_create_info : nullptr;
 
     VkPipeline pipeline = VK_NULL_HANDLE;
-    vkCheck(vkCreateGraphicsPipelines(device->handle(), format.pipeline_cache, 1, &pipeline_info, nullptr,
-                                      &pipeline),
+    vkCheck(vkCreateGraphicsPipelines(device->handle(), format.pipeline_cache, 1, &pipeline_info, nullptr, &pipeline),
             "failed to create graphics pipeline!");
 
     return PipelinePtr(new Pipeline(std::move(device), pipeline_layout, VK_PIPELINE_BIND_POINT_GRAPHICS, pipeline));
@@ -201,14 +201,14 @@ PipelinePtr Pipeline::create(DevicePtr device, graphics_pipeline_info_t format)
 
 PipelinePtr Pipeline::create(DevicePtr device, vierkant::raytracing_pipeline_info_t raytracing_info)
 {
-    auto vkCreateRayTracingPipelinesKHR = reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(vkGetDeviceProcAddr(
-            device->handle(), "vkCreateRayTracingPipelinesKHR"));
+    auto vkCreateRayTracingPipelinesKHR = reinterpret_cast<PFN_vkCreateRayTracingPipelinesKHR>(
+            vkGetDeviceProcAddr(device->handle(), "vkCreateRayTracingPipelinesKHR"));
 
-    if(!vkCreateRayTracingPipelinesKHR){ return nullptr; }
+    if(!vkCreateRayTracingPipelinesKHR) { return nullptr; }
 
     // shader stages
-    auto stage_create_infos = shader_stage_create_infos(raytracing_info.shader_stages,
-                                                        raytracing_info.specialization_info);
+    auto stage_create_infos =
+            shader_stage_create_infos(raytracing_info.shader_stages, raytracing_info.specialization_info);
 
     // shader groups
     auto group_create_infos = raytracing_shader_groups(raytracing_info.shader_stages);
@@ -236,7 +236,8 @@ PipelinePtr Pipeline::create(DevicePtr device, vierkant::raytracing_pipeline_inf
 
     VkPipeline pipeline = VK_NULL_HANDLE;
     vkCheck(vkCreateRayTracingPipelinesKHR(device->handle(), VK_NULL_HANDLE, VK_NULL_HANDLE, 1, &pipeline_create_info,
-                                           VK_NULL_HANDLE, &pipeline), "could not create raytracing pipeline");
+                                           VK_NULL_HANDLE, &pipeline),
+            "could not create raytracing pipeline");
 
     return PipelinePtr(
             new Pipeline(std::move(device), pipeline_layout, VK_PIPELINE_BIND_POINT_RAY_TRACING_KHR, pipeline));
@@ -270,24 +271,19 @@ PipelinePtr Pipeline::create(DevicePtr device, vierkant::compute_pipeline_info_t
     pipeline_create_info.stage = stage_create_infos.back();
 
     VkPipeline pipeline = VK_NULL_HANDLE;
-    vkCheck(vkCreateComputePipelines(device->handle(), VK_NULL_HANDLE, 1, &pipeline_create_info,
-                                     VK_NULL_HANDLE, &pipeline), "could not create compute pipeline");
+    vkCheck(vkCreateComputePipelines(device->handle(), VK_NULL_HANDLE, 1, &pipeline_create_info, VK_NULL_HANDLE,
+                                     &pipeline),
+            "could not create compute pipeline");
 
-    return PipelinePtr(
-            new Pipeline(std::move(device), pipeline_layout, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline));
+    return PipelinePtr(new Pipeline(std::move(device), pipeline_layout, VK_PIPELINE_BIND_POINT_COMPUTE, pipeline));
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 Pipeline::Pipeline(DevicePtr device, VkPipelineLayout pipeline_layout, VkPipelineBindPoint bind_point,
-                   VkPipeline pipeline) :
-        m_device(std::move(device)),
-        m_pipeline_layout(pipeline_layout),
-        m_bind_point(bind_point),
-        m_pipeline(pipeline)
-{
-
-}
+                   VkPipeline pipeline)
+    : m_device(std::move(device)), m_pipeline_layout(pipeline_layout), m_bind_point(bind_point), m_pipeline(pipeline)
+{}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -295,8 +291,8 @@ Pipeline::~Pipeline()
 {
     if(m_device)
     {
-        if(m_pipeline_layout){ vkDestroyPipelineLayout(m_device->handle(), m_pipeline_layout, nullptr); }
-        if(m_pipeline){ vkDestroyPipeline(m_device->handle(), m_pipeline, nullptr); }
+        if(m_pipeline_layout) { vkDestroyPipelineLayout(m_device->handle(), m_pipeline_layout, nullptr); }
+        if(m_pipeline) { vkDestroyPipeline(m_device->handle(), m_pipeline, nullptr); }
     }
 }
 

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -63,7 +63,7 @@ Rasterizer::Rasterizer(DevicePtr device, const create_info_t &create_info)
         vkGetPhysicalDeviceProperties2(m_device->physical_device(), &props);
     }
     use_mesh_shader = create_info.enable_mesh_shader && vkCmdDrawMeshTasksEXT;
-    m_mesh_task_count = create_info.mesh_task_count;
+    m_mesh_task_count = m_mesh_shader_properties.maxPreferredTaskWorkGroupInvocations;//create_info.mesh_task_count;
 
     viewport = create_info.viewport;
     scissor = create_info.scissor;
@@ -154,6 +154,7 @@ void swap(Rasterizer &lhs, Rasterizer &rhs) noexcept
     std::swap(lhs.m_start_time, rhs.m_start_time);
 
     std::swap(lhs.use_mesh_shader, rhs.use_mesh_shader);
+    std::swap(lhs.m_mesh_shader_properties, rhs.m_mesh_shader_properties);
     std::swap(lhs.m_mesh_task_count, rhs.m_mesh_task_count);
 }
 

--- a/src/pipeline_formats.cpp
+++ b/src/pipeline_formats.cpp
@@ -20,11 +20,6 @@ static inline bool operator==(const VkVertexInputBindingDescription &lhs, const 
     return true;
 }
 
-//static inline bool operator!=(const VkVertexInputBindingDescription &lhs, const VkVertexInputBindingDescription &rhs)
-//{
-//    return !(lhs == rhs);
-//}
-
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
 static inline bool operator==(const VkVertexInputAttributeDescription &lhs,
@@ -36,12 +31,6 @@ static inline bool operator==(const VkVertexInputAttributeDescription &lhs,
     if(lhs.offset != rhs.offset){ return false; }
     return true;
 }
-
-//static inline bool operator!=(const VkVertexInputAttributeDescription &lhs,
-//                              const VkVertexInputAttributeDescription &rhs)
-//{
-//    return !(lhs == rhs);
-//}
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -59,12 +48,6 @@ static inline bool operator==(const VkPipelineColorBlendAttachmentState &lhs,
     return true;
 }
 
-//static inline bool operator!=(const VkPipelineColorBlendAttachmentState &lhs,
-//                              const VkPipelineColorBlendAttachmentState &rhs)
-//{
-//    return !(lhs == rhs);
-//}
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 static inline bool operator==(const VkPushConstantRange &lhs, const VkPushConstantRange &rhs)
@@ -74,11 +57,6 @@ static inline bool operator==(const VkPushConstantRange &lhs, const VkPushConsta
     if(lhs.stageFlags != rhs.stageFlags){ return false; }
     return true;
 }
-
-//static inline bool operator!=(const VkPushConstantRange &lhs, const VkPushConstantRange &rhs)
-//{
-//    return !(lhs == rhs);
-//}
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -263,7 +241,7 @@ bool graphics_pipeline_info_t::operator==(const graphics_pipeline_info_t &other)
     if(subpass != other.subpass){ return false; }
     if(base_pipeline != other.base_pipeline){ return false; }
     if(base_pipeline_index != other.base_pipeline_index){ return false; }
-    if(specialization_info != other.specialization_info){ return false; }
+    if(pipeline_specialization != other.pipeline_specialization){ return false; }
     if(pipeline_cache != other.pipeline_cache){ return false; }
     if(dynamic_states != other.dynamic_states){ return false; }
     if(descriptor_set_layouts != other.descriptor_set_layouts){ return false; }
@@ -351,6 +329,17 @@ struct hash<VkPushConstantRange>
 
 }
 
+size_t std::hash<vierkant::pipeline_specialization>::operator()(vierkant::pipeline_specialization const &ps) const
+{
+    size_t h = 0;
+    for(const auto &[constant_id, blob] : ps.constant_blobs)
+    {
+        hash_combine(h, constant_id);
+        for(const auto &byte : blob){ hash_combine(h, byte); }
+    }
+    return h;
+}
+
 size_t std::hash<vierkant::graphics_pipeline_info_t>::operator()(vierkant::graphics_pipeline_info_t const &fmt) const
 {
     size_t h = 0;
@@ -427,7 +416,7 @@ size_t std::hash<vierkant::graphics_pipeline_info_t>::operator()(vierkant::graph
     hash_combine(h, fmt.subpass);
     hash_combine(h, fmt.base_pipeline);
     hash_combine(h, fmt.base_pipeline_index);
-    hash_combine(h, fmt.specialization_info);
+    hash_combine(h, fmt.pipeline_specialization);
     hash_combine(h, fmt.pipeline_cache);
     for(const auto &ds : fmt.dynamic_states){ hash_combine(h, ds); }
     for(const auto &dsl : fmt.descriptor_set_layouts){ hash_combine(h, dsl); }

--- a/src/pipeline_formats.cpp
+++ b/src/pipeline_formats.cpp
@@ -241,7 +241,7 @@ bool graphics_pipeline_info_t::operator==(const graphics_pipeline_info_t &other)
     if(subpass != other.subpass){ return false; }
     if(base_pipeline != other.base_pipeline){ return false; }
     if(base_pipeline_index != other.base_pipeline_index){ return false; }
-    if(pipeline_specialization != other.pipeline_specialization){ return false; }
+    if(specialization != other.specialization){ return false; }
     if(pipeline_cache != other.pipeline_cache){ return false; }
     if(dynamic_states != other.dynamic_states){ return false; }
     if(descriptor_set_layouts != other.descriptor_set_layouts){ return false; }
@@ -416,7 +416,7 @@ size_t std::hash<vierkant::graphics_pipeline_info_t>::operator()(vierkant::graph
     hash_combine(h, fmt.subpass);
     hash_combine(h, fmt.base_pipeline);
     hash_combine(h, fmt.base_pipeline_index);
-    hash_combine(h, fmt.pipeline_specialization);
+    hash_combine(h, fmt.specialization);
     hash_combine(h, fmt.pipeline_cache);
     for(const auto &ds : fmt.dynamic_states){ hash_combine(h, ds); }
     for(const auto &dsl : fmt.descriptor_set_layouts){ hash_combine(h, dsl); }


### PR DESCRIPTION
- add an utility-class to wrap/wrangle vulkan's pipeline-specialization-constants
- switch raw-pointer with an std::optional, if specialization is required
- apply that for existing cases
- add specialization-constants to set mesh/task-shader workgroup-sizes