### PR TITLE
Wrap queues with a mutex each, finally required

### DIFF
--- a/include/vierkant/Device.hpp
+++ b/include/vierkant/Device.hpp
@@ -52,6 +52,12 @@ public:
         uint32_t num_queues = 0;
     };
 
+    struct queue_asset_t
+    {
+        VkQueue queue = VK_NULL_HANDLE;
+        std::unique_ptr<std::mutex> mutex;
+    };
+
     struct properties_t
     {
         VkPhysicalDeviceProperties core;
@@ -78,6 +84,9 @@ public:
 
         //! short-circuit function-pointers directly to device/driver entries (useful if only a single device exists)
         bool direct_function_pointers = false;
+
+        //! maximum number of queues to create, default: 0 (no limit)
+        uint32_t max_num_queues = 0;
 
         //! optional VkSurface
         VkSurfaceKHR surface = VK_NULL_HANDLE;
@@ -129,7 +138,7 @@ public:
     /**
      * @return  handle for queues
      */
-    [[nodiscard]] const std::vector<VkQueue> &queues(Queue type) const;
+    [[nodiscard]] const std::vector<queue_asset_t> &queues(Queue type) const;
 
     /**
      * @return  const ref to the used QueueFamilyIndices
@@ -183,7 +192,7 @@ private:
     VkSampleCountFlagBits m_max_usable_samples = VK_SAMPLE_COUNT_1_BIT;
 
     // a map holding all queues for logical device
-    std::map<Queue, std::vector<VkQueue>> m_queues;
+    std::map<Queue, std::vector<queue_asset_t>> m_queues;
 
     // keeps track of queue family indices
     std::map<Queue, queue_family_info_t> m_queue_indices;

--- a/tests/TestSemaphore.cpp
+++ b/tests/TestSemaphore.cpp
@@ -69,8 +69,8 @@ TEST(Semaphore, WaitBeforeSignal)
     auto semaphore = vierkant::Semaphore(testContext.device, 0);
 
     // two independent queues
-    auto queue1 = testContext.device->queues(vierkant::Device::Queue::COMPUTE).front();
-    auto queue2 = testContext.device->queues(vierkant::Device::Queue::GRAPHICS).back();
+    auto queue1 = testContext.device->queues(vierkant::Device::Queue::COMPUTE).front().queue;
+    auto queue2 = testContext.device->queues(vierkant::Device::Queue::GRAPHICS).back().queue;
 
     constexpr uint64_t signal1 = 42, signal2 = 666;
 

--- a/tests/test_context.hpp
+++ b/tests/test_context.hpp
@@ -44,6 +44,9 @@ public:
         device_info.instance = instance.handle();
         device_info.physical_device = physical_device;
         device_info.use_validation = instance.use_validation_layers();
+
+        // limit testing to two queues
+        device_info.max_num_queues = 2;
         device_info.surface = surface;
         device_info.extensions = device_extensions;
         device = vierkant::Device::create(device_info);


### PR DESCRIPTION
- Wrap queues with a mutex
- Add device-param `max_num_queues` to limit number of created queues
-  Limit number of queues for testing