### PR TITLE
clone (deep-copy) scenegraph-subtrees including components

### DIFF
--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -168,6 +168,8 @@ public:
         throw std::runtime_error("component does not exist");
     }
 
+    Object3DPtr clone() const;
+
     //! set of tags
     std::set<std::string> tags;
 

--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -168,6 +168,11 @@ public:
         throw std::runtime_error("component does not exist");
     }
 
+    /**
+     * @brief   clone will perform a recursive deep-copy, including all components.
+     *
+     * @return  a newly created Object3DPtr, containing a deep-copy of entire sub-tree
+     */
     Object3DPtr clone() const;
 
     //! set of tags

--- a/tests/TestObject3D.cpp
+++ b/tests/TestObject3D.cpp
@@ -131,5 +131,5 @@ TEST(Object3D, clone)
     EXPECT_NE(a->get_component<test_component_t>(), c->get_component<test_component_t>());
 
     // test recursive component-cloning
-    EXPECT_EQ(a->children.front()->get_component<test_component_t>(), b->get_component<test_component_t>());
+    EXPECT_EQ(c->children.front()->get_component<test_component_t>(), b->get_component<test_component_t>());
 }


### PR DESCRIPTION
- upgrade entt-version for opaque component-copying
- implement a Object3D::clone method, performing a recursive scenegraph deep-copy including components
- -unit test Object3D::clone