### PR TITLE
Add lookup-function for draw-ids from object-id 

### DIFF
--- a/include/vierkant/RayBuilder.hpp
+++ b/include/vierkant/RayBuilder.hpp
@@ -183,8 +183,11 @@ public:
         //! the scene used to generate above data
         SceneConstPtr scene;
 
-        //! maps sub-entry-indices to their entity/sub_entry indices
+        //! maps draw internal entry-indices to their entity/sub_entry indices
         std::unordered_map<uint32_t, vierkant::id_entry_t> entry_idx_to_object_id;
+
+        //! maps object-ids to an array of draw internal entry-indices
+        std::unordered_map<uint32_t, std::vector<uint32_t>> object_id_to_entry_indices;
     };
 
     //! struct grouping parameters for 'build_scene_acceleration'-routine.

--- a/include/vierkant/SceneRenderer.hpp
+++ b/include/vierkant/SceneRenderer.hpp
@@ -17,8 +17,11 @@ DEFINE_CLASS_PTR(SceneRenderer)
 class SceneRenderer
 {
 public:
-    //! signature for a function. returns an id_entry_t for internal draw-indices
+    //! signature for a lookup function. returns an id_entry_t for internal draw-indices
     using object_id_by_index_fn_t = std::function<vierkant::id_entry_t(uint32_t idx)>;
+
+    //! signature for a lookup function. returns an array of draw-indices for an object-id
+    using indices_by_id_fn_t = std::function<std::vector<uint32_t>(uint32_t id)>;
 
     //! groups results of rendering operations.
     struct render_result_t
@@ -29,6 +32,7 @@ public:
         uint32_t num_contribution_culled = 0;
         vierkant::ImagePtr object_ids;
         object_id_by_index_fn_t object_by_index_fn;
+        indices_by_id_fn_t indices_by_id_fn;
         std::vector<semaphore_submit_info_t> semaphore_infos;
     };
 

--- a/include/vierkant/culling.hpp
+++ b/include/vierkant/culling.hpp
@@ -31,6 +31,9 @@ struct cull_result_t
     //! lookup: drawable-id -> entity/entry
     std::unordered_map<vierkant::DrawableId, id_entry_t> entity_map;
 
+    //! lookup: object-id -> drawable-indices
+    std::unordered_map<uint32_t, std::vector<uint32_t>> object_id_to_drawable_indices;
+
     //! lookup: (id/entry) -> drawable-index
     index_cache_t index_map;
 

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -483,14 +483,18 @@ SceneRenderer::render_result_t PBRDeferred::render_scene(Rasterizer &renderer, c
     }
 
     SceneRenderer::render_result_t ret = {};
-    ret.object_by_index_fn = [scene,
-                              &cull_result = frame_context.cull_result](uint32_t object_idx) -> vierkant::id_entry_t {
-        if(object_idx < cull_result.drawables.size())
+    ret.object_by_index_fn = [&cull_result = frame_context.cull_result](uint32_t draw_idx) -> vierkant::id_entry_t {
+        if(draw_idx < cull_result.drawables.size())
         {
             // picked_idx is an index into an array of drawables
-            auto drawable_id = cull_result.drawables[object_idx].id;
+            auto drawable_id = cull_result.drawables[draw_idx].id;
             return cull_result.entity_map.at(drawable_id);
         }
+        return {};
+    };
+    ret.indices_by_id_fn = [&cull_result = frame_context.cull_result](uint32_t object_id) -> std::vector<uint32_t> {
+        auto it = cull_result.object_id_to_drawable_indices.find(object_id);
+        if(it != cull_result.object_id_to_drawable_indices.end()) { return it->second; }
         return {};
     };
     ret.num_draws = frame_context.cull_result.drawables.size();

--- a/src/RayBuilder.cpp
+++ b/src/RayBuilder.cpp
@@ -390,7 +390,8 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
     vierkant::SelectVisitor<Object3D> visitor;
     params.scene->root()->accept(visitor);
 
-    for(const auto &object: visitor.objects)
+    //  cache-lookup / non-blocking build of acceleration structures
+    for(auto object: visitor.objects)
     {
         if(!object->has_component<vierkant::mesh_component_t>()) { continue; }
 
@@ -476,6 +477,8 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
             // store next entry-index
             size_t entry_idx = entries.size();
             ret.entry_idx_to_object_id[entry_idx] = {object->id(), i};
+            ret.object_id_to_entry_indices[object->id()].push_back(entry_idx);
+
             instance.instanceCustomIndex = entry_idx;
             instance.mask = 0xFF;
             instance.instanceShaderBindingTableRecordOffset = 0;

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -63,10 +63,12 @@ public:
 
                     id_entry_t key = {object.id(), drawable.entry_index};
                     m_cull_result.index_map[key] = i + m_cull_result.drawables.size();
-                }
 
-                // move drawables into cull_result
-                std::move(mesh_drawables.begin(), mesh_drawables.end(), std::back_inserter(m_cull_result.drawables));
+                    m_cull_result.object_id_to_drawable_indices[object.id()].push_back(m_cull_result.drawables.size());
+
+                    // move drawable into cull_result
+                    m_cull_result.drawables.push_back(std::move(drawable));
+                }
             }
             //            if(object.has_component<vierkant::model::lightsource_t>())
             //            {


### PR DESCRIPTION
- define signature in SceneRenderer-interface, implement in path-tracer and rasterizer
--> allows object-overlays from ui-picking, extending to all sub-objects