### PR TITLE
Add a linear_hashmap type and unit-test

### DIFF
--- a/include/vierkant/hash.hpp
+++ b/include/vierkant/hash.hpp
@@ -30,6 +30,20 @@ inline uint64_t murmur3_fmix64(uint64_t k)
     return k;
 }
 
+// Generate a random uint32_t from two uint32_t values
+// @see: "Mark Jarzynski and Marc Olano, Hash Functions for GPU Rendering, Journal of Computer Graphics Techniques (JCGT), vol. 9, no. 3, 21-38, 2020"
+// https://jcgt.org/published/0009/03/02/
+uint32_t xxhash32(uint32_t lhs, uint32_t rhs)
+{
+    const uint32_t PRIME32_2 = 2246822519U, PRIME32_3 = 3266489917U;
+    const uint32_t PRIME32_4 = 668265263U, PRIME32_5 = 374761393U;
+    uint32_t h32 = lhs + PRIME32_5 + rhs * PRIME32_3;
+    h32 = PRIME32_4 * ((h32 << 17) | (h32 >> (32 - 17)));
+    h32 = PRIME32_2 * (h32 ^ (h32 >> 15));
+    h32 = PRIME32_3 * (h32 ^ (h32 >> 13));
+    return h32 ^ (h32 >> 16);
+}
+
 template<class T>
 inline void hash_combine(std::size_t &seed, const T &v)
 {

--- a/include/vierkant/hash.hpp
+++ b/include/vierkant/hash.hpp
@@ -10,6 +10,26 @@
 namespace vierkant
 {
 
+inline uint32_t murmur3_fmix32(uint32_t h)
+{
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+}
+
+inline uint64_t murmur3_fmix64(uint64_t k)
+{
+    k ^= k >> 33;
+    k *= 0xff51afd7ed558ccdLLU;
+    k ^= k >> 33;
+    k *= 0xc4ceb9fe1a85ec53LLU;
+    k ^= k >> 33;
+    return k;
+}
+
 template<class T>
 inline void hash_combine(std::size_t &seed, const T &v)
 {
@@ -17,14 +37,11 @@ inline void hash_combine(std::size_t &seed, const T &v)
     seed ^= hasher(v) + 0x9e3779b9 + (seed << 6U) + (seed >> 2U);
 }
 
-template <typename It>
+template<typename It>
 std::size_t hash_range(It first, It last)
 {
     std::size_t seed = 0;
-    for (; first != last; ++first)
-    {
-        hash_combine(seed, *first);
-    }
+    for(; first != last; ++first) { hash_combine(seed, *first); }
     return seed;
 }
 

--- a/include/vierkant/hash.hpp
+++ b/include/vierkant/hash.hpp
@@ -33,7 +33,7 @@ inline uint64_t murmur3_fmix64(uint64_t k)
 // Generate a random uint32_t from two uint32_t values
 // @see: "Mark Jarzynski and Marc Olano, Hash Functions for GPU Rendering, Journal of Computer Graphics Techniques (JCGT), vol. 9, no. 3, 21-38, 2020"
 // https://jcgt.org/published/0009/03/02/
-uint32_t xxhash32(uint32_t lhs, uint32_t rhs)
+inline uint32_t xxhash32(uint32_t lhs, uint32_t rhs)
 {
     const uint32_t PRIME32_2 = 2246822519U, PRIME32_3 = 3266489917U;
     const uint32_t PRIME32_4 = 668265263U, PRIME32_5 = 374761393U;

--- a/include/vierkant/linear_hashmap.hpp
+++ b/include/vierkant/linear_hashmap.hpp
@@ -1,0 +1,99 @@
+//
+// Created by Croc Dialer on 28.09.24.
+//
+
+#pragma once
+
+#include <atomic>
+#include <cstdint>
+#include <memory>
+#include <optional>
+
+#include <crocore/utils.hpp>
+#include <vierkant/hash.hpp>
+
+namespace vierkant
+{
+
+class linear_hashmap
+{
+public:
+    using key_t = uint64_t;
+    using value_t = uint64_t;
+    using hash_fn = std::function<uint64_t(key_t)>;
+
+    linear_hashmap() = default;
+
+    explicit linear_hashmap(uint64_t capacity)
+        : m_capacity(crocore::next_pow_2(capacity)), m_storage(std::make_unique<storage_item_t[]>(m_capacity))
+    {
+        clear();
+    }
+
+    inline size_t size() const { return m_num_elements; }
+
+    inline size_t capacity() const { return m_capacity; }
+
+    inline bool empty() const { return size() == 0; }
+
+    inline void clear()
+    {
+        storage_item_t *ptr = m_storage.get(), *end = ptr + m_capacity;
+        for(; ptr != end; ++ptr) { ptr->key = 0; }
+    }
+
+    void insert(const key_t &key, value_t value)
+    {
+        assert(m_capacity);
+        for(uint64_t idx = m_hash_fn(key);; idx++)
+        {
+            idx &= m_capacity - 1;
+            auto &item = m_storage[idx];
+
+            // load previous key
+            key_t probed_key = m_storage[idx].key;
+
+            if(probed_key != key)
+            {
+                // hit another entry, keep searching
+                if(probed_key != 0) { continue; }
+
+                item.key.compare_exchange_strong(probed_key, key, std::memory_order_relaxed, std::memory_order_relaxed);
+                if(probed_key && probed_key != key)
+                {
+                    // another thread just stole it
+                    continue;
+                }
+                m_num_elements++;
+            }
+            item.value = value;
+            return;
+        }
+    }
+
+    [[nodiscard]] std::optional<value_t> get(const key_t &key) const
+    {
+        assert(m_capacity);
+        for(uint64_t idx = m_hash_fn(key);; idx++)
+        {
+            idx &= m_capacity - 1;
+            auto &item = m_storage[idx];
+            if(!item.key) { return {}; }
+            else if(key == item.key) { return item.value; }
+        }
+    }
+
+    [[nodiscard]] inline bool contains(const key_t &key) const { return get(key) != std::nullopt; }
+
+private:
+    struct storage_item_t
+    {
+        std::atomic<key_t> key;
+        value_t value{};
+    };
+    uint64_t m_capacity{};
+    std::atomic<uint64_t> m_num_elements;
+    std::unique_ptr<storage_item_t[]> m_storage;
+    hash_fn m_hash_fn = vierkant::murmur3_fmix64;
+};
+}// namespace vierkant

--- a/include/vierkant/linear_hashmap.hpp
+++ b/include/vierkant/linear_hashmap.hpp
@@ -8,6 +8,7 @@
 #include <cstdint>
 #include <memory>
 #include <optional>
+#include <shared_mutex>
 
 #include <crocore/utils.hpp>
 #include <vierkant/hash.hpp>
@@ -15,13 +16,23 @@
 namespace vierkant
 {
 
+template<typename K, typename V>
 class linear_hashmap
 {
 public:
-    using key_t = uint64_t;
-    using value_t = uint64_t;
-    using hash_fn = std::function<uint64_t(key_t)>;
+    using key_t = K;
+    using value_t = V;
+    using hash_fn = std::function<uint64_t(uint64_t)>;
+    static_assert(key_t() == key_t(), "key_t not comparable");
+
     linear_hashmap() = default;
+    linear_hashmap(const linear_hashmap &) = delete;
+    linear_hashmap(linear_hashmap &other) : linear_hashmap() { swap(*this, other); };
+    linear_hashmap &operator=(linear_hashmap other)
+    {
+        swap(*this, other);
+        return *this;
+    }
 
     explicit linear_hashmap(uint64_t min_capacity)
         : m_capacity(crocore::next_pow_2(min_capacity)), m_storage(std::make_unique<storage_item_t[]>(m_capacity))
@@ -41,10 +52,12 @@ public:
         for(; ptr != end; ++ptr) { ptr->key = 0; }
     }
 
-    value_t& insert(const key_t &key, value_t value)
+    value_t &put(const key_t &key, value_t value)
     {
         if(m_num_elements >= m_capacity) { throw std::overflow_error("capacity overflow"); }
-        for(uint64_t idx = m_hash_fn(key);; idx++)
+        std::shared_lock lock(m_mutex);
+
+        for(uint64_t idx = hash(key);; idx++)
         {
             idx &= m_capacity - 1;
             auto &item = m_storage[idx];
@@ -71,8 +84,10 @@ public:
 
     [[nodiscard]] std::optional<value_t> get(const key_t &key) const
     {
+        std::shared_lock lock(m_mutex);
+
         if(!m_capacity) { return {}; }
-        for(uint64_t idx = m_hash_fn(key);; idx++)
+        for(uint64_t idx = hash(key);; idx++)
         {
             idx &= m_capacity - 1;
             auto &item = m_storage[idx];
@@ -87,17 +102,56 @@ public:
 
     size_t storage_num_bytes() const { return sizeof(storage_item_t) * m_capacity; }
 
+    void resize(size_t new_capacity)
+    {
+        if(new_capacity > m_capacity)
+        {
+            auto new_linear_hashmap = linear_hashmap(new_capacity);
+            storage_item_t *ptr = m_storage.get(), *end = ptr + m_capacity;
+            for(; ptr != end; ++ptr) { new_linear_hashmap.put(ptr->key, ptr->value); }
+            swap(*this, new_linear_hashmap);
+        }
+    }
+
+    friend void swap(linear_hashmap &lhs, linear_hashmap &rhs)
+    {
+        std::lock(lhs.m_mutex, rhs.m_mutex);
+        std::unique_lock lock_lhs(lhs.m_mutex, std::adopt_lock), lock_rhs(rhs.m_mutex, std::adopt_lock);
+        std::swap(lhs.m_capacity, rhs.m_capacity);
+        lhs.m_num_elements = rhs.m_num_elements.exchange(lhs.m_num_elements);
+        std::swap(lhs.m_storage, rhs.m_storage);
+        std::swap(lhs.m_hash_fn, rhs.m_hash_fn);
+    }
+
 private:
     struct alignas(16) storage_item_t
     {
         std::atomic<key_t> key;
         value_t value{};
     };
-    static_assert(sizeof(storage_item_t) == sizeof(key_t) + sizeof(value_t));
+    static_assert(sizeof(storage_item_t) == sizeof(key_t) + sizeof(value_t),
+                  "alignment/size requirements not met for key_t");
 
+    inline uint64_t hash(const key_t &key) const
+    {
+        constexpr uint32_t num_hashes = sizeof(key_t) / sizeof(uint64_t);
+        constexpr uint32_t num_excess_bytes = sizeof(key_t) % sizeof(uint64_t);
+        auto ptr = reinterpret_cast<const uint64_t *>(&key), end = ptr + num_hashes;
+        size_t h = 0;
+        for(; ptr != end; ++ptr) { vierkant::hash_combine(h, m_hash_fn(*ptr)); }
+        if constexpr(num_excess_bytes)
+        {
+            auto end_u8 = reinterpret_cast<const uint8_t *>(end);
+            uint64_t tail = 0;
+            for(uint32_t i = 0; i < num_excess_bytes; ++i) { tail |= end_u8[i] << (i * 8); }
+            vierkant::hash_combine(h, m_hash_fn(tail));
+        }
+        return h;
+    }
     uint64_t m_capacity{};
     std::atomic<uint64_t> m_num_elements;
     std::unique_ptr<storage_item_t[]> m_storage;
     hash_fn m_hash_fn = vierkant::murmur3_fmix64;
+    mutable std::shared_mutex m_mutex;
 };
 }// namespace vierkant

--- a/include/vierkant/linear_hashmap.hpp
+++ b/include/vierkant/linear_hashmap.hpp
@@ -41,7 +41,7 @@ public:
         for(; ptr != end; ++ptr) { ptr->key = 0; }
     }
 
-    void insert(const key_t &key, value_t value)
+    value_t& insert(const key_t &key, value_t value)
     {
         if(m_num_elements >= m_capacity) { throw std::overflow_error("capacity overflow"); }
         for(uint64_t idx = m_hash_fn(key);; idx++)
@@ -65,8 +65,7 @@ public:
                 }
                 m_num_elements++;
             }
-            item.value = value;
-            return;
+            return item.value = value;
         }
     }
 

--- a/shaders/utils/random.glsl
+++ b/shaders/utils/random.glsl
@@ -47,6 +47,16 @@ uint hash(uint a)
     return a;
 }
 
+uint murmur3_fmix32(uint h)
+{
+    h ^= h >> 16;
+    h *= 0x85ebca6b;
+    h ^= h >> 13;
+    h *= 0xc2b2ae35;
+    h ^= h >> 16;
+    return h;
+}
+
 ////! random number generation using pcg32i_random_t, using inc = 1. Our random state is a uint.
 //uint rng_step(uint rng_state)
 //{

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,6 +1,9 @@
 include_directories(${vierkant_INCLUDE_DIRS})
 set(LIBS ${vierkant_LIBRARIES} GTest::gtest_main)
-
+if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
+    # gcc requires additional linking against libatomic, msvc/clang do not provide it.
+    set(LIBS ${LIBS} atomic)
+endif ()
 FILE(GLOB TEST_SOURCES "*.c*")
 FILE(GLOB TEST_HEADERS "*.h")
 
@@ -13,4 +16,4 @@ FOREACH (test_file ${TEST_SOURCES})
     add_executable(${test_name} ${test_file} ${TEST_HEADERS})
     TARGET_LINK_LIBRARIES(${test_name} ${LIBS})
     gtest_discover_tests(${test_name})
-ENDFOREACH(test_file)
+ENDFOREACH (test_file)

--- a/tests/TestLinearHashmap.cpp
+++ b/tests/TestLinearHashmap.cpp
@@ -1,0 +1,33 @@
+#include <vierkant/linear_hashmap.hpp>
+#include <gtest/gtest.h>
+
+
+TEST(linear_hashmap, empty)
+{
+    vierkant::linear_hashmap hashmap;
+    EXPECT_TRUE(hashmap.empty());
+    EXPECT_EQ(hashmap.capacity(), 0);
+}
+
+TEST(linear_hashmap, basic)
+{
+    constexpr uint32_t test_capacity = 100;
+    vierkant::linear_hashmap hashmap(test_capacity);
+    EXPECT_TRUE(hashmap.empty());
+
+    // capacity will be rounded to next pow2
+    EXPECT_GE(hashmap.capacity(), test_capacity);
+    EXPECT_TRUE(crocore::is_pow_2(hashmap.capacity()));
+
+    EXPECT_FALSE(hashmap.contains(13));
+    EXPECT_FALSE(hashmap.contains(42));
+
+    hashmap.insert(69, 99);
+    hashmap.insert(13, 12);
+    EXPECT_EQ(hashmap.size(), 2);
+
+    EXPECT_TRUE(hashmap.contains(69));
+    EXPECT_EQ(hashmap.get(69), 99);
+    EXPECT_TRUE(hashmap.contains(13));
+    EXPECT_EQ(hashmap.get(13), 12);
+}

--- a/tests/TestLinearHashmap.cpp
+++ b/tests/TestLinearHashmap.cpp
@@ -29,8 +29,10 @@ TEST(linear_hashmap, basic)
     EXPECT_FALSE(hashmap.contains(13));
     EXPECT_FALSE(hashmap.contains(42));
 
-    hashmap.insert(69, 99);
-    hashmap.insert(13, 12);
+    auto &v1 = hashmap.insert(69, 99);
+    EXPECT_EQ(v1, 99);
+    auto &v2 = hashmap.insert(13, 12);
+    EXPECT_EQ(v2, 12);
     EXPECT_EQ(hashmap.size(), 2);
 
     EXPECT_TRUE(hashmap.contains(69));

--- a/tests/TestLinearHashmap.cpp
+++ b/tests/TestLinearHashmap.cpp
@@ -36,9 +36,30 @@ TEST(linear_hashmap, basic)
     EXPECT_EQ(hashmap.get(69), 99);
     EXPECT_TRUE(hashmap.contains(13));
     EXPECT_EQ(hashmap.get(13), 12);
+}
 
-    vierkant::linear_hashmap<uint64_t, uint64_t> other_map;
-    other_map = vierkant::linear_hashmap<uint64_t, uint64_t>(19);
+TEST(linear_hashmap, custom_key)
+{
+    // custom 32-byte key
+    struct custom_key_t
+    {
+        int v[8]{};
+        constexpr bool operator==(const custom_key_t &other) const
+        {
+            for(uint32_t i = 0; i < 8; ++i)
+            {
+                if(v[i] != other.v[i]) { return false; }
+            }
+            return true;
+        }
+    };
+    constexpr uint32_t test_capacity = 100;
+    auto hashmap = vierkant::linear_hashmap<custom_key_t, uint64_t>(test_capacity);
+
+    custom_key_t k1{{1, 2, 3, 4, 5, 6, 7, 8}};
+    hashmap.put(k1, 69);
+    EXPECT_TRUE(hashmap.contains(k1));
+    EXPECT_FALSE(hashmap.contains(custom_key_t()));
 }
 
 TEST(linear_hashmap, resize)

--- a/tests/TestLinearHashmap.cpp
+++ b/tests/TestLinearHashmap.cpp
@@ -7,7 +7,6 @@ TEST(linear_hashmap, empty)
     vierkant::linear_hashmap<uint64_t, uint64_t> hashmap;
     EXPECT_TRUE(hashmap.empty());
     EXPECT_EQ(hashmap.capacity(), 0);
-    EXPECT_EQ(hashmap.storage(), nullptr);
     EXPECT_FALSE(hashmap.storage_num_bytes());
 }
 
@@ -16,7 +15,6 @@ TEST(linear_hashmap, basic)
     constexpr uint32_t test_capacity = 100;
     vierkant::linear_hashmap<uint64_t, uint64_t> hashmap(test_capacity);
     EXPECT_TRUE(hashmap.empty());
-    EXPECT_TRUE(hashmap.storage());
     EXPECT_TRUE(hashmap.storage_num_bytes());
 
     // capacity will be rounded to next pow2
@@ -36,6 +34,9 @@ TEST(linear_hashmap, basic)
     EXPECT_EQ(hashmap.get(69), 99);
     EXPECT_TRUE(hashmap.contains(13));
     EXPECT_EQ(hashmap.get(13), 12);
+
+    auto storage = std::make_unique<uint8_t[]>(hashmap.storage_num_bytes());
+    hashmap.get_storage(storage.get());
 }
 
 TEST(linear_hashmap, custom_key)
@@ -72,7 +73,6 @@ TEST(linear_hashmap, resize)
     // fix by resizing
     hashmap.resize(17);
     EXPECT_TRUE(hashmap.empty());
-    EXPECT_TRUE(hashmap.storage());
     hashmap.put(13, 12);
     EXPECT_TRUE(hashmap.contains(13));
 }

--- a/tests/TestLinearHashmap.cpp
+++ b/tests/TestLinearHashmap.cpp
@@ -1,23 +1,20 @@
-#include <vierkant/linear_hashmap.hpp>
 #include <gtest/gtest.h>
+#include <vierkant/linear_hashmap.hpp>
 
 
 TEST(linear_hashmap, empty)
 {
-    vierkant::linear_hashmap hashmap;
+    vierkant::linear_hashmap<uint64_t, uint64_t> hashmap;
     EXPECT_TRUE(hashmap.empty());
     EXPECT_EQ(hashmap.capacity(), 0);
     EXPECT_EQ(hashmap.storage(), nullptr);
     EXPECT_FALSE(hashmap.storage_num_bytes());
-
-    // empty / no capacity specified -> expect overflow on insert
-    EXPECT_THROW(hashmap.insert(13, 12), std::overflow_error);
 }
 
 TEST(linear_hashmap, basic)
 {
     constexpr uint32_t test_capacity = 100;
-    vierkant::linear_hashmap hashmap(test_capacity);
+    vierkant::linear_hashmap<uint64_t, uint64_t> hashmap(test_capacity);
     EXPECT_TRUE(hashmap.empty());
     EXPECT_TRUE(hashmap.storage());
     EXPECT_TRUE(hashmap.storage_num_bytes());
@@ -29,9 +26,9 @@ TEST(linear_hashmap, basic)
     EXPECT_FALSE(hashmap.contains(13));
     EXPECT_FALSE(hashmap.contains(42));
 
-    auto &v1 = hashmap.insert(69, 99);
+    auto &v1 = hashmap.put(69, 99);
     EXPECT_EQ(v1, 99);
-    auto &v2 = hashmap.insert(13, 12);
+    auto &v2 = hashmap.put(13, 12);
     EXPECT_EQ(v2, 12);
     EXPECT_EQ(hashmap.size(), 2);
 
@@ -39,4 +36,22 @@ TEST(linear_hashmap, basic)
     EXPECT_EQ(hashmap.get(69), 99);
     EXPECT_TRUE(hashmap.contains(13));
     EXPECT_EQ(hashmap.get(13), 12);
+
+    vierkant::linear_hashmap<uint64_t, uint64_t> other_map;
+    other_map = vierkant::linear_hashmap<uint64_t, uint64_t>(19);
+}
+
+TEST(linear_hashmap, resize)
+{
+    vierkant::linear_hashmap<uint64_t, uint64_t> hashmap;
+
+    // empty / no capacity specified -> expect overflow on insert
+    EXPECT_THROW(hashmap.put(13, 12), std::overflow_error);
+
+    // fix by resizing
+    hashmap.resize(17);
+    EXPECT_TRUE(hashmap.empty());
+    EXPECT_TRUE(hashmap.storage());
+    hashmap.put(13, 12);
+    EXPECT_TRUE(hashmap.contains(13));
 }

--- a/tests/TestLinearHashmap.cpp
+++ b/tests/TestLinearHashmap.cpp
@@ -7,6 +7,11 @@ TEST(linear_hashmap, empty)
     vierkant::linear_hashmap hashmap;
     EXPECT_TRUE(hashmap.empty());
     EXPECT_EQ(hashmap.capacity(), 0);
+    EXPECT_EQ(hashmap.storage(), nullptr);
+    EXPECT_FALSE(hashmap.storage_num_bytes());
+
+    // empty / no capacity specified -> expect overflow on insert
+    EXPECT_THROW(hashmap.insert(13, 12), std::overflow_error);
 }
 
 TEST(linear_hashmap, basic)
@@ -14,6 +19,8 @@ TEST(linear_hashmap, basic)
     constexpr uint32_t test_capacity = 100;
     vierkant::linear_hashmap hashmap(test_capacity);
     EXPECT_TRUE(hashmap.empty());
+    EXPECT_TRUE(hashmap.storage());
+    EXPECT_TRUE(hashmap.storage_num_bytes());
 
     // capacity will be rounded to next pow2
     EXPECT_GE(hashmap.capacity(), test_capacity);


### PR DESCRIPTION
- atomic/thread-safe, dead-simple, no deletion
- meant to receive a gpu/shader-counterpart