### PR TITLE
use anyhit-shader for alpha-cutoff/blending

### DIFF
--- a/shaders/ray/anyhit.rahit
+++ b/shaders/ray/anyhit.rahit
@@ -43,7 +43,7 @@ void main()
     entry_t entry = entries[gl_InstanceCustomIndexEXT];
     material_t material = materials[entry.material_index];
 
-    if(material.blend_mode == BLEND_MODE_MASK || material.blend_mode == BLEND_MODE_BLEND)
+    if(!material.null_surface && (material.blend_mode == BLEND_MODE_MASK || material.blend_mode == BLEND_MODE_BLEND))
     {
         // albedo
         if((material.texture_type_flags & TEXTURE_TYPE_COLOR) != 0)

--- a/shaders/ray/raygen.rgen
+++ b/shaders/ray/raygen.rgen
@@ -118,7 +118,8 @@ trace_result_t trace(vec2 coord, vec2 size)
             payload.cone = cone;
             payload.entity_index = MAX_UINT16;
 
-            const uint ray_flags = media_index > 0 ? gl_RayFlagsOpaqueEXT : gl_RayFlagsCullBackFacingTrianglesEXT;
+            uint ray_flags = gl_RayFlagsOpaqueEXT;
+            ray_flags |= media_index > 0 ? 0 : gl_RayFlagsCullBackFacingTrianglesEXT;
 
             // trace one ray
             traceRayEXT(topLevelAS,         // acceleration structure

--- a/shaders/ray/raygen.rgen
+++ b/shaders/ray/raygen.rgen
@@ -118,8 +118,8 @@ trace_result_t trace(vec2 coord, vec2 size)
             payload.cone = cone;
             payload.entity_index = MAX_UINT16;
 
-            uint ray_flags = gl_RayFlagsOpaqueEXT;
-            ray_flags |= media_index > 0 ? 0 : gl_RayFlagsCullBackFacingTrianglesEXT;
+            //ray_flags = gl_RayFlagsOpaqueEXT; -> circumvent anyhit
+            uint ray_flags = media_index > 0 ? 0 : gl_RayFlagsCullBackFacingTrianglesEXT;
 
             // trace one ray
             traceRayEXT(topLevelAS,         // acceleration structure

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -99,13 +99,13 @@ PBRPathTracer::PBRPathTracer(const DevicePtr &device, const PBRPathTracer::creat
 
     m_shader_stages = {{VK_SHADER_STAGE_RAYGEN_BIT_KHR, raygen},
                        {VK_SHADER_STAGE_MISS_BIT_KHR, ray_miss},
-                       {VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, ray_closest_hit}/*,
-                       {VK_SHADER_STAGE_ANY_HIT_BIT_KHR, ray_any_hit}*/};
+                       {VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, ray_closest_hit},
+                       {VK_SHADER_STAGE_ANY_HIT_BIT_KHR, ray_any_hit}};
 
     m_shader_stages_env = {{VK_SHADER_STAGE_RAYGEN_BIT_KHR, raygen},
                            {VK_SHADER_STAGE_MISS_BIT_KHR, ray_miss_env},
-                           {VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, ray_closest_hit}/*,
-                           {VK_SHADER_STAGE_ANY_HIT_BIT_KHR, ray_any_hit}*/};
+                           {VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR, ray_closest_hit},
+                           {VK_SHADER_STAGE_ANY_HIT_BIT_KHR, ray_any_hit}};
 
     // create drawables for post-fx-pass
     {

--- a/src/RayTracer.cpp
+++ b/src/RayTracer.cpp
@@ -199,20 +199,16 @@ RayTracer::create_shader_binding_table(VkPipeline pipeline, const vierkant::rayt
     size_t handle_index = 0;
     auto buf_ptr = static_cast<uint8_t *>(binding_table.buffer->map());
 
-    for(const auto &[group, num_elements]: group_elements)
+    for(uint32_t g = Group::Raygen; g < Group::MAX_ENUM; ++g)
     {
-        auto &address_region = binding_table.strided_address_region[group];
+        auto &address_region = binding_table.strided_address_region[g];
         address_region.deviceAddress = binding_table.buffer->device_address() + buffer_offset;
-
         auto data_ptr = buf_ptr + buffer_offset;
         buffer_offset += address_region.size;
 
-        for(uint32_t c = 0; c < num_elements; c++)
-        {
-            memcpy(data_ptr, shader_handle_data.data() + handle_size * handle_index, handle_size);
-            data_ptr += address_region.stride;
-            handle_index++;
-        }
+        memcpy(data_ptr, shader_handle_data.data() + handle_size * handle_index, handle_size);
+        data_ptr += address_region.stride;
+        handle_index++;
     }
     binding_table.buffer->unmap();
     return binding_table;

--- a/src/RayTracer.cpp
+++ b/src/RayTracer.cpp
@@ -188,10 +188,10 @@ RayTracer::create_shader_binding_table(VkPipeline pipeline, const vierkant::rayt
 
     const uint32_t group_count = group_create_infos.size();
 
-    // retrieve the shader-handles into host-memory
-    std::vector<uint8_t> shader_handle_data(shader_stages.size() * handle_size);
-    vkCheck(vkGetRayTracingShaderGroupHandlesKHR(m_device->handle(), pipeline, 0, group_count,
-                                                 shader_handle_data.size(), shader_handle_data.data()),
+    // retrieve the group-handles into host-memory
+    std::vector<uint8_t> group_handle_data(group_count * handle_size);
+    vkCheck(vkGetRayTracingShaderGroupHandlesKHR(m_device->handle(), pipeline, 0, group_count, group_handle_data.size(),
+                                                 group_handle_data.data()),
             "Raytracer::trace_rays: could not retrieve shader group handles");
 
     // copy opaque shader-handles with proper stride (handle_size_aligned)
@@ -206,7 +206,7 @@ RayTracer::create_shader_binding_table(VkPipeline pipeline, const vierkant::rayt
         auto data_ptr = buf_ptr + buffer_offset;
         buffer_offset += address_region.size;
 
-        memcpy(data_ptr, shader_handle_data.data() + handle_size * handle_index, handle_size);
+        memcpy(data_ptr, group_handle_data.data() + handle_size * handle_index, handle_size);
         data_ptr += address_region.stride;
         handle_index++;
     }


### PR DESCRIPTION
- Shader binding table fix required to get things working
- anyhit-shader enabled now, doing alpha-cutoff/blending
- circumventing closest-hit also has the side-effect of pixel-perfect selection masks for cut-outs (I like it)