### PR TITLE
bumped glm version, hoping to rid some bogus warnings in msvc.

### DIFF
--- a/include/vierkant/transform.hpp
+++ b/include/vierkant/transform.hpp
@@ -30,7 +30,7 @@ using transform_t = transform_t_<float>;
 template<typename T1, typename T2>
 inline glm::vec<3, T2> operator*(const transform_t_<T1> &t, const glm::vec<3, T2> &v)
 {
-    return glm::rotate(t.rotation, v * t.scale) + t.translation;
+    return t.rotation * (v * t.scale) + t.translation;
 }
 
 /**

--- a/include/vierkant/transform.hpp
+++ b/include/vierkant/transform.hpp
@@ -44,7 +44,7 @@ template<typename T>
 inline transform_t_<T> operator*(const transform_t_<T> &lhs, const transform_t_<T> &rhs)
 {
     transform_t_<T> ret = lhs;
-    ret.translation += glm::rotate(lhs.rotation, rhs.translation * lhs.scale);
+    ret.translation += lhs.rotation * (rhs.translation * lhs.scale);
     ret.rotation *= rhs.rotation;
     ret.scale *= rhs.scale;
     return ret;

--- a/src/CameraControl.cpp
+++ b/src/CameraControl.cpp
@@ -106,7 +106,7 @@ vierkant::mouse_delegate_t OrbitCamera::mouse_delegate()
 vierkant::transform_t OrbitCamera::transform() const
 {
     auto rot = rotation();
-    return {look_at + glm::rotate(rot, glm::vec3(0, 0, distance)), rot};
+    return {look_at + rot * glm::vec3(0, 0, distance), rot};
 }
 
 vierkant::joystick_delegate_t OrbitCamera::joystick_delegate()


### PR DESCRIPTION
- bumped glm version, hoping to rid some bogus warnings in msvc ("GLM_GTX_hash requires C++11 standard library support")
- ran into API-changes, quaternion-rotations with operator* instead of glm::rotate, weird