### PR TITLE
Drop VkRenderPass and VkFramebuffer

### DIFF
--- a/include/vierkant/Framebuffer.hpp
+++ b/include/vierkant/Framebuffer.hpp
@@ -13,8 +13,6 @@
 namespace vierkant
 {
 
-using RenderPassPtr = std::shared_ptr<VkRenderPass_T>;
-
 /**
  * @brief   Enum to differentiate Image-Attachments
  */
@@ -27,22 +25,19 @@ enum class AttachmentType
 
 using attachment_map_t = std::map<AttachmentType, std::vector<vierkant::ImagePtr>>;
 
-/**
- * @brief                           Utility function to create a shared RenderPass.
- *
- * @param   device                  handle for the vierkant::Device to create the RenderPass with
- * @param   attachments             an attachment_map_t to derive the RenderPass from
- * @param   subpass_dependencies    optional array of VkSubpassDependency objects
- *
- * @return  the newly created RenderpassPtr
- */
-RenderPassPtr create_renderpass(const vierkant::DevicePtr &device, const attachment_map_t &attachments,
-                                bool clear_color, bool clear_depth,
-                                const std::vector<VkSubpassDependency2> &subpass_dependencies = {});
-
 class Framebuffer
 {
 public:
+    //! group parameters for  'begin_rendering'-routine
+    struct begin_rendering_info_t
+    {
+        bool use_color_attachment = true;
+        bool clear_color_attachment = true;
+        bool use_depth_attachment = true;
+        bool clear_depth_attachment = true;
+        VkRenderingFlags flags = 0;
+    };
+
     /**
      * @brief   Framebuffer::Format groups information necessary to create a set of Image-Attachments
      */
@@ -58,18 +53,8 @@ public:
         Image::Format depth_attachment_format;
         vierkant::CommandPoolPtr command_pool = nullptr;
         VkQueue queue = VK_NULL_HANDLE;
-        RenderPassPtr renderpass = nullptr;
+        begin_rendering_info_t rendering_info = {};
         std::optional<vierkant::debug_label_t> debug_label;
-    };
-
-    //! group parameters for  'begin_rendering'-routine
-    struct begin_rendering_info_t
-    {
-        VkCommandBuffer commandbuffer = VK_NULL_HANDLE;
-        bool use_color_attachment = true;
-        bool clear_color_attachment = true;
-        bool use_depth_attachment = true;
-        bool clear_depth_attachment = true;
     };
 
     /**
@@ -95,9 +80,8 @@ public:
      *
      * @param   device          handle for the vierkant::Device to create the Framebuffer with
      * @param   attachments     a Framebuffer::AttachmentMap holding the desired Image-attachments
-     * @param   renderpass      an optional, shared RenderPass object to be used with the Framebuffer
      */
-    Framebuffer(DevicePtr device, attachment_map_t attachments, RenderPassPtr renderpass = nullptr);
+    Framebuffer(DevicePtr device, attachment_map_t attachments, const begin_rendering_info_t &begin_rendering_info);
 
     Framebuffer() = default;
 
@@ -105,14 +89,12 @@ public:
 
     Framebuffer(const Framebuffer &) = delete;
 
-    ~Framebuffer();
-
     Framebuffer &operator=(Framebuffer the_other);
 
     /**
-     * @brief   Execute a provided array of secondary VkCommandBuffers within a Renderpass for this Framebuffer.
+     * @brief   Execute a provided array of secondary VkCommandBuffers within a dynamic rendering scope.
      *
-     * @param   command_buffers an array of secondary VkCommandBuffers to render into this Framebuffer.
+     * @param   commandbuffers an array of secondary VkCommandBuffers to render into this Framebuffer.
      */
     VkCommandBuffer record_commandbuffer(const std::vector<VkCommandBuffer> &commandbuffers);
 
@@ -120,7 +102,7 @@ public:
      * @brief   Execute a provided array of secondary VkCommandBuffers within a renderpass for this Framebuffer,
      *          submit to a VkQueue with optional submit_info.
      *
-     * @param   command_buffers an array of secondary VkCommandBuffers to render into this Framebuffer.
+     * @param   commandbuffers  an array of secondary VkCommandBuffers to render into this Framebuffer.
      * @param   queue           a VkQueue to submit the primary VkCommandBuffer to.
      * @param   semaphore_infos an optional array of semaphore_submit_info_t, can be used to pass in signal/wait semaphores
      * @return  a fence that will be signaled when rendering is done.
@@ -136,11 +118,10 @@ public:
     /**
      * @brief   Begin a direct-rendering-pass using this Framebuffer.
      *
-     * @param   commandbuffer           a (primary) VkCommandBuffer handle to record into
-     * @param   clear_color_attachment  optional flag to set if color should be cleared prior to rendering.
-     * @param   clear_depth_attachment  optional flag to set if depth should be cleared prior to rendering.
+     * @param   commandbuffer   a (primary) VkCommandBuffer handle to record into
+     * @param   info            a begin_rendering_info_t struct
      */
-    void begin_rendering(const begin_rendering_info_t &info) const;
+    void begin_rendering(VkCommandBuffer commandbuffer, const begin_rendering_info_t &info) const;
 
     /**
      * @brief   End a direct-rendering-pass using this Framebuffer.
@@ -175,22 +156,12 @@ public:
     vierkant::ImagePtr depth_attachment() const;
 
     /**
-     * @return  handle for the managed VkFramebuffer
-     */
-    VkFramebuffer handle() const { return m_framebuffer; }
-
-    /**
-     * @return  handle for the (possibly shared) VkRenderPass
-     */
-    RenderPassPtr renderpass() const { return m_renderpass; }
-
-    /**
      * @return  true if this Framebuffer is initialized
      */
-    inline explicit operator bool() const { return m_framebuffer && m_renderpass; };
+    inline explicit operator bool() const { return !m_attachments.empty(); };
 
 
-    friend void swap(Framebuffer &lhs, Framebuffer &rhs);
+    friend void swap(Framebuffer &lhs, Framebuffer &rhs) noexcept;
 
     /**
      * @brief   the clear-value used for Color-Attachments
@@ -206,28 +177,13 @@ public:
     std::optional<vierkant::debug_label_t> debug_label;
 
 private:
-    void init(attachment_map_t attachments, RenderPassPtr renderpass);
-
-    /**
-     * @brief   Begin a render-pass using this Framebuffer
-     * @param   commandbuffer     the VkCommandBuffer handle to record into
-     * @param   subpass_contents
-     */
-    void begin_renderpass(VkCommandBuffer commandbuffer,
-                          VkSubpassContents subpass_contents = VK_SUBPASS_CONTENTS_INLINE) const;
-
-    /**
-     * @brief   End an currently active render-pass. Does nothing, if there is no active render-pass
-     */
-    void end_renderpass() const;
+    void init(attachment_map_t attachments);
 
     DevicePtr m_device;
 
     VkExtent3D m_extent = {};
 
     attachment_map_t m_attachments;
-
-    VkFramebuffer m_framebuffer = VK_NULL_HANDLE;
 
     vierkant::FencePtr m_fence;
 
@@ -236,8 +192,6 @@ private:
     vierkant::CommandBuffer m_commandbuffer;
 
     mutable VkCommandBuffer m_active_commandbuffer = VK_NULL_HANDLE, m_direct_rendering_commandbuffer = VK_NULL_HANDLE;
-
-    RenderPassPtr m_renderpass;
 
     Framebuffer::create_info_t m_format;
 };

--- a/include/vierkant/Framebuffer.hpp
+++ b/include/vierkant/Framebuffer.hpp
@@ -16,9 +16,9 @@ namespace vierkant
 /**
  * @brief   Enum to differentiate Image-Attachments
  */
-enum class AttachmentType
+enum class AttachmentType : uint32_t
 {
-    Color,
+    Color = 0,
     Resolve,
     DepthStencil
 };
@@ -38,6 +38,12 @@ public:
         VkRenderingFlags flags = 0;
     };
 
+    struct end_rendering_info_t
+    {
+        VkImageLayout final_layout_color = VK_IMAGE_LAYOUT_UNDEFINED;
+        VkImageLayout final_layout_depth = VK_IMAGE_LAYOUT_UNDEFINED;
+    };
+
     /**
      * @brief   Framebuffer::Format groups information necessary to create a set of Image-Attachments
      */
@@ -53,7 +59,8 @@ public:
         Image::Format depth_attachment_format;
         vierkant::CommandPoolPtr command_pool = nullptr;
         VkQueue queue = VK_NULL_HANDLE;
-        begin_rendering_info_t rendering_info = {};
+        begin_rendering_info_t begin_rendering_info = {};
+        end_rendering_info_t end_rendering_info = {};
         std::optional<vierkant::debug_label_t> debug_label;
     };
 
@@ -81,7 +88,7 @@ public:
      * @param   device          handle for the vierkant::Device to create the Framebuffer with
      * @param   attachments     a Framebuffer::AttachmentMap holding the desired Image-attachments
      */
-    Framebuffer(DevicePtr device, attachment_map_t attachments, const begin_rendering_info_t &begin_rendering_info);
+    Framebuffer(DevicePtr device, attachment_map_t attachments, const create_info_t &create_info);
 
     Framebuffer() = default;
 
@@ -126,7 +133,7 @@ public:
     /**
      * @brief   End a direct-rendering-pass using this Framebuffer.
      */
-    void end_rendering() const;
+    void end_rendering(const end_rendering_info_t &end_rendering_info) const;
 
     /**
      * @return  the VkExtent3D used by the Image-Attachments

--- a/include/vierkant/Framebuffer.hpp
+++ b/include/vierkant/Framebuffer.hpp
@@ -78,7 +78,6 @@ public:
      *          according to the requested Framebuffer::Format and a RenderPass to match those attachments.
      *
      * @param   device      handle for the vierkant::Device to create the Framebuffer with
-     * @param   size        the desired size for the Framebuffer in pixels
      * @param   create_info      an optional Framebuffer::Format object
      */
     Framebuffer(DevicePtr device, create_info_t create_info);

--- a/include/vierkant/GBuffer.hpp
+++ b/include/vierkant/GBuffer.hpp
@@ -33,8 +33,7 @@ enum GBuffer : uint32_t
  * @return  a vierkant::Framebuffer representing a g-buffer
  */
 vierkant::Framebuffer create_g_buffer(const DevicePtr &device,
-                                      const VkExtent3D &extent,
-                                      const vierkant::RenderPassPtr &renderpass = nullptr);
+                                      const VkExtent3D &extent);
 
 enum GBufferPropertyFlagBits : uint32_t
 {

--- a/include/vierkant/SwapChain.hpp
+++ b/include/vierkant/SwapChain.hpp
@@ -73,11 +73,6 @@ public:
     [[nodiscard]] DevicePtr device() const { return m_device; }
 
     /**
-     * @return  handle for the shared VkRenderPass, used by all contained Framebuffers
-     */
-    [[nodiscard]] VkRenderPass renderpass() const;
-
-    /**
      * @return  a reference for the contained array of Framebuffers
      */
     std::vector<vierkant::Framebuffer> &framebuffers() { return m_framebuffers; }
@@ -122,7 +117,7 @@ public:
      */
     [[nodiscard]] uint32_t image_index() const { return m_swapchain_image_index; }
 
-    friend void swap(SwapChain &lhs, SwapChain &rhs);
+    friend void swap(SwapChain &lhs, SwapChain &rhs) noexcept;
 
     inline explicit operator bool() const { return static_cast<bool>(m_swap_chain); };
 

--- a/include/vierkant/pipeline_formats.hpp
+++ b/include/vierkant/pipeline_formats.hpp
@@ -211,7 +211,7 @@ struct graphics_pipeline_info_t
     // optional attachment-specific blendStates (will override global state if present)
     std::vector<VkPipelineColorBlendAttachmentState> attachment_blend_states;
 
-    VkRenderPass renderpass = VK_NULL_HANDLE;
+    // VkRenderPass renderpass = VK_NULL_HANDLE;
 
     // direct rendering
     uint32_t view_mask = 0;

--- a/src/Bloom.cpp
+++ b/src/Bloom.cpp
@@ -88,9 +88,7 @@ vierkant::ImagePtr Bloom::apply(const ImagePtr &image, VkCommandBuffer commandbu
     vierkant::begin_label(commandbuffer, {"Bloom::apply"});
 
     // threshold
-    vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-    begin_rendering_info.commandbuffer = commandbuffer;
-    m_thresh_framebuffer.begin_rendering(begin_rendering_info);
+    m_thresh_framebuffer.begin_rendering(commandbuffer, {});
 
     vierkant::Rasterizer::rendering_info_t rendering_info = {};
     rendering_info.command_buffer = commandbuffer;

--- a/src/CommandBuffer.cpp
+++ b/src/CommandBuffer.cpp
@@ -213,10 +213,7 @@ void CommandBuffer::begin(VkCommandBufferUsageFlags flags, VkCommandBufferInheri
 {
     if(m_handle)
     {
-        if(inheritance)
-        {
-            flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
-        }
+        if(inheritance) { flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT; }
         VkCommandBufferBeginInfo begin_info = {};
         begin_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_BEGIN_INFO;
         begin_info.flags = flags;

--- a/src/CommandBuffer.cpp
+++ b/src/CommandBuffer.cpp
@@ -213,7 +213,7 @@ void CommandBuffer::begin(VkCommandBufferUsageFlags flags, VkCommandBufferInheri
 {
     if(m_handle)
     {
-        if(inheritance && inheritance->renderPass && inheritance->framebuffer)
+        if(inheritance)
         {
             flags |= VK_COMMAND_BUFFER_USAGE_RENDER_PASS_CONTINUE_BIT;
         }

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -191,18 +191,16 @@ Framebuffer::Framebuffer(DevicePtr device, create_info_t create_info)
     }
 
     init(create_attachments(m_device, m_format));
-    m_format.rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
+    m_format.begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 Framebuffer::Framebuffer(DevicePtr device, attachment_map_t attachments,
-                         const begin_rendering_info_t &begin_rendering_info)
-    : m_device(std::move(device))
+                         const create_info_t &create_info)
+    : m_device(std::move(device)), m_format(create_info)
 {
     init(std::move(attachments));
-    m_format.rendering_info = begin_rendering_info;
-    m_format.rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -226,7 +224,7 @@ VkCommandBuffer Framebuffer::record_commandbuffer(const std::vector<VkCommandBuf
     if(debug_label) { vierkant::begin_label(m_commandbuffer.handle(), *debug_label); }
 
     // begin rendering
-    begin_rendering(m_commandbuffer.handle(), m_format.rendering_info);
+    begin_rendering(m_commandbuffer.handle(), m_format.begin_rendering_info);
 
     // execute secondary commandbuffers
     if(!commandbuffers.empty())
@@ -234,8 +232,8 @@ VkCommandBuffer Framebuffer::record_commandbuffer(const std::vector<VkCommandBuf
         vkCmdExecuteCommands(m_commandbuffer.handle(), commandbuffers.size(), commandbuffers.data());
     }
 
-    // end dynamic rendering
-    end_rendering();
+    // TODO: pass layout-info here, end dynamic rendering
+    end_rendering(m_format.end_rendering_info);
 
     // end commandbuffer
     if(debug_label) { vierkant::end_label(m_commandbuffer.handle()); }
@@ -327,6 +325,8 @@ void Framebuffer::init(attachment_map_t attachments)
         }
     }
     m_format.color_attachment_format.num_layers = num_layers;
+
+    m_format.begin_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
 
     // now move attachments
     m_attachments = std::move(attachments);
@@ -514,11 +514,28 @@ void Framebuffer::begin_rendering(VkCommandBuffer commandbuffer, const begin_ren
     m_direct_rendering_commandbuffer = commandbuffer;
 }
 
-void Framebuffer::end_rendering() const
+void Framebuffer::end_rendering(const end_rendering_info_t &end_rendering_info) const
 {
     if(m_direct_rendering_commandbuffer)
     {
         vkCmdEndRendering(m_direct_rendering_commandbuffer);
+
+        for(auto &[type, images]: m_attachments)
+        {
+            for(auto &img: images)
+            {
+                if(type == AttachmentType::Color && end_rendering_info.final_layout_color != VK_IMAGE_LAYOUT_UNDEFINED)
+                {
+                    img->transition_layout(end_rendering_info.final_layout_color, m_direct_rendering_commandbuffer);
+                }
+                else if(type == AttachmentType::DepthStencil &&
+                        end_rendering_info.final_layout_depth != VK_IMAGE_LAYOUT_UNDEFINED)
+                {
+                    img->transition_layout(end_rendering_info.final_layout_depth, m_direct_rendering_commandbuffer);
+                }
+            }
+        }
+
         m_direct_rendering_commandbuffer = VK_NULL_HANDLE;
     }
 }

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -31,130 +31,6 @@ inline bool check_attachment(AttachmentType attachment, const attachment_map_t &
                        [attachment](const auto &it) { return it.first == attachment && !it.second.empty(); });
 }
 
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-//
-// RenderPassPtr create_renderpass(const vierkant::DevicePtr &device, const attachment_map_t &attachments,
-//                                 bool clear_color, bool clear_depth,
-//                                 const std::vector<VkSubpassDependency2> &subpass_dependencies)
-// {
-//     VkRenderPass renderpass = VK_NULL_HANDLE;
-//
-//     bool has_depth_stencil = check_attachment(AttachmentType::DepthStencil, attachments);
-//     bool has_resolve = check_attachment(AttachmentType::Resolve, attachments);
-//
-//     // create RenderPass according to AttachmentMap
-//     std::vector<VkAttachmentDescription2> attachment_descriptions;
-//
-//     for(const auto &[type, images]: attachments)
-//     {
-//         VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-//         VkAttachmentStoreOp storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-//         VkAttachmentLoadOp stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-//         VkAttachmentStoreOp stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-//
-//         switch(type)
-//         {
-//             case AttachmentType::Color:
-//                 loadOp = clear_color ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
-//                 storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-//                 break;
-//
-//             case AttachmentType::Resolve:
-//                 loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-//                 storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-//                 break;
-//
-//             case AttachmentType::DepthStencil:
-//                 loadOp = clear_depth ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
-//                 storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-//
-//                 if(has_depth_stencil)
-//                 {
-//                     stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-//                     stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-//                 }
-//                 break;
-//
-//             default: break;
-//         }
-//
-//         for(const auto &img: images)
-//         {
-//             VkAttachmentDescription2 description = {};
-//             description.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
-//             description.format = img->format().format;
-//             description.samples = img->format().sample_count;
-//             description.loadOp = loadOp;
-//             description.storeOp = storeOp;
-//             description.stencilLoadOp = stencilLoadOp;
-//             description.stencilStoreOp = stencilStoreOp;
-//             description.initialLayout = img->image_layout();//VK_IMAGE_LAYOUT_UNDEFINED;
-//             description.finalLayout = img->image_layout();
-//             attachment_descriptions.push_back(description);
-//         }
-//     }
-//
-//     uint32_t attachment_index = 0, num_color_images = 0;
-//     std::vector<VkAttachmentReference2> color_refs, depth_stencil_refs, resolve_refs;
-//
-//     auto color_it = attachments.find(AttachmentType::Color);
-//
-//     if(color_it != attachments.end()) { num_color_images = static_cast<uint32_t>(color_it->second.size()); }
-//
-//     for(uint32_t i = 0; i < num_color_images; ++i)
-//     {
-//         VkAttachmentReference2 color_attachment_ref = {};
-//         color_attachment_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-//         color_attachment_ref.attachment = i;
-//         color_attachment_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-//         color_attachment_ref.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-//         color_refs.push_back(color_attachment_ref);
-//         attachment_index++;
-//
-//         if(has_resolve)
-//         {
-//             VkAttachmentReference2 color_attachment_resolve_ref = {};
-//             color_attachment_resolve_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-//             color_attachment_resolve_ref.attachment = i + num_color_images;
-//             color_attachment_resolve_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-//             color_attachment_resolve_ref.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-//             resolve_refs.push_back(color_attachment_resolve_ref);
-//             attachment_index++;
-//         }
-//     }
-//     if(has_depth_stencil)
-//     {
-//         VkAttachmentReference2 depth_attachment_ref = {};
-//         depth_attachment_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-//         depth_attachment_ref.attachment = attachment_index;
-//         depth_attachment_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-//         depth_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-//         depth_stencil_refs = {depth_attachment_ref};
-//     }
-//
-//     VkSubpassDescription2 subpass = {};
-//     subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
-//     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-//     subpass.colorAttachmentCount = static_cast<uint32_t>(color_refs.size());
-//     subpass.pColorAttachments = color_refs.data();
-//     subpass.pDepthStencilAttachment = depth_stencil_refs.empty() ? nullptr : depth_stencil_refs.data();
-//     subpass.pResolveAttachments = resolve_refs.empty() ? nullptr : resolve_refs.data();
-//
-//     VkRenderPassCreateInfo2 render_pass_info = {};
-//     render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
-//     render_pass_info.attachmentCount = static_cast<uint32_t>(attachment_descriptions.size());
-//     render_pass_info.pAttachments = attachment_descriptions.data();
-//     render_pass_info.subpassCount = 1;
-//     render_pass_info.pSubpasses = &subpass;
-//     render_pass_info.dependencyCount = static_cast<uint32_t>(subpass_dependencies.size());
-//     render_pass_info.pDependencies = subpass_dependencies.data();
-//
-//     vkCheck(vkCreateRenderPass2(device->handle(), &render_pass_info, nullptr, &renderpass),
-//             "failed to create render pass!");
-//
-//     return {renderpass, [device](VkRenderPass p) { vkDestroyRenderPass(device->handle(), p, nullptr); }};
-// }
-
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 Framebuffer::Framebuffer(DevicePtr device, create_info_t create_info)
@@ -196,12 +72,9 @@ Framebuffer::Framebuffer(DevicePtr device, create_info_t create_info)
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-Framebuffer::Framebuffer(DevicePtr device, attachment_map_t attachments,
-                         const create_info_t &create_info)
+Framebuffer::Framebuffer(DevicePtr device, attachment_map_t attachments, const create_info_t &create_info)
     : m_device(std::move(device)), m_format(create_info)
-{
-    init(std::move(attachments));
-}
+{ init(std::move(attachments)); }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -232,7 +105,7 @@ VkCommandBuffer Framebuffer::record_commandbuffer(const std::vector<VkCommandBuf
         vkCmdExecuteCommands(m_commandbuffer.handle(), commandbuffers.size(), commandbuffers.data());
     }
 
-    // TODO: pass layout-info here, end dynamic rendering
+    // passing optional final layout-info here, end dynamic rendering
     end_rendering(m_format.end_rendering_info);
 
     // end commandbuffer

--- a/src/Framebuffer.cpp
+++ b/src/Framebuffer.cpp
@@ -1,5 +1,7 @@
 #include "vierkant/Framebuffer.hpp"
 
+#include "bc7enc/rgbcx.h"
+
 namespace vierkant
 {
 
@@ -30,128 +32,128 @@ inline bool check_attachment(AttachmentType attachment, const attachment_map_t &
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-RenderPassPtr create_renderpass(const vierkant::DevicePtr &device, const attachment_map_t &attachments,
-                                bool clear_color, bool clear_depth,
-                                const std::vector<VkSubpassDependency2> &subpass_dependencies)
-{
-    VkRenderPass renderpass = VK_NULL_HANDLE;
-
-    bool has_depth_stencil = check_attachment(AttachmentType::DepthStencil, attachments);
-    bool has_resolve = check_attachment(AttachmentType::Resolve, attachments);
-
-    // create RenderPass according to AttachmentMap
-    std::vector<VkAttachmentDescription2> attachment_descriptions;
-
-    for(const auto &[type, images]: attachments)
-    {
-        VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        VkAttachmentStoreOp storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-        VkAttachmentLoadOp stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-        VkAttachmentStoreOp stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
-
-        switch(type)
-        {
-            case AttachmentType::Color:
-                loadOp = clear_color ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
-                storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-                break;
-
-            case AttachmentType::Resolve:
-                loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
-                storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-                break;
-
-            case AttachmentType::DepthStencil:
-                loadOp = clear_depth ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
-                storeOp = VK_ATTACHMENT_STORE_OP_STORE;
-
-                if(has_depth_stencil)
-                {
-                    stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
-                    stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
-                }
-                break;
-
-            default: break;
-        }
-
-        for(const auto &img: images)
-        {
-            VkAttachmentDescription2 description = {};
-            description.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
-            description.format = img->format().format;
-            description.samples = img->format().sample_count;
-            description.loadOp = loadOp;
-            description.storeOp = storeOp;
-            description.stencilLoadOp = stencilLoadOp;
-            description.stencilStoreOp = stencilStoreOp;
-            description.initialLayout = img->image_layout();//VK_IMAGE_LAYOUT_UNDEFINED;
-            description.finalLayout = img->image_layout();
-            attachment_descriptions.push_back(description);
-        }
-    }
-
-    uint32_t attachment_index = 0, num_color_images = 0;
-    std::vector<VkAttachmentReference2> color_refs, depth_stencil_refs, resolve_refs;
-
-    auto color_it = attachments.find(AttachmentType::Color);
-
-    if(color_it != attachments.end()) { num_color_images = static_cast<uint32_t>(color_it->second.size()); }
-
-    for(uint32_t i = 0; i < num_color_images; ++i)
-    {
-        VkAttachmentReference2 color_attachment_ref = {};
-        color_attachment_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-        color_attachment_ref.attachment = i;
-        color_attachment_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-        color_attachment_ref.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-        color_refs.push_back(color_attachment_ref);
-        attachment_index++;
-
-        if(has_resolve)
-        {
-            VkAttachmentReference2 color_attachment_resolve_ref = {};
-            color_attachment_resolve_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-            color_attachment_resolve_ref.attachment = i + num_color_images;
-            color_attachment_resolve_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-            color_attachment_resolve_ref.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
-            resolve_refs.push_back(color_attachment_resolve_ref);
-            attachment_index++;
-        }
-    }
-    if(has_depth_stencil)
-    {
-        VkAttachmentReference2 depth_attachment_ref = {};
-        depth_attachment_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
-        depth_attachment_ref.attachment = attachment_index;
-        depth_attachment_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
-        depth_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
-        depth_stencil_refs = {depth_attachment_ref};
-    }
-
-    VkSubpassDescription2 subpass = {};
-    subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
-    subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
-    subpass.colorAttachmentCount = static_cast<uint32_t>(color_refs.size());
-    subpass.pColorAttachments = color_refs.data();
-    subpass.pDepthStencilAttachment = depth_stencil_refs.empty() ? nullptr : depth_stencil_refs.data();
-    subpass.pResolveAttachments = resolve_refs.empty() ? nullptr : resolve_refs.data();
-
-    VkRenderPassCreateInfo2 render_pass_info = {};
-    render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
-    render_pass_info.attachmentCount = static_cast<uint32_t>(attachment_descriptions.size());
-    render_pass_info.pAttachments = attachment_descriptions.data();
-    render_pass_info.subpassCount = 1;
-    render_pass_info.pSubpasses = &subpass;
-    render_pass_info.dependencyCount = static_cast<uint32_t>(subpass_dependencies.size());
-    render_pass_info.pDependencies = subpass_dependencies.data();
-
-    vkCheck(vkCreateRenderPass2(device->handle(), &render_pass_info, nullptr, &renderpass),
-            "failed to create render pass!");
-
-    return {renderpass, [device](VkRenderPass p) { vkDestroyRenderPass(device->handle(), p, nullptr); }};
-}
+//
+// RenderPassPtr create_renderpass(const vierkant::DevicePtr &device, const attachment_map_t &attachments,
+//                                 bool clear_color, bool clear_depth,
+//                                 const std::vector<VkSubpassDependency2> &subpass_dependencies)
+// {
+//     VkRenderPass renderpass = VK_NULL_HANDLE;
+//
+//     bool has_depth_stencil = check_attachment(AttachmentType::DepthStencil, attachments);
+//     bool has_resolve = check_attachment(AttachmentType::Resolve, attachments);
+//
+//     // create RenderPass according to AttachmentMap
+//     std::vector<VkAttachmentDescription2> attachment_descriptions;
+//
+//     for(const auto &[type, images]: attachments)
+//     {
+//         VkAttachmentLoadOp loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+//         VkAttachmentStoreOp storeOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+//         VkAttachmentLoadOp stencilLoadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+//         VkAttachmentStoreOp stencilStoreOp = VK_ATTACHMENT_STORE_OP_DONT_CARE;
+//
+//         switch(type)
+//         {
+//             case AttachmentType::Color:
+//                 loadOp = clear_color ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
+//                 storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+//                 break;
+//
+//             case AttachmentType::Resolve:
+//                 loadOp = VK_ATTACHMENT_LOAD_OP_DONT_CARE;
+//                 storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+//                 break;
+//
+//             case AttachmentType::DepthStencil:
+//                 loadOp = clear_depth ? VK_ATTACHMENT_LOAD_OP_CLEAR : VK_ATTACHMENT_LOAD_OP_LOAD;
+//                 storeOp = VK_ATTACHMENT_STORE_OP_STORE;
+//
+//                 if(has_depth_stencil)
+//                 {
+//                     stencilLoadOp = VK_ATTACHMENT_LOAD_OP_CLEAR;
+//                     stencilStoreOp = VK_ATTACHMENT_STORE_OP_STORE;
+//                 }
+//                 break;
+//
+//             default: break;
+//         }
+//
+//         for(const auto &img: images)
+//         {
+//             VkAttachmentDescription2 description = {};
+//             description.sType = VK_STRUCTURE_TYPE_ATTACHMENT_DESCRIPTION_2;
+//             description.format = img->format().format;
+//             description.samples = img->format().sample_count;
+//             description.loadOp = loadOp;
+//             description.storeOp = storeOp;
+//             description.stencilLoadOp = stencilLoadOp;
+//             description.stencilStoreOp = stencilStoreOp;
+//             description.initialLayout = img->image_layout();//VK_IMAGE_LAYOUT_UNDEFINED;
+//             description.finalLayout = img->image_layout();
+//             attachment_descriptions.push_back(description);
+//         }
+//     }
+//
+//     uint32_t attachment_index = 0, num_color_images = 0;
+//     std::vector<VkAttachmentReference2> color_refs, depth_stencil_refs, resolve_refs;
+//
+//     auto color_it = attachments.find(AttachmentType::Color);
+//
+//     if(color_it != attachments.end()) { num_color_images = static_cast<uint32_t>(color_it->second.size()); }
+//
+//     for(uint32_t i = 0; i < num_color_images; ++i)
+//     {
+//         VkAttachmentReference2 color_attachment_ref = {};
+//         color_attachment_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+//         color_attachment_ref.attachment = i;
+//         color_attachment_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+//         color_attachment_ref.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+//         color_refs.push_back(color_attachment_ref);
+//         attachment_index++;
+//
+//         if(has_resolve)
+//         {
+//             VkAttachmentReference2 color_attachment_resolve_ref = {};
+//             color_attachment_resolve_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+//             color_attachment_resolve_ref.attachment = i + num_color_images;
+//             color_attachment_resolve_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+//             color_attachment_resolve_ref.aspectMask = VK_IMAGE_ASPECT_COLOR_BIT;
+//             resolve_refs.push_back(color_attachment_resolve_ref);
+//             attachment_index++;
+//         }
+//     }
+//     if(has_depth_stencil)
+//     {
+//         VkAttachmentReference2 depth_attachment_ref = {};
+//         depth_attachment_ref.sType = VK_STRUCTURE_TYPE_ATTACHMENT_REFERENCE_2;
+//         depth_attachment_ref.attachment = attachment_index;
+//         depth_attachment_ref.layout = VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL;
+//         depth_attachment_ref.aspectMask = VK_IMAGE_ASPECT_DEPTH_BIT;
+//         depth_stencil_refs = {depth_attachment_ref};
+//     }
+//
+//     VkSubpassDescription2 subpass = {};
+//     subpass.sType = VK_STRUCTURE_TYPE_SUBPASS_DESCRIPTION_2;
+//     subpass.pipelineBindPoint = VK_PIPELINE_BIND_POINT_GRAPHICS;
+//     subpass.colorAttachmentCount = static_cast<uint32_t>(color_refs.size());
+//     subpass.pColorAttachments = color_refs.data();
+//     subpass.pDepthStencilAttachment = depth_stencil_refs.empty() ? nullptr : depth_stencil_refs.data();
+//     subpass.pResolveAttachments = resolve_refs.empty() ? nullptr : resolve_refs.data();
+//
+//     VkRenderPassCreateInfo2 render_pass_info = {};
+//     render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_CREATE_INFO_2;
+//     render_pass_info.attachmentCount = static_cast<uint32_t>(attachment_descriptions.size());
+//     render_pass_info.pAttachments = attachment_descriptions.data();
+//     render_pass_info.subpassCount = 1;
+//     render_pass_info.pSubpasses = &subpass;
+//     render_pass_info.dependencyCount = static_cast<uint32_t>(subpass_dependencies.size());
+//     render_pass_info.pDependencies = subpass_dependencies.data();
+//
+//     vkCheck(vkCreateRenderPass2(device->handle(), &render_pass_info, nullptr, &renderpass),
+//             "failed to create render pass!");
+//
+//     return {renderpass, [device](VkRenderPass p) { vkDestroyRenderPass(device->handle(), p, nullptr); }};
+// }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -188,15 +190,19 @@ Framebuffer::Framebuffer(DevicePtr device, create_info_t create_info)
         }
     }
 
-    init(create_attachments(m_device, m_format), m_format.renderpass);
+    init(create_attachments(m_device, m_format));
+    m_format.rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-Framebuffer::Framebuffer(DevicePtr device, attachment_map_t attachments, RenderPassPtr renderpass)
+Framebuffer::Framebuffer(DevicePtr device, attachment_map_t attachments,
+                         const begin_rendering_info_t &begin_rendering_info)
     : m_device(std::move(device))
 {
-    init(std::move(attachments), std::move(renderpass));
+    init(std::move(attachments));
+    m_format.rendering_info = begin_rendering_info;
+    m_format.rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
 }
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
@@ -205,82 +211,10 @@ Framebuffer::Framebuffer(Framebuffer &&other) noexcept : Framebuffer() { swap(*t
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-Framebuffer::~Framebuffer()
-{
-    if(m_device)
-    {
-        m_extent = {};
-        clear_color = {};
-        m_attachments.clear();
-
-        if(m_framebuffer)
-        {
-            vkDestroyFramebuffer(m_device->handle(), m_framebuffer, nullptr);
-            m_framebuffer = VK_NULL_HANDLE;
-        }
-        m_renderpass.reset();
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
 Framebuffer &Framebuffer::operator=(Framebuffer other)
 {
     swap(*this, other);
     return *this;
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-void Framebuffer::begin_renderpass(VkCommandBuffer commandbuffer, VkSubpassContents subpass_contents) const
-{
-    if(*this && !m_active_commandbuffer)
-    {
-        VkRenderPassBeginInfo render_pass_info = {};
-        render_pass_info.sType = VK_STRUCTURE_TYPE_RENDER_PASS_BEGIN_INFO;
-        render_pass_info.renderPass = m_renderpass.get();
-        render_pass_info.framebuffer = m_framebuffer;
-        render_pass_info.renderArea.offset = {0, 0};
-        render_pass_info.renderArea.extent = {m_extent.width, m_extent.height};
-
-        // clear values
-        std::vector<VkClearValue> clear_values;
-
-        for(const auto &[type, images]: m_attachments)
-        {
-            for(uint32_t i = 0; i < images.size(); ++i)
-            {
-                VkClearValue v = {};
-
-                switch(type)
-                {
-                    case AttachmentType::Color:
-                        v.color = {{clear_color.x, clear_color.y, clear_color.z, clear_color.w}};
-                        break;
-                    case AttachmentType::DepthStencil: v.depthStencil = clear_depth_stencil; break;
-
-                    default: break;
-                }
-                clear_values.push_back(v);
-            }
-        }
-        render_pass_info.clearValueCount = static_cast<uint32_t>(clear_values.size());
-        render_pass_info.pClearValues = clear_values.data();
-
-        vkCmdBeginRenderPass(commandbuffer, &render_pass_info, subpass_contents);
-        m_active_commandbuffer = commandbuffer;
-    }
-}
-
-///////////////////////////////////////////////////////////////////////////////////////////////////
-
-void Framebuffer::end_renderpass() const
-{
-    if(*this && m_active_commandbuffer)
-    {
-        vkCmdEndRenderPass(m_active_commandbuffer);
-        m_active_commandbuffer = VK_NULL_HANDLE;
-    }
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////
@@ -291,8 +225,8 @@ VkCommandBuffer Framebuffer::record_commandbuffer(const std::vector<VkCommandBuf
     m_commandbuffer.begin(0);//VK_COMMAND_BUFFER_USAGE_SIMULTANEOUS_USE_BIT
     if(debug_label) { vierkant::begin_label(m_commandbuffer.handle(), *debug_label); }
 
-    // begin the renderpass
-    begin_renderpass(m_commandbuffer.handle(), VK_SUBPASS_CONTENTS_SECONDARY_COMMAND_BUFFERS);
+    // begin rendering
+    begin_rendering(m_commandbuffer.handle(), m_format.rendering_info);
 
     // execute secondary commandbuffers
     if(!commandbuffers.empty())
@@ -300,8 +234,8 @@ VkCommandBuffer Framebuffer::record_commandbuffer(const std::vector<VkCommandBuf
         vkCmdExecuteCommands(m_commandbuffer.handle(), commandbuffers.size(), commandbuffers.data());
     }
 
-    // end renderpass
-    end_renderpass();
+    // end dynamic rendering
+    end_rendering();
 
     // end commandbuffer
     if(debug_label) { vierkant::end_label(m_commandbuffer.handle()); }
@@ -349,7 +283,7 @@ size_t Framebuffer::num_attachments(vierkant::AttachmentType type) const
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-void Framebuffer::init(attachment_map_t attachments, RenderPassPtr renderpass)
+void Framebuffer::init(attachment_map_t attachments)
 {
     auto command_pool =
             m_command_pool ? m_command_pool
@@ -359,9 +293,6 @@ void Framebuffer::init(attachment_map_t attachments, RenderPassPtr renderpass)
     m_commandbuffer = vierkant::CommandBuffer(m_device, command_pool.get());
     m_command_pool = command_pool;
     m_fence = vierkant::create_fence(m_device, true);
-
-    if(!renderpass) { renderpass = create_renderpass(m_device, attachments, true, true); }
-    m_renderpass = renderpass;
 
     VkExtent3D extent = {0, 0, 0};
 
@@ -396,19 +327,6 @@ void Framebuffer::init(attachment_map_t attachments, RenderPassPtr renderpass)
         }
     }
     m_format.color_attachment_format.num_layers = num_layers;
-
-    // create vkFramebuffer using the existing VkRenderpass
-    VkFramebufferCreateInfo framebuffer_info = {};
-    framebuffer_info.sType = VK_STRUCTURE_TYPE_FRAMEBUFFER_CREATE_INFO;
-    framebuffer_info.renderPass = m_renderpass.get();
-    framebuffer_info.attachmentCount = static_cast<uint32_t>(attachment_views.size());
-    framebuffer_info.pAttachments = attachment_views.data();
-    framebuffer_info.width = extent.width;
-    framebuffer_info.height = extent.height;
-    framebuffer_info.layers = m_format.color_attachment_format.num_layers;
-
-    vkCheck(vkCreateFramebuffer(m_device->handle(), &framebuffer_info, nullptr, &m_framebuffer),
-            "failed to create framebuffer!");
 
     // now move attachments
     m_attachments = std::move(attachments);
@@ -509,23 +427,21 @@ vierkant::ImagePtr Framebuffer::depth_attachment() const
 
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
-void swap(Framebuffer &lhs, Framebuffer &rhs)
+void swap(Framebuffer &lhs, Framebuffer &rhs) noexcept
 {
     std::swap(lhs.clear_depth_stencil, rhs.clear_depth_stencil);
     std::swap(lhs.clear_color, rhs.clear_color);
     std::swap(lhs.m_device, rhs.m_device);
     std::swap(lhs.m_extent, rhs.m_extent);
     std::swap(lhs.m_attachments, rhs.m_attachments);
-    std::swap(lhs.m_framebuffer, rhs.m_framebuffer);
     std::swap(lhs.m_fence, rhs.m_fence);
     std::swap(lhs.m_command_pool, rhs.m_command_pool);
     std::swap(lhs.m_commandbuffer, rhs.m_commandbuffer);
     std::swap(lhs.m_active_commandbuffer, rhs.m_active_commandbuffer);
-    std::swap(lhs.m_renderpass, rhs.m_renderpass);
     std::swap(lhs.m_format, rhs.m_format);
 }
 
-void Framebuffer::begin_rendering(const begin_rendering_info_t &info) const
+void Framebuffer::begin_rendering(VkCommandBuffer commandbuffer, const begin_rendering_info_t &info) const
 {
     std::vector<VkRenderingAttachmentInfo> color_attachments;
     std::vector<VkRenderingAttachmentInfo> depth_attachments;
@@ -540,7 +456,7 @@ void Framebuffer::begin_rendering(const begin_rendering_info_t &info) const
         for(uint32_t i = 0; i < images.size(); ++i)
         {
             const auto &img = images[i];
-            img->transition_layout(VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, info.commandbuffer);
+            img->transition_layout(VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, commandbuffer);
 
             if(type == AttachmentType::DepthStencil && use_depth_attachment)
             {
@@ -583,6 +499,7 @@ void Framebuffer::begin_rendering(const begin_rendering_info_t &info) const
 
     VkRenderingInfo pass_info = {};
     pass_info.sType = VK_STRUCTURE_TYPE_RENDERING_INFO;
+    pass_info.flags = info.flags;
     pass_info.viewMask = 0;
     pass_info.renderArea.offset = {0, 0};
     pass_info.renderArea.extent = {m_extent.width, m_extent.height};
@@ -593,8 +510,8 @@ void Framebuffer::begin_rendering(const begin_rendering_info_t &info) const
 
     // TODO: check actual VK_FORMAT and figure our if stencil is required
     //    pass_info.pStencilAttachment = depth_attachments.empty() ? nullptr : depth_attachments.data();
-    vkCmdBeginRendering(info.commandbuffer, &pass_info);
-    m_direct_rendering_commandbuffer = info.commandbuffer;
+    vkCmdBeginRendering(commandbuffer, &pass_info);
+    m_direct_rendering_commandbuffer = commandbuffer;
 }
 
 void Framebuffer::end_rendering() const

--- a/src/GBuffer.cpp
+++ b/src/GBuffer.cpp
@@ -9,8 +9,7 @@
 
 namespace vierkant
 {
-vierkant::Framebuffer create_g_buffer(const vierkant::DevicePtr &device, const VkExtent3D &extent,
-                                      const vierkant::RenderPassPtr &renderpass)
+vierkant::Framebuffer create_g_buffer(const vierkant::DevicePtr &device, const VkExtent3D &extent)
 {
     std::vector<vierkant::ImagePtr> g_buffer_attachments(G_BUFFER_SIZE);
 
@@ -75,7 +74,7 @@ vierkant::Framebuffer create_g_buffer(const vierkant::DevicePtr &device, const V
     depth_attachment_format.name = "depth";
     attachments[AttachmentType::DepthStencil] = {vierkant::Image::create(device, depth_attachment_format)};
 
-    auto ret = vierkant::Framebuffer(device, attachments, renderpass);
+    auto ret = vierkant::Framebuffer(device, attachments, {});
     ret.clear_color = glm::vec4{0.f};
     return ret;
 }

--- a/src/GaussianBlur.cpp
+++ b/src/GaussianBlur.cpp
@@ -49,10 +49,10 @@ GaussianBlur_<NUM_TAPS>::GaussianBlur_(const DevicePtr &device, const create_inf
     fb_attachments_ping[vierkant::AttachmentType::Color] = {vierkant::Image::create(device, img_fmt)};
     fb_attachments_pong[vierkant::AttachmentType::Color] = {vierkant::Image::create(device, img_fmt)};
 
-    vierkant::Framebuffer::begin_rendering_info_t rendering_info = {.clear_color_attachment = true,
-                                                                    .clear_depth_attachment = false};
-    m_ping_pongs[0].framebuffer = vierkant::Framebuffer(device, fb_attachments_ping, rendering_info);
-    m_ping_pongs[1].framebuffer = vierkant::Framebuffer(device, fb_attachments_pong, rendering_info);
+    vierkant::Framebuffer::create_info_t fb_create_info = {};
+    fb_create_info.begin_rendering_info = {.clear_color_attachment = true, .clear_depth_attachment = false};
+    m_ping_pongs[0].framebuffer = vierkant::Framebuffer(device, fb_attachments_ping, fb_create_info);
+    m_ping_pongs[1].framebuffer = vierkant::Framebuffer(device, fb_attachments_pong, fb_create_info);
 
     m_command_buffer = vierkant::CommandBuffer(device, command_pool.get());
 

--- a/src/GaussianBlur.cpp
+++ b/src/GaussianBlur.cpp
@@ -49,11 +49,10 @@ GaussianBlur_<NUM_TAPS>::GaussianBlur_(const DevicePtr &device, const create_inf
     fb_attachments_ping[vierkant::AttachmentType::Color] = {vierkant::Image::create(device, img_fmt)};
     fb_attachments_pong[vierkant::AttachmentType::Color] = {vierkant::Image::create(device, img_fmt)};
 
-    vierkant::RenderPassPtr renderpass;
-    renderpass = vierkant::create_renderpass(device, fb_attachments_ping, true, false);
-
-    m_ping_pongs[0].framebuffer = vierkant::Framebuffer(device, fb_attachments_ping, renderpass);
-    m_ping_pongs[1].framebuffer = vierkant::Framebuffer(device, fb_attachments_pong, renderpass);
+    vierkant::Framebuffer::begin_rendering_info_t rendering_info = {.clear_color_attachment = true,
+                                                                    .clear_depth_attachment = false};
+    m_ping_pongs[0].framebuffer = vierkant::Framebuffer(device, fb_attachments_ping, rendering_info);
+    m_ping_pongs[1].framebuffer = vierkant::Framebuffer(device, fb_attachments_pong, rendering_info);
 
     m_command_buffer = vierkant::CommandBuffer(device, command_pool.get());
 
@@ -182,9 +181,6 @@ vierkant::ImagePtr GaussianBlur_<NUM_TAPS>::apply(const ImagePtr &image, VkComma
     // debug label
     vierkant::begin_label(commandbuffer, {std::format("GaussianBlur_<{}>::apply>", NUM_TAPS)});
 
-    vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-    begin_rendering_info.commandbuffer = commandbuffer;
-
     for(uint32_t i = 0; i < m_num_iterations; ++i)
     {
         ping.drawable.descriptors[0].images = {current_img};
@@ -198,7 +194,7 @@ vierkant::ImagePtr GaussianBlur_<NUM_TAPS>::apply(const ImagePtr &image, VkComma
         m_renderer.stage_drawable(ping.drawable);
         current_img->transition_layout(VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL, commandbuffer);
         ping.framebuffer.color_attachment()->transition_layout(VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, commandbuffer);
-        ping.framebuffer.begin_rendering(begin_rendering_info);
+        ping.framebuffer.begin_rendering(commandbuffer, {});
         m_renderer.render(rendering_info);
         vkCmdEndRendering(commandbuffer);
 
@@ -206,7 +202,7 @@ vierkant::ImagePtr GaussianBlur_<NUM_TAPS>::apply(const ImagePtr &image, VkComma
         m_renderer.stage_drawable(pong.drawable);
         ping.framebuffer.color_attachment()->transition_layout(VK_IMAGE_LAYOUT_READ_ONLY_OPTIMAL, commandbuffer);
         pong.framebuffer.color_attachment()->transition_layout(VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, commandbuffer);
-        pong.framebuffer.begin_rendering(begin_rendering_info);
+        pong.framebuffer.begin_rendering(commandbuffer, {});
         m_renderer.render(rendering_info);
         vkCmdEndRendering(commandbuffer);
         current_img = pong.framebuffer.color_attachment();

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -1314,10 +1314,10 @@ void vierkant::PBRDeferred::resize_storage(vierkant::PBRDeferred::frame_context_
         frame_context.g_buffer_main = create_g_buffer(m_device, size);
         frame_context.g_buffer_main.debug_label = {.text = "g_buffer_main"};
 
-        vierkant::Framebuffer::begin_rendering_info_t rendering_info = {.clear_color_attachment = false,
-                                                                        .clear_depth_attachment = false};
+        vierkant::Framebuffer::create_info_t fb_create_info = {};
+        fb_create_info.begin_rendering_info = {.clear_color_attachment = false, .clear_depth_attachment = false};
         frame_context.g_buffer_post =
-                vierkant::Framebuffer(m_device, frame_context.g_buffer_main.attachments(), rendering_info);
+                vierkant::Framebuffer(m_device, frame_context.g_buffer_main.attachments(), fb_create_info);
         frame_context.g_buffer_post.debug_label = {.text = "g_buffer_post"};
         frame_context.g_buffer_post.clear_color = glm::vec4(0.f);
 

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -1054,13 +1054,12 @@ vierkant::Framebuffer &PBRDeferred::lighting_pass(const cull_result_t &cull_resu
         m_renderer_lighting.stage_drawable(drawable);
 
         vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-        begin_rendering_info.commandbuffer = frame_context.cmd_lighting.handle();
         begin_rendering_info.use_depth_attachment = false;
         begin_rendering_info.clear_depth_attachment = false;
 
         vkCmdWriteTimestamp2(frame_context.cmd_lighting.handle(), VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
                              frame_context.query_pool.get(), 2 * SemaphoreValue::LIGHTING);
-        frame_context.lighting_buffer.begin_rendering(begin_rendering_info);
+        frame_context.lighting_buffer.begin_rendering(frame_context.cmd_lighting.handle(), begin_rendering_info);
 
         m_renderer_lighting.render(rendering_info);
         vkCmdEndRendering(frame_context.cmd_lighting.handle());
@@ -1074,7 +1073,8 @@ vierkant::Framebuffer &PBRDeferred::lighting_pass(const cull_result_t &cull_resu
 
                 begin_rendering_info.clear_color_attachment = false;
                 begin_rendering_info.use_depth_attachment = true;
-                frame_context.lighting_buffer.begin_rendering(begin_rendering_info);
+                frame_context.lighting_buffer.begin_rendering(frame_context.cmd_lighting.handle(),
+                                                              begin_rendering_info);
                 m_renderer_lighting.render(rendering_info);
                 vkCmdEndRendering(frame_context.cmd_lighting.handle());
             }
@@ -1137,9 +1137,7 @@ vierkant::ImagePtr PBRDeferred::post_fx_pass(const Object3DPtr &cam, const vierk
         drawable.pipeline_format.scissor.extent.width = color_attachment->width();
         drawable.pipeline_format.scissor.extent.height = color_attachment->height();
 
-        vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-        begin_rendering_info.commandbuffer = cmd;
-        framebuffer->begin_rendering(begin_rendering_info);
+        framebuffer->begin_rendering(cmd, {});
         renderer.stage_drawable(drawable);
 
         vierkant::Rasterizer::rendering_info_t rendering_info = {};
@@ -1316,10 +1314,10 @@ void vierkant::PBRDeferred::resize_storage(vierkant::PBRDeferred::frame_context_
         frame_context.g_buffer_main = create_g_buffer(m_device, size);
         frame_context.g_buffer_main.debug_label = {.text = "g_buffer_main"};
 
-        auto renderpass_no_clear_depth =
-                vierkant::create_renderpass(m_device, frame_context.g_buffer_main.attachments(), false, false);
+        vierkant::Framebuffer::begin_rendering_info_t rendering_info = {.clear_color_attachment = false,
+                                                                        .clear_depth_attachment = false};
         frame_context.g_buffer_post =
-                vierkant::Framebuffer(m_device, frame_context.g_buffer_main.attachments(), renderpass_no_clear_depth);
+                vierkant::Framebuffer(m_device, frame_context.g_buffer_main.attachments(), rendering_info);
         frame_context.g_buffer_post.debug_label = {.text = "g_buffer_post"};
         frame_context.g_buffer_post.clear_color = glm::vec4(0.f);
 
@@ -1345,7 +1343,7 @@ void vierkant::PBRDeferred::resize_storage(vierkant::PBRDeferred::frame_context_
 
         // use depth from g_buffer
         lighting_attachments[vierkant::AttachmentType::DepthStencil] = {frame_context.g_buffer_post.depth_attachment()};
-        frame_context.lighting_buffer = vierkant::Framebuffer(m_device, lighting_attachments);
+        frame_context.lighting_buffer = vierkant::Framebuffer(m_device, lighting_attachments, {});
         frame_context.lighting_buffer.debug_label = {.text = "lighting_buffer"};
 
         // resize ambient occlusion context

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -416,9 +416,7 @@ void PBRPathTracer::post_fx_pass(frame_context_t &frame_context)
         vkCmdWriteTimestamp2(frame_context.cmd_post_fx.handle(), VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
                              frame_context.query_pool.get(), 2 * SemaphoreValue::TONEMAP);
 
-        vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-        begin_rendering_info.commandbuffer = frame_context.cmd_post_fx.handle();
-        frame_context.post_fx_ping_pongs[0].begin_rendering(begin_rendering_info);
+        frame_context.post_fx_ping_pongs[0].begin_rendering(frame_context.cmd_post_fx.handle(), {});
 
         vierkant::Rasterizer::rendering_info_t rendering_info = {};
         rendering_info.command_buffer = frame_context.cmd_post_fx.handle();

--- a/src/Pipeline.cpp
+++ b/src/Pipeline.cpp
@@ -186,14 +186,9 @@ PipelinePtr Pipeline::create(DevicePtr device, graphics_pipeline_info_t format)
     pipeline_info.pDynamicState = &dynamic_state_create_info;
     pipeline_info.pTessellationState = use_tesselation ? &tessellation_state_create_info : nullptr;
     pipeline_info.layout = pipeline_layout;
-    pipeline_info.renderPass = format.renderpass;
     pipeline_info.subpass = format.subpass;
     pipeline_info.basePipelineHandle = format.base_pipeline;
     pipeline_info.basePipelineIndex = format.base_pipeline_index;
-
-    bool direct_rendering = !format.renderpass && (!format.color_attachment_formats.empty() ||
-                                                   format.depth_attachment_format != VK_FORMAT_UNDEFINED ||
-                                                   format.stencil_attachment_format != VK_FORMAT_UNDEFINED);
 
     VkPipelineRenderingCreateInfo rendering_create_info = {};
     rendering_create_info.sType = VK_STRUCTURE_TYPE_PIPELINE_RENDERING_CREATE_INFO;
@@ -202,7 +197,7 @@ PipelinePtr Pipeline::create(DevicePtr device, graphics_pipeline_info_t format)
     rendering_create_info.pColorAttachmentFormats = format.color_attachment_formats.data();
     rendering_create_info.depthAttachmentFormat = format.depth_attachment_format;
     rendering_create_info.stencilAttachmentFormat = format.stencil_attachment_format;
-    pipeline_info.pNext = direct_rendering ? &rendering_create_info : nullptr;
+    pipeline_info.pNext = &rendering_create_info;
 
     VkPipeline pipeline = VK_NULL_HANDLE;
     vkCheck(vkCreateGraphicsPipelines(device->handle(), format.pipeline_cache, 1, &pipeline_info, nullptr, &pipeline),

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -180,18 +180,44 @@ VkCommandBuffer Rasterizer::render(const vierkant::Framebuffer &framebuffer, boo
         return frame_assets.command_buffer.handle();
     }
 
+    std::vector<VkFormat> color_attachment_formats;
+    VkFormat depth_attachment_format =
+            framebuffer.depth_attachment() ? framebuffer.depth_attachment()->format().format : VK_FORMAT_UNDEFINED;
+    ;
+    for(const auto &[type, images]: framebuffer.attachments())
+    {
+        if(type == AttachmentType::Color)
+        {
+            color_attachment_formats.resize(images.size());
+            for(uint32_t i = 0; i < color_attachment_formats.size(); ++i)
+            {
+                color_attachment_formats[i] = images[i]->format().format;
+            }
+        }
+    }
+
     // inject renderpass-handle
     for(auto &drawable: frame_assets.drawables)
     {
         auto &pipeline_format = drawable.pipeline_format;
-        pipeline_format.renderpass = framebuffer.renderpass().get();
+        pipeline_format.color_attachment_formats = color_attachment_formats;
+        pipeline_format.depth_attachment_format = depth_attachment_format;
     }
 
-    // (re-)create secondary command-buffer
+    // pass inheritance-info for secondary command-buffer
+    VkCommandBufferInheritanceRenderingInfo inheritance_rendering_info = {};
+    inheritance_rendering_info.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_RENDERING_INFO;
+    inheritance_rendering_info.flags = VK_RENDERING_CONTENTS_SECONDARY_COMMAND_BUFFERS_BIT;
+    inheritance_rendering_info.pColorAttachmentFormats = color_attachment_formats.data();
+    inheritance_rendering_info.colorAttachmentCount = color_attachment_formats.size();
+    inheritance_rendering_info.depthAttachmentFormat = depth_attachment_format;
+    inheritance_rendering_info.rasterizationSamples = framebuffer.num_attachments(AttachmentType::Color)
+                                                              ? framebuffer.color_attachment(0)->format().sample_count
+                                                              : VK_SAMPLE_COUNT_1_BIT;
+
     VkCommandBufferInheritanceInfo inheritance = {};
     inheritance.sType = VK_STRUCTURE_TYPE_COMMAND_BUFFER_INHERITANCE_INFO;
-    inheritance.framebuffer = framebuffer.handle();
-    inheritance.renderPass = framebuffer.renderpass().get();
+    inheritance.pNext = &inheritance_rendering_info;
 
     // begin secondary command-buffer
     auto &command_buffer = frame_assets.command_buffer;
@@ -225,7 +251,6 @@ void Rasterizer::render(const rendering_info_t &rendering_info)
     for(auto &drawable: frame_assets.drawables)
     {
         auto &pipeline_format = drawable.pipeline_format;
-        pipeline_format.renderpass = nullptr;
         pipeline_format.view_mask = rendering_info.view_mask;
         pipeline_format.color_attachment_formats = rendering_info.color_attachment_formats;
         pipeline_format.depth_attachment_format = rendering_info.depth_attachment_format;

--- a/src/SwapChain.cpp
+++ b/src/SwapChain.cpp
@@ -80,9 +80,7 @@ VkPresentModeKHR choose_swap_present_mode(const std::vector<VkPresentModeKHR> &m
 }
 
 bool has_stencil_component(VkFormat the_format)
-{
-    return the_format == VK_FORMAT_D32_SFLOAT_S8_UINT || the_format == VK_FORMAT_D24_UNORM_S8_UINT;
-}
+{ return the_format == VK_FORMAT_D32_SFLOAT_S8_UINT || the_format == VK_FORMAT_D24_UNORM_S8_UINT; }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
@@ -318,20 +316,10 @@ void SwapChain::create_framebuffers()
     attachments[vierkant::AttachmentType::Color] = {color_image};
     attachments[vierkant::AttachmentType::DepthStencil] = {depth_image};
     if(resolve) { attachments[vierkant::AttachmentType::Resolve] = {m_images.front()}; }
-
-    // // subpass is dependant on swapchain image
-    // VkSubpassDependency2 dependency = {};
-    // dependency.sType = VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2;
-    // dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-    // dependency.dstSubpass = 0;
-    // dependency.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-    // dependency.srcAccessMask = VK_ACCESS_2_NONE;
-    // dependency.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-    // dependency.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
-    //
-    // auto renderpass = vierkant::create_renderpass(m_device, attachments, true, true, {dependency});
-
     m_framebuffers.resize(m_images.size());
+
+    vierkant::Framebuffer::create_info_t fb_create_info = {};
+    fb_create_info.end_rendering_info = {.final_layout_color = VK_IMAGE_LAYOUT_PRESENT_SRC_KHR};
 
     for(size_t i = 0; i < m_images.size(); i++)
     {
@@ -340,7 +328,7 @@ void SwapChain::create_framebuffers()
         {
             attachments[vierkant::AttachmentType::Color] = {m_images[i]};
         }
-        m_framebuffers[i] = vierkant::Framebuffer(m_device, attachments, {});
+        m_framebuffers[i] = vierkant::Framebuffer(m_device, attachments, fb_create_info);
     }
 }
 

--- a/src/SwapChain.cpp
+++ b/src/SwapChain.cpp
@@ -264,7 +264,7 @@ VkResult SwapChain::present()
     return result;
 }
 
-void swap(SwapChain &lhs, SwapChain &rhs)
+void swap(SwapChain &lhs, SwapChain &rhs) noexcept
 {
     std::swap(lhs.m_device, rhs.m_device);
     std::swap(lhs.m_num_samples, rhs.m_num_samples);
@@ -279,14 +279,6 @@ void swap(SwapChain &lhs, SwapChain &rhs)
     std::swap(lhs.m_sync_objects, rhs.m_sync_objects);
     std::swap(lhs.m_current_frame_index, rhs.m_current_frame_index);
     std::swap(lhs.m_swapchain_image_index, rhs.m_swapchain_image_index);
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-VkRenderPass SwapChain::renderpass() const
-{
-    if(!m_framebuffers.empty()) { return m_framebuffers.front().renderpass().get(); }
-    return VK_NULL_HANDLE;
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -327,17 +319,17 @@ void SwapChain::create_framebuffers()
     attachments[vierkant::AttachmentType::DepthStencil] = {depth_image};
     if(resolve) { attachments[vierkant::AttachmentType::Resolve] = {m_images.front()}; }
 
-    // subpass is dependant on swapchain image
-    VkSubpassDependency2 dependency = {};
-    dependency.sType = VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2;
-    dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
-    dependency.dstSubpass = 0;
-    dependency.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.srcAccessMask = VK_ACCESS_2_NONE;
-    dependency.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
-    dependency.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
-
-    auto renderpass = vierkant::create_renderpass(m_device, attachments, true, true, {dependency});
+    // // subpass is dependant on swapchain image
+    // VkSubpassDependency2 dependency = {};
+    // dependency.sType = VK_STRUCTURE_TYPE_SUBPASS_DEPENDENCY_2;
+    // dependency.srcSubpass = VK_SUBPASS_EXTERNAL;
+    // dependency.dstSubpass = 0;
+    // dependency.srcStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+    // dependency.srcAccessMask = VK_ACCESS_2_NONE;
+    // dependency.dstStageMask = VK_PIPELINE_STAGE_2_COLOR_ATTACHMENT_OUTPUT_BIT;
+    // dependency.dstAccessMask = VK_ACCESS_2_COLOR_ATTACHMENT_WRITE_BIT;
+    //
+    // auto renderpass = vierkant::create_renderpass(m_device, attachments, true, true, {dependency});
 
     m_framebuffers.resize(m_images.size());
 
@@ -348,7 +340,7 @@ void SwapChain::create_framebuffers()
         {
             attachments[vierkant::AttachmentType::Color] = {m_images[i]};
         }
-        m_framebuffers[i] = vierkant::Framebuffer(m_device, attachments, renderpass);
+        m_framebuffers[i] = vierkant::Framebuffer(m_device, attachments, {});
     }
 }
 

--- a/src/ambient_occlusion.cpp
+++ b/src/ambient_occlusion.cpp
@@ -150,9 +150,7 @@ vierkant::ImagePtr ambient_occlusion(const ambient_occlusion_context_ptr &contex
     auto ao_img = context->framebuffer.color_attachment();
     ao_img->transition_layout(VK_IMAGE_LAYOUT_ATTACHMENT_OPTIMAL, params.commandbuffer);
 
-    vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-    begin_rendering_info.commandbuffer = params.commandbuffer;
-    context->framebuffer.begin_rendering(begin_rendering_info);
+    context->framebuffer.begin_rendering(params.commandbuffer, {});
 
     vierkant::Rasterizer::rendering_info_t rendering_info = {};
     rendering_info.command_buffer = params.commandbuffer;

--- a/src/pipeline_formats.cpp
+++ b/src/pipeline_formats.cpp
@@ -274,7 +274,6 @@ bool graphics_pipeline_info_t::operator==(const graphics_pipeline_info_t &other)
     if(min_sample_shading != other.min_sample_shading) { return false; }
     if(memcmp(&blend_state, &other.blend_state, sizeof(VkPipelineColorBlendAttachmentState)) != 0) { return false; }
     if(attachment_blend_states != other.attachment_blend_states) { return false; }
-    if(renderpass != other.renderpass) { return false; }
     if(view_mask != other.view_mask) { return false; }
     if(color_attachment_formats != other.color_attachment_formats) { return false; }
     if(depth_attachment_format != other.depth_attachment_format) { return false; }
@@ -463,7 +462,6 @@ std::hash<vierkant::graphics_pipeline_info_t>::operator()(vierkant::graphics_pip
     hash_combine(h, fmt.min_sample_shading);
     hash_combine(h, fmt.blend_state);
     for(const auto &bs: fmt.attachment_blend_states) { hash_combine(h, bs); }
-    hash_combine(h, fmt.renderpass);
     hash_combine(h, fmt.view_mask);
     for(const auto &caf: fmt.color_attachment_formats) { hash_combine(h, caf); }
     hash_combine(h, fmt.depth_attachment_format);

--- a/tests/TestFramebuffer.cpp
+++ b/tests/TestFramebuffer.cpp
@@ -207,7 +207,7 @@ TEST(TestFramebuffer, Manual_Attachments)
                                               {vierkant::AttachmentType::DepthStencil, {depth_stencil_img}},
                                               {vierkant::AttachmentType::Resolve, {resolve_img}}};
 
-    auto framebuffer = vierkant::Framebuffer(test_context.device, attachments);
+    auto framebuffer = vierkant::Framebuffer(test_context.device, attachments, {});
     EXPECT_TRUE(framebuffer);
     EXPECT_EQ(framebuffer.num_attachments(vierkant::AttachmentType::Color), 1);
     EXPECT_EQ(framebuffer.num_attachments(vierkant::AttachmentType::Resolve), 1);
@@ -253,9 +253,8 @@ TEST(TestFramebuffer, DirectRendering)
     // record direct rendering-pass
     cmd_buffer.begin();
     vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-    begin_rendering_info.commandbuffer = cmd_buffer.handle();
-    framebuffer.begin_rendering(begin_rendering_info);
-    framebuffer.end_rendering();
+    framebuffer.begin_rendering(cmd_buffer.handle(), begin_rendering_info);
+    framebuffer.end_rendering({});
 
     // submit to queue
     VkQueue queue = test_context.device->queue();
@@ -292,9 +291,8 @@ TEST(TestFramebuffer, DirectRendering_MSAA)
     // record direct rendering-pass
     cmd_buffer.begin();
     vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-    begin_rendering_info.commandbuffer = cmd_buffer.handle();
-    framebuffer.begin_rendering(begin_rendering_info);
-    framebuffer.end_rendering();
+    framebuffer.begin_rendering(cmd_buffer.handle(), begin_rendering_info);
+    framebuffer.end_rendering({});
 
     // submit to queue
     VkQueue queue = test_context.device->queue();

--- a/tests/TestPipeline.cpp
+++ b/tests/TestPipeline.cpp
@@ -90,7 +90,6 @@ TEST(TestPipeline, PipelineCache)
     vierkant::graphics_pipeline_info_t fmt;
     fmt.viewport.width = static_cast<float>(framebuffer.extent().width);
     fmt.viewport.height = static_cast<float>(framebuffer.extent().height);
-    fmt.renderpass = framebuffer.renderpass().get();
     fmt.shader_stages = vierkant::create_shader_stages(vierkant::ShaderType::UNLIT_TEXTURE);
 
     // TODO: we expected errors here already, but Mesa/radv 25 just crashes instead of returning an error :(

--- a/tests/TestRasterizer.cpp
+++ b/tests/TestRasterizer.cpp
@@ -89,8 +89,7 @@ TEST(Rasterizer, direct_API)
     auto cmd_buffer = vierkant::CommandBuffer(test_context.device, command_pool.get());
     cmd_buffer.begin();
     vierkant::Framebuffer::begin_rendering_info_t begin_rendering_info = {};
-    begin_rendering_info.commandbuffer = cmd_buffer.handle();
-    framebuffer.begin_rendering(begin_rendering_info);
+    framebuffer.begin_rendering(cmd_buffer.handle(), begin_rendering_info);
 
     vierkant::Rasterizer::rendering_info_t rendering_info = {};
     rendering_info.command_buffer = cmd_buffer.handle();
@@ -98,7 +97,7 @@ TEST(Rasterizer, direct_API)
 
     // record drawing commands into an active command-buffer
     rasterizer.render(rendering_info);
-    framebuffer.end_rendering();
+    framebuffer.end_rendering({});
 
     cmd_buffer.submit(test_context.device->queue(), true);
 }


### PR DESCRIPTION
- rewrite render-scopes to only use `VK_KHR_dynamic_rendering`
- simpler and cleaner, keep basic Framebuffer API/usage same