### PR TITLE
Do not re-create timeline semaphores, just let them roll

### DIFF
--- a/include/vierkant/PBRDeferred.hpp
+++ b/include/vierkant/PBRDeferred.hpp
@@ -273,6 +273,7 @@ private:
         size_t scene_hash = 0;
         bool recycle_commands = false;
 
+        uint64_t current_semaphore_value = 0;
         SemaphoreValue semaphore_value_done = SemaphoreValue::INVALID;
         Rasterizer::indirect_draw_bundle_t indirect_draw_params_main = {}, indirect_draw_params_post = {};
         camera_params_t camera_params;

--- a/include/vierkant/PBRPathTracer.hpp
+++ b/include/vierkant/PBRPathTracer.hpp
@@ -165,6 +165,8 @@ private:
         //! timeline semaphore to sync raytracing and draw-operations
         vierkant::Semaphore semaphore;
 
+        uint64_t semaphore_value = 0;
+
         SemaphoreValue semaphore_value_done = SemaphoreValue::INVALID;
 
         //! re-usable command-buffers for all stages

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -81,11 +81,22 @@ PBRPathTracer::PBRPathTracer(const DevicePtr &device, const PBRPathTracer::creat
         frame_context.ray_miss_ubo =
                 vierkant::Buffer::create(device, &frame_context.settings.environment_factor, sizeof(float),
                                          VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
-        frame_context.cmd_pre_render = vierkant::CommandBuffer(m_device, m_command_pool.get());
 
-        frame_context.cmd_trace = vierkant::CommandBuffer(m_device, m_command_pool.get());
-        frame_context.cmd_denoise = vierkant::CommandBuffer(m_device, m_command_pool.get());
-        frame_context.cmd_post_fx = vierkant::CommandBuffer(m_device, m_command_pool.get());
+        vierkant::CommandBuffer::create_info_t cmd_buffer_info = {};
+        cmd_buffer_info.device = m_device;
+        cmd_buffer_info.command_pool = m_command_pool.get();
+
+        cmd_buffer_info.name = "cmd_pre_render";
+        frame_context.cmd_pre_render = vierkant::CommandBuffer(cmd_buffer_info);
+
+        cmd_buffer_info.name = "cmd_trace";
+        frame_context.cmd_trace = vierkant::CommandBuffer(cmd_buffer_info);
+
+        cmd_buffer_info.name = "cmd_denoise";
+        frame_context.cmd_denoise = vierkant::CommandBuffer(cmd_buffer_info);
+
+        cmd_buffer_info.name = "cmd_post_fx";
+        frame_context.cmd_post_fx = vierkant::CommandBuffer(cmd_buffer_info);
 
         frame_context.scene_acceleration_context = m_ray_builder.create_scene_acceleration_context();
 


### PR DESCRIPTION
Semaphore (re-)creation is (became!?) terribly slow on linux/nvidia, prob. in general.
This PR adds additional counters to keep track of semaphore-values and omits recreation, just keeps on incrementing.