### PR TITLE
support VK_DESCRIPTOR_TYPE_INLINE_UNIFORM_BLOCK

### DIFF
--- a/include/vierkant/descriptor.hpp
+++ b/include/vierkant/descriptor.hpp
@@ -51,6 +51,9 @@ struct descriptor_t
     //! used for descriptor containing a raytracing acceleration-structure
     AccelerationStructurePtr acceleration_structure;
 
+    //! used for descriptors containing an inline uniform-buffer
+    std::vector<uint8_t > inline_uniform_data;
+
     bool operator==(const descriptor_t &other) const;
 
     bool operator!=(const descriptor_t &other) const { return !(*this == other); };


### PR DESCRIPTION
adding an optional inline_uniform payload to descriptor_t, usable for inline-uniform data. not tested yet