### PR TITLE
PBRDeferred: switch to mesh_compute

### DIFF
--- a/include/vierkant/PBRDeferred.hpp
+++ b/include/vierkant/PBRDeferred.hpp
@@ -111,6 +111,7 @@ public:
 
     struct timings_t
     {
+        double mesh_compute_ms = 0.0;
         double g_buffer_pre_ms = 0.0;
         double depth_pyramid_ms = 0.0;
         double culling_ms = 0.0;
@@ -216,7 +217,7 @@ private:
     enum SemaphoreValue : uint64_t
     {
         INVALID = 0,
-        PRE_RENDER,
+        MESH_COMPUTE,
         G_BUFFER_LAST_VISIBLE,
         DEPTH_PYRAMID,
         CULLING,
@@ -306,8 +307,9 @@ private:
         vierkant::BufferPtr staging_main, staging_anim, staging_post_fx;
 
         vierkant::mesh_compute_context_handle mesh_compute_context;
-//        vierkant::BufferPtr bone_buffer;
-//        vierkant::BufferPtr morph_param_buffer;
+        vierkant::mesh_compute_result_t mesh_compute_result;
+        //        vierkant::BufferPtr bone_buffer;
+        //        vierkant::BufferPtr morph_param_buffer;
         vierkant::BufferPtr g_buffer_camera_ubo;
 
         // lighting

--- a/include/vierkant/PBRDeferred.hpp
+++ b/include/vierkant/PBRDeferred.hpp
@@ -304,8 +304,10 @@ private:
 
         // host-visible
         vierkant::BufferPtr staging_main, staging_anim, staging_post_fx;
-        vierkant::BufferPtr bone_buffer;
-        vierkant::BufferPtr morph_param_buffer;
+
+        vierkant::mesh_compute_context_handle mesh_compute_context;
+//        vierkant::BufferPtr bone_buffer;
+//        vierkant::BufferPtr morph_param_buffer;
         vierkant::BufferPtr g_buffer_camera_ubo;
 
         // lighting

--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -109,13 +109,19 @@ public:
         //! number of array-elements in 'draws_in'
         uint32_t num_draws = 0;
 
-        //! device array containing any array of mesh_draw_t
+        //! device array containing an array of mesh_draw_t
         vierkant::BufferPtr mesh_draws;
 
-        //! device array containing any array of mesh_entry_t
+        //! host-memory
+        const mesh_draw_t* mesh_draws_host = nullptr;
+
+        //! device array containing an array of vertex-buffer device-addresses
+        vierkant::BufferPtr vertex_buffer_addresses;
+
+        //! device array containing an array of mesh_entry_t
         vierkant::BufferPtr mesh_entries;
 
-        //! device array containing any array of material_t
+        //! device array containing an array of material_t
         vierkant::BufferPtr materials;
 
         //! device array a visibility bitfield for all meshlets
@@ -298,6 +304,7 @@ private:
         indirect_draw_bundle_t indirect_indexed_bundle;
 
         std::vector<drawable_t> drawables;
+        std::vector<mesh_draw_t> mesh_draws;
         vierkant::CommandBuffer command_buffer, staging_command_buffer;
 
         // used for gpu timestamps

--- a/include/vierkant/drawable.hpp
+++ b/include/vierkant/drawable.hpp
@@ -75,6 +75,9 @@ struct drawable_t
 
     MeshConstPtr mesh;
 
+    //! optional override for vertex-buffer provided by mesh, if any
+    VkDeviceAddress vertex_buffer = 0;
+
     uint32_t entry_index = 0;
 
     graphics_pipeline_info_t pipeline_format = {};

--- a/shaders/pbr/indirect_cull.comp
+++ b/shaders/pbr/indirect_cull.comp
@@ -169,11 +169,6 @@ void main()
         draw.groupCountY = draw.groupCountZ = 1;
         draw.base_meshlet = lod.base_meshlet;
         draw.num_meshlets = lod.num_meshlets;
-
-        for(uint i = 0; i < lod_index; ++i)
-        {
-            draw.meshlet_visibility_index += div_up(mesh_entry.lods[i].num_meshlets, 32);
-        }
     }
 
     // count managment

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -16,7 +16,7 @@ const char *PBRDeferred::to_string(PBRDeferred::SemaphoreValue v)
     switch(v)
     {
         case INVALID: return "INVALID";
-        case PRE_RENDER: return "PRE_RENDER";
+        case MESH_COMPUTE: return "PRE_RENDER";
         case G_BUFFER_LAST_VISIBLE: return "G_BUFFER_LAST_VISIBLE";
         case DEPTH_PYRAMID: return "DEPTH_PYRAMID";
         case CULLING: return "CULLING";
@@ -536,7 +536,6 @@ void PBRDeferred::update_animation_transforms(frame_context_t &frame_context)
     frame_context.cull_result.scene->root()->accept(visitor);
 
     std::unordered_map<uint32_t, vierkant::animated_mesh_t> mesh_compute_entities;
-    vierkant::mesh_compute_result_t mesh_compute_result = {};
 
     if(frame_context.mesh_compute_context)
     {
@@ -544,10 +543,10 @@ void PBRDeferred::update_animation_transforms(frame_context_t &frame_context)
         mesh_compute_params.queue = m_queue;
         mesh_compute_params.semaphore_submit_info.semaphore = frame_context.timeline.handle();
         mesh_compute_params.semaphore_submit_info.signal_value =
-                frame_context.current_semaphore_value + SemaphoreValue::PRE_RENDER;
+                frame_context.current_semaphore_value + SemaphoreValue::MESH_COMPUTE;
         mesh_compute_params.query_pool = frame_context.query_pool;
-        mesh_compute_params.query_index_start = 2 * SemaphoreValue::PRE_RENDER;
-        mesh_compute_params.query_index_end = 2 * SemaphoreValue::PRE_RENDER + 1;
+        mesh_compute_params.query_index_start = 2 * SemaphoreValue::MESH_COMPUTE;
+        mesh_compute_params.query_index_end = 2 * SemaphoreValue::MESH_COMPUTE + 1;
 
         //  check for skin/morph meshes and schedule a mesh-compute operation
         for(const auto &object: visitor.objects)
@@ -569,150 +568,43 @@ void PBRDeferred::update_animation_transforms(frame_context_t &frame_context)
         // updates of animated (skin/morph) assets
         if(!mesh_compute_params.mesh_compute_items.empty())
         {
-            mesh_compute_result = vierkant::mesh_compute(frame_context.mesh_compute_context, mesh_compute_params);
+            frame_context.mesh_compute_result =
+                    vierkant::mesh_compute(frame_context.mesh_compute_context, mesh_compute_params);
         }
-        else { frame_context.timeline.signal(frame_context.current_semaphore_value + SemaphoreValue::PRE_RENDER); }
+        else { frame_context.timeline.signal(frame_context.current_semaphore_value + SemaphoreValue::MESH_COMPUTE); }
     }
-
-    //    for(const auto *object: visitor.objects)
-    //    {
-    //        auto object_id = object->id();
-    //
-    //        auto *mesh_component = object->get_component_ptr<mesh_component_t>();
-    //        auto *animation_state = object->get_component_ptr<animation_component_t>();
-    //        if(!mesh_component || !animation_state) { continue; }
-    //
-    //        const auto &mesh = mesh_component->mesh;
-    //        const auto &animation = mesh->node_animations[animation_state->index];
-    //
-    //        if(mesh->root_bone)
-    //        {
-    //            std::vector<vierkant::transform_t> bone_transforms;
-    //            vierkant::nodes::build_node_matrices_bfs(mesh->root_bone, animation, animation_state->current_time,
-    //                                                     bone_transforms);
-    //
-    //            // min alignment for storage-buffers
-    //            auto min_alignment = m_device->properties().core.limits.minStorageBufferOffsetAlignment;
-    //            size_t num_bytes = bone_transforms.size() * sizeof(vierkant::transform_t);
-    //            if(num_bytes % min_alignment) { bone_transforms.push_back({}); }
-    //
-    //            // keep track of offset
-    //            entity_bone_buffer_offsets[object_id] = all_bone_transforms.size() * sizeof(vierkant::transform_t);
-    //            all_bone_transforms.insert(all_bone_transforms.end(), bone_transforms.begin(), bone_transforms.end());
-    //        }
-    //        else if(mesh->morph_buffer)
-    //        {
-    //            // morph-target weights
-    //            std::vector<std::vector<float>> node_morph_weights;
-    //            vierkant::nodes::build_morph_weights_bfs(mesh->root_node, animation, animation_state->current_time,
-    //                                                     node_morph_weights);
-    //
-    //            for(uint32_t i = 0; i < mesh->entries.size(); ++i)
-    //            {
-    //                const auto &entry = mesh->entries[i];
-    //                id_entry_t key = {object_id, i};
-    //                const auto &weights = node_morph_weights[entry.node_index];
-    //
-    //                morph_params_t p;
-    //                p.base_vertex = entry.morph_vertex_offset;
-    //                p.vertex_count = entry.num_vertices;
-    //                p.morph_count = weights.size();
-    //
-    //                assert(p.morph_count * sizeof(float) <= sizeof(p.weights));
-    //                memcpy(p.weights, weights.data(), weights.size() * sizeof(float));
-    //
-    //                // keep track of offset
-    //                morph_buffer_offsets[key] = all_morph_params.size() * sizeof(morph_params_t);
-    //                all_morph_params.push_back(p);
-    //            }
-    //        }
-    //    }
-    //
-    //    frame_context.cmd_pre_render.begin(0);
-    //    vierkant::begin_label(frame_context.cmd_pre_render.handle(), {"update animations"});
-    //
-    //    // barriers
-    //    VkBuffer buffers[] = {frame_context.bone_buffer->handle(), frame_context.morph_param_buffer->handle()};
-    //    vierkant::barrier(frame_context.cmd_pre_render.handle(), buffers, 2, VK_PIPELINE_STAGE_2_TRANSFER_BIT,
-    //                      VK_ACCESS_2_TRANSFER_WRITE_BIT, VK_PIPELINE_STAGE_2_TRANSFER_BIT, VK_ACCESS_2_TRANSFER_WRITE_BIT);
-    //    vierkant::staging_copy_context_t staging_context = {};
-    //    staging_context.staging_buffer = frame_context.staging_anim;
-    //    staging_context.command_buffer = frame_context.cmd_pre_render.handle();
-    //
-    //    vierkant::staging_copy_info_t copy_bones = {};
-    //    copy_bones.num_bytes = all_bone_transforms.size() * sizeof(vierkant::transform_t);
-    //    copy_bones.data = all_bone_transforms.data();
-    //    copy_bones.dst_buffer = frame_context.bone_buffer;
-    //    copy_bones.dst_access = VK_ACCESS_2_SHADER_READ_BIT;
-    //    copy_bones.dst_stage = VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT;
-    //
-    //    vierkant::staging_copy_info_t copy_morphs = {};
-    //    copy_morphs.num_bytes = all_morph_params.size() * sizeof(morph_params_t);
-    //    copy_morphs.data = all_morph_params.data();
-    //    copy_morphs.dst_buffer = frame_context.morph_param_buffer;
-    //    copy_morphs.dst_access = VK_ACCESS_2_SHADER_READ_BIT;
-    //    copy_morphs.dst_stage = VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT;
-    //
-    //    vierkant::staging_copy(staging_context, {copy_bones, copy_morphs});
-    //
-    //    vierkant::end_label(frame_context.cmd_pre_render.handle());
-    //    vierkant::semaphore_submit_info_t semaphore_info = {};
-    //    semaphore_info.semaphore = frame_context.timeline.handle();
-    //    semaphore_info.signal_value = frame_context.current_semaphore_value + SemaphoreValue::PRE_RENDER;
-    //    frame_context.cmd_pre_render.submit(m_queue, false, VK_NULL_HANDLE, {semaphore_info});
 
     if(!frame_context.recycle_commands)
     {
         // insert previous matrices from cache, if any
         for(auto &drawable: frame_context.cull_result.drawables)
         {
-            auto [entity, sub_entry] = frame_context.cull_result.entity_map[drawable.id];
+            auto [obj_id, sub_entry] = frame_context.cull_result.entity_map[drawable.id];
 
             // search previous matrices
-            id_entry_t key = {static_cast<uint32_t>(entity), drawable.entry_index};
+            id_entry_t key = {obj_id, drawable.entry_index};
             auto it = m_entry_matrix_cache.find(key);
             if(it != m_entry_matrix_cache.end()) { drawable.last_matrices = it->second; }
 
-            //            // descriptors for bone buffers, if necessary
-            //            if(drawable.mesh && drawable.mesh->root_bone)
-            //            {
-            //                uint32_t buffer_offset = entity_bone_buffer_offsets[entity];
-            //
-            //                vierkant::descriptor_t desc_bones = {};
-            //                desc_bones.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            //                desc_bones.stage_flags = VK_SHADER_STAGE_VERTEX_BIT;
-            //                desc_bones.buffers = {frame_context.bone_buffer};
-            //                desc_bones.buffer_offsets = {buffer_offset};
-            //                drawable.descriptors[Rasterizer::BINDING_BONES] = desc_bones;
-            //
-            //                if(last_frame_context.bone_buffer &&
-            //                   last_frame_context.bone_buffer->num_bytes() == frame_context.bone_buffer->num_bytes())
-            //                {
-            //                    desc_bones.buffers = {last_frame_context.bone_buffer};
-            //                }
-            //                drawable.descriptors[Rasterizer::BINDING_PREVIOUS_BONES] = desc_bones;
-            //            }
-            //
-            //            if(drawable.mesh && drawable.mesh->morph_buffer)
-            //            {
-            //                //! morph_params_t contains information to access a morph-target buffer
-            //                uint32_t buffer_offset = morph_buffer_offsets[key];
-            //
-            //                // use combined buffer
-            //                vierkant::descriptor_t desc_morph_params = {};
-            //                desc_morph_params.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            //                desc_morph_params.stage_flags = VK_SHADER_STAGE_VERTEX_BIT;
-            //                desc_morph_params.buffers = {frame_context.morph_param_buffer};
-            //                desc_morph_params.buffer_offsets = {buffer_offset};
-            //                drawable.descriptors[Rasterizer::BINDING_MORPH_PARAMS] = desc_morph_params;
-            //
-            //                if(last_frame_context.morph_param_buffer &&
-            //                   last_frame_context.morph_param_buffer->num_bytes() == frame_context.morph_param_buffer->num_bytes())
-            //                {
-            //                    desc_morph_params.buffers = {last_frame_context.morph_param_buffer};
-            //                }
-            //                drawable.descriptors[Rasterizer::BINDING_PREVIOUS_MORPH_PARAMS] = desc_morph_params;
-            //            }
+            // current and previous vertex-buffers
+            auto address_it = frame_context.mesh_compute_result.vertex_buffer_offsets.find(obj_id);
+
+            if(address_it != frame_context.mesh_compute_result.vertex_buffer_offsets.end())
+            {
+                VkDeviceAddress address =
+                        frame_context.mesh_compute_result.result_buffer->device_address() + address_it->second;
+                VkDeviceAddress prev_address = address;
+
+                auto prev_it = last_frame_context.mesh_compute_result.vertex_buffer_offsets.find(obj_id);
+                if(prev_it != last_frame_context.mesh_compute_result.vertex_buffer_offsets.end())
+                {
+                    prev_address =
+                            last_frame_context.mesh_compute_result.result_buffer->device_address() + prev_it->second;
+                    (void) prev_address;
+                }
+
+                // TODO: store/assign new vertex-buffers
+            }
         }
     }
 }
@@ -778,7 +670,7 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             uint32_t shader_flags = PROP_DEFAULT;
 
             // check if vertex-skinning is required
-            if(drawable.mesh->root_bone) { shader_flags |= PROP_SKIN; }
+            //            if(drawable.mesh->root_bone) { shader_flags |= PROP_SKIN; }
 
             // check if tangents are available
             if(drawable.mesh->vertex_attribs.count(Mesh::ATTRIB_TANGENT)) { shader_flags |= PROP_TANGENT_SPACE; }
@@ -787,8 +679,7 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             drawable.pipeline_format.attribute_descriptions.clear();
             drawable.pipeline_format.binding_descriptions.clear();
 
-            const bool use_meshlet_pipeline = drawable.mesh->meshlets && frame_context.settings.use_meshlet_pipeline &&
-                                              !drawable.mesh->morph_buffer && !drawable.mesh->root_bone;
+            const bool use_meshlet_pipeline = drawable.mesh->meshlets && frame_context.settings.use_meshlet_pipeline;
 
             if(use_meshlet_pipeline)
             {
@@ -810,8 +701,8 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
                 desc_depth_pyramid.images = {vierkant::get_depth_pyramid(frame_context.gpu_cull_context)};
             }
 
-            // check if morph-targets are available
-            if(drawable.mesh->morph_buffer) { shader_flags |= PROP_MORPH_TARGET; }
+            //            // check if morph-targets are available
+            //            if(drawable.mesh->morph_buffer) { shader_flags |= PROP_MORPH_TARGET; }
 
             // select shader-stages from cache
             auto stage_it = m_g_buffer_shader_stages.find(shader_flags);
@@ -955,7 +846,8 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
     auto cmd_buffer_pre = m_g_renderer_main.render(frame_context.g_buffer_main, frame_context.recycle_commands);
     vierkant::semaphore_submit_info_t g_buffer_semaphore_submit_info_pre = {};
     g_buffer_semaphore_submit_info_pre.semaphore = frame_context.timeline.handle();
-    g_buffer_semaphore_submit_info_pre.wait_value = frame_context.current_semaphore_value + SemaphoreValue::PRE_RENDER;
+    g_buffer_semaphore_submit_info_pre.wait_value =
+            frame_context.current_semaphore_value + SemaphoreValue::MESH_COMPUTE;
     g_buffer_semaphore_submit_info_pre.wait_stage = VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT;
     g_buffer_semaphore_submit_info_pre.signal_value =
             frame_context.current_semaphore_value +
@@ -1524,7 +1416,7 @@ void PBRDeferred::update_timing(frame_context_t &frame_context)
     {
         auto timestamp_period = m_device->properties().core.limits.timestampPeriod;
 
-        for(uint32_t i = G_BUFFER_LAST_VISIBLE; i <= frame_context.semaphore_value_done; ++i)
+        for(uint32_t i = MESH_COMPUTE; i <= frame_context.semaphore_value_done; ++i)
         {
             auto val = SemaphoreValue(i);
             auto measurement = vierkant::timestamp_millis(timestamps, val, timestamp_period);
@@ -1532,6 +1424,7 @@ void PBRDeferred::update_timing(frame_context_t &frame_context)
         }
     }
 
+    timings_result.mesh_compute_ms = frame_context.timings_map[SemaphoreValue::MESH_COMPUTE].count();
     timings_result.g_buffer_pre_ms = frame_context.timings_map[SemaphoreValue::G_BUFFER_LAST_VISIBLE].count();
     timings_result.depth_pyramid_ms = timing_millis[SemaphoreValue::DEPTH_PYRAMID];
     timings_result.culling_ms = timing_millis[SemaphoreValue::CULLING];

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -520,17 +520,19 @@ SceneRenderer::render_result_t PBRDeferred::render_scene(Rasterizer &renderer, c
 void PBRDeferred::update_animation_transforms(frame_context_t &frame_context)
 {
     // cache/collect bone-matrices
-    std::unordered_map<uint32_t, size_t> entity_bone_buffer_offsets;
-    std::vector<vierkant::transform_t> all_bone_transforms;
+    //    std::unordered_map<uint32_t, size_t> entity_bone_buffer_offsets;
+    //    std::vector<vierkant::transform_t> all_bone_transforms;
+    //
+    //    // cache/collect morph-params
+    //    using morph_buffer_offset_mapt_t = std::unordered_map<id_entry_t, size_t>;
+    //    morph_buffer_offset_mapt_t morph_buffer_offsets;
+    //    std::vector<morph_params_t> all_morph_params;
 
-    // cache/collect morph-params
-    using morph_buffer_offset_mapt_t = std::unordered_map<id_entry_t, size_t>;
-    morph_buffer_offset_mapt_t morph_buffer_offsets;
-    std::vector<morph_params_t> all_morph_params;
+    frame_context.mesh_compute_result.vertex_buffer_offsets.clear();
 
-    size_t last_index = (m_g_renderer_main.current_index() + m_g_renderer_main.num_concurrent_frames() - 1) %
-                        m_g_renderer_main.num_concurrent_frames();
-    auto &last_frame_context = m_frame_contexts[last_index];
+    //    size_t last_index = (m_g_renderer_main.current_index() + m_g_renderer_main.num_concurrent_frames() - 1) %
+    //                        m_g_renderer_main.num_concurrent_frames();
+    //    auto &last_frame_context = m_frame_contexts[last_index];
 
     SelectVisitor<Object3D> visitor;
     frame_context.cull_result.scene->root()->accept(visitor);
@@ -586,25 +588,25 @@ void PBRDeferred::update_animation_transforms(frame_context_t &frame_context)
             auto it = m_entry_matrix_cache.find(key);
             if(it != m_entry_matrix_cache.end()) { drawable.last_matrices = it->second; }
 
-            // current and previous vertex-buffers
-            auto address_it = frame_context.mesh_compute_result.vertex_buffer_offsets.find(obj_id);
-
-            if(address_it != frame_context.mesh_compute_result.vertex_buffer_offsets.end())
-            {
-                VkDeviceAddress address =
-                        frame_context.mesh_compute_result.result_buffer->device_address() + address_it->second;
-                VkDeviceAddress prev_address = address;
-
-                auto prev_it = last_frame_context.mesh_compute_result.vertex_buffer_offsets.find(obj_id);
-                if(prev_it != last_frame_context.mesh_compute_result.vertex_buffer_offsets.end())
-                {
-                    prev_address =
-                            last_frame_context.mesh_compute_result.result_buffer->device_address() + prev_it->second;
-                    (void) prev_address;
-                }
-
-                // TODO: store/assign new vertex-buffers
-            }
+            //            // current and previous vertex-buffers
+            //            auto address_it = frame_context.mesh_compute_result.vertex_buffer_offsets.find(obj_id);
+            //
+            //            if(address_it != frame_context.mesh_compute_result.vertex_buffer_offsets.end())
+            //            {
+            //                VkDeviceAddress address =
+            //                        frame_context.mesh_compute_result.result_buffer->device_address() + address_it->second;
+            //                VkDeviceAddress prev_address = address;
+            //
+            //                auto prev_it = last_frame_context.mesh_compute_result.vertex_buffer_offsets.find(obj_id);
+            //                if(prev_it != last_frame_context.mesh_compute_result.vertex_buffer_offsets.end())
+            //                {
+            //                    prev_address =
+            //                            last_frame_context.mesh_compute_result.result_buffer->device_address() + prev_it->second;
+            //                    (void) prev_address;
+            //                }
+            //
+            //                // TODO: store/assign new vertex-buffers
+            //            }
         }
     }
 }
@@ -799,7 +801,8 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
                         frame_context.cmd_clear.handle(), src_stage, src_access, dst_stage, dst_access);
             }
         }
-        else if(params.num_draws && !frame_context.dirty_drawable_indices.empty())
+        else if(params.num_draws && (!frame_context.dirty_drawable_indices.empty() ||
+                                     !frame_context.mesh_compute_result.vertex_buffer_offsets.empty()))
         {
             params.mesh_draws->barrier(frame_context.cmd_clear.handle(), src_stage, src_access, src_stage, src_access);
             constexpr size_t stride = sizeof(Rasterizer::mesh_draw_t);
@@ -809,6 +812,7 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             std::vector<vierkant::staging_copy_info_t> copy_transforms;
             uint32_t i = 0;
 
+            // transform updates for drawables
             for(auto idx: frame_context.dirty_drawable_indices)
             {
                 if(idx < frame_context.cull_result.drawables.size())
@@ -832,6 +836,35 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
                 {
                     spdlog::warn("idx >= frame_context.cull_result.drawables.size()");
                     break;
+                }
+            }
+
+            // vertex-buffers update from animation
+            std::vector<VkDeviceAddress> addresses;
+            addresses.reserve(frame_context.mesh_compute_result.vertex_buffer_offsets.size());
+            std::unordered_set<uint32_t> mesh_indices;
+
+            for(const auto &[obj_id, offset]: frame_context.mesh_compute_result.vertex_buffer_offsets)
+            {
+                auto &address = addresses.emplace_back(
+                        frame_context.mesh_compute_result.result_buffer->device_address() + offset);
+
+                for(uint32_t idx: frame_context.cull_result.object_id_to_drawable_indices[obj_id])
+                {
+                    uint32_t mesh_index = params.mesh_draws_host[idx].mesh_index;
+
+                    if(!mesh_indices.contains(mesh_index))
+                    {
+                        vierkant::staging_copy_info_t copy_vertex_address = {};
+                        copy_vertex_address.num_bytes = sizeof(VkDeviceAddress);
+                        copy_vertex_address.data = &address;
+                        copy_vertex_address.dst_buffer = params.vertex_buffer_addresses;
+                        copy_vertex_address.dst_offset = sizeof(VkDeviceAddress) * mesh_index;
+                        copy_vertex_address.dst_access = VK_ACCESS_2_SHADER_READ_BIT;
+                        copy_vertex_address.dst_stage = VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT;
+                        copy_transforms.push_back(copy_vertex_address);
+                        mesh_indices.insert(mesh_index);
+                    }
                 }
             }
             vierkant::staging_copy(staging_context, copy_transforms);

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -417,8 +417,6 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
 
             if(drawable->mesh && drawable->mesh->index_buffer)
             {
-                bool use_meshlets = drawable->mesh->meshlets && !drawable->mesh->morph_buffer &&
-                                    !drawable->mesh->bone_vertex_buffer;
                 auto draw_command = static_cast<indexed_indirect_command_t *>(
                                             frame_assets.indirect_indexed_bundle.draws_in->map()) +
                                     frame_assets.indirect_indexed_bundle.num_draws++;
@@ -434,7 +432,8 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
                 draw_command->count_buffer_offset = indirect_draw_asset.count_buffer_offset;
                 draw_command->first_draw_index = indirect_draw_asset.first_indexed_draw_index;
                 draw_command->object_index = indexed_drawable.object_index;
-                draw_command->flags = DRAW_COMMAND_FLAG_ENABLED | (use_meshlets ? DRAW_COMMAND_FLAG_MESHLETS : 0);
+                draw_command->flags =
+                        DRAW_COMMAND_FLAG_ENABLED | (drawable->mesh->meshlets ? DRAW_COMMAND_FLAG_MESHLETS : 0);
 
                 draw_command->base_meshlet = drawable->base_meshlet;
                 draw_command->num_meshlets = drawable->num_meshlets;
@@ -544,9 +543,8 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
             vkCmdPushConstants(command_buffer, pipeline->layout(), VK_SHADER_STAGE_ALL, 0, sizeof(push_constants_t),
                                &push_constants);
 
-            // feature enabled/available, mesh exists and contains a meshlet-buffer. skinning/morphing not supported
-            bool use_meshlets = vkCmdDrawMeshTasksEXT && use_mesh_shader && mesh && mesh->meshlets &&
-                                !mesh->root_bone && !mesh->morph_buffer;
+            // feature enabled/available, mesh exists and contains a meshlet-buffer.
+            bool use_meshlets = vkCmdDrawMeshTasksEXT && use_mesh_shader && mesh && mesh->meshlets;
 
             if(mesh && current_mesh != mesh)
             {

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -379,14 +379,9 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
         // bindless texture-array
         pipeline_format.descriptor_set_layouts.push_back(bindless_texture_layout.get());
 
-        if(drawable.mesh && drawable.mesh->meshlets && drawable.entry_index < drawable.mesh->entries.size())
-        {
-            indexed_drawable.meshlet_visibility_index = meshlet_visibility_index;
-            for(const auto &lod: drawable.mesh->entries[drawable.entry_index].lods)
-            {
-                meshlet_visibility_index += div_up(lod.num_meshlets, 32);
-            }
-        }
+        // enough meshlet-visibility bits for lod0
+        indexed_drawable.meshlet_visibility_index = meshlet_visibility_index;
+        meshlet_visibility_index += div_up(drawable.num_meshlets, 32);
 
         // push intermediate struct
         pipeline_drawables[pipeline_format].push_back(indexed_drawable);
@@ -744,12 +739,9 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, Raster
                 material_data.push_back(drawable.material);
             }
 
-            // set visibility-bits low/hi for all lods
-            size_t num_array_elems = 0;
+            // set visibility-bits low/hi for lod0
             uint32_t vis = 0xFFFFFFFF;
-            const auto &entry = drawable.mesh->entries[drawable.entry_index];
-            for(const auto &lod: entry.lods) { num_array_elems += div_up(lod.num_meshlets, 32); }
-            meshlet_visibility_data.resize(meshlet_visibility_data.size() + num_array_elems, vis);
+            meshlet_visibility_data.resize(meshlet_visibility_data.size() + div_up(drawable.num_meshlets, 32), vis);
         }
         else { material_data.push_back(drawable.material); }
 

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -725,7 +725,11 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, Raster
                 mesh_entry.center = e.bounding_sphere.center;
                 mesh_entry.radius = e.bounding_sphere.radius;
                 mesh_entries.push_back(mesh_entry);
-                vertex_buffer_refs.push_back(drawable.mesh->vertex_buffer->device_address());
+
+                VkDeviceAddress vertex_buffer_address = drawable.vertex_buffer
+                                                                ? drawable.vertex_buffer
+                                                                : drawable.mesh->vertex_buffer->device_address();
+                vertex_buffer_refs.push_back(vertex_buffer_address);
             }
             else { mesh_index = mesh_entry_it->second; }
 

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -37,8 +37,7 @@ std::vector<vierkant::drawable_t> create_drawables(const vierkant::mesh_componen
         vierkant::nodes::build_morph_weights_bfs(mesh->root_node, animation, params.animation_time, node_morph_weights);
     }
 
-    bool use_meshlets = mesh->meshlets && mesh->meshlet_vertices && mesh->meshlet_triangles && !mesh->root_bone &&
-                        !mesh->morph_buffer;
+    bool use_meshlets = mesh->meshlets && mesh->meshlet_vertices && mesh->meshlet_triangles;
 
     for(uint32_t i = 0; i < mesh->entries.size(); ++i)
     {
@@ -89,22 +88,22 @@ std::vector<vierkant::drawable_t> create_drawables(const vierkant::mesh_componen
 
         if(!drawable.use_own_buffers)
         {
-            if(drawable.mesh->bone_vertex_buffer)
-            {
-                auto &desc_vertices = drawable.descriptors[Rasterizer::BINDING_BONE_VERTEX_DATA];
-                desc_vertices.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_vertices.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
-                desc_vertices.buffers = {drawable.mesh->bone_vertex_buffer};
-            }
-
-            if(drawable.mesh->morph_buffer)
-            {
-                // add descriptors for morph- buffer_params
-                vierkant::descriptor_t &desc_morph_buffer = drawable.descriptors[Rasterizer::BINDING_MORPH_TARGETS];
-                desc_morph_buffer.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_morph_buffer.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
-                desc_morph_buffer.buffers = {drawable.mesh->morph_buffer};
-            }
+//            if(drawable.mesh->bone_vertex_buffer)
+//            {
+//                auto &desc_vertices = drawable.descriptors[Rasterizer::BINDING_BONE_VERTEX_DATA];
+//                desc_vertices.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+//                desc_vertices.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
+//                desc_vertices.buffers = {drawable.mesh->bone_vertex_buffer};
+//            }
+//
+//            if(drawable.mesh->morph_buffer)
+//            {
+//                // add descriptors for morph- buffer_params
+//                vierkant::descriptor_t &desc_morph_buffer = drawable.descriptors[Rasterizer::BINDING_MORPH_TARGETS];
+//                desc_morph_buffer.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+//                desc_morph_buffer.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
+//                desc_morph_buffer.buffers = {drawable.mesh->morph_buffer};
+//            }
 
             if(use_meshlets)
             {


### PR DESCRIPTION
PBRDeferred/Rasterizer:
completely rework animation-handling, switch to baking vertex-buffer with mesh_compute.
this is the same as done for the path-tracer and removes long-standing issues when mixed with indirect drawing.