### PR TITLE
Dispersion: continuous lambda

### DIFF
--- a/shaders/slang/ray/ray_common.slang
+++ b/shaders/slang/ray/ray_common.slang
@@ -83,8 +83,8 @@ public struct payload_t
 
     public float last_ior;
 
-    //! locked dispersion channel (-1 = unlocked); set on first dispersive transmission
-    public int disp_channel;
+    //! locked dispersion wavelength in nm (< 0 = unlocked); set on first dispersive transmission
+    public float disp_lambda;
 
     //! accumulated radiance along a path
     public float3 radiance;

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -6,6 +6,7 @@ import "ray/pixel_data";
 import "ray/bsdf_disney";
 import "ray/direct_lighting";
 
+import "utils/bsdf";
 import "utils/transform";
 import "utils/packed_vertex";
 import "utils/random";
@@ -110,7 +111,7 @@ trace_result_t trace(uint2 coord, uint2 size)
 
         float3 beta = float3(1);
         float3 path_radiance = float3(0);
-        int disp_channel = -1;
+        float disp_lambda = -1.0;
 
         ray::payload_t payload;
 
@@ -126,7 +127,7 @@ trace_result_t trace(uint2 coord, uint2 size)
             payload.beta = beta;
             payload.media = media[media_index];
             payload.last_ior = media[media_index > 0u ? media_index - 1u : 0u].ior;
-            payload.disp_channel = disp_channel;
+            payload.disp_lambda = disp_lambda;
             payload.ray = next_ray;
             payload.cone = cone;
             payload.entity_index = utils::MAX_UINT16;
@@ -147,7 +148,7 @@ trace_result_t trace(uint2 coord, uint2 size)
             cone = payload.cone;
             next_ray = payload.ray;
             beta = payload.beta;
-            disp_channel = payload.disp_channel;
+            disp_lambda = payload.disp_lambda;
 
             if(payload.media_op == ray::MediaOp::Enter)
             {
@@ -266,9 +267,6 @@ utils::transform_t to_aabb_norm(Ptr<ray::entry_t, Access::Read> entry)
 }
 
 float channel_avg(float3 v) { return (v.x + v.y + v.z) / 3.0; }
-
-//! one-hot RGB mask for a dispersion channel (0=R, 1=G, 2=B)
-float3 channel_mask(int c) { return float3(c == 0, c == 1, c == 2); }
 
 utils::Vertex interpolate_vertex(Ptr<ray::entry_t, Access::Read> entry, ray::Triangle t, float2 bary_coords)
 {
@@ -389,19 +387,14 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
     bool sample_surface = !(material.null_surface || sample_medium);
     bool backface = (HitKind() == HIT_KIND_BACK_FACE);
 
-    // chromatic dispersion (glTF KHR_materials_dispersion): split into R/G/B IORs and pick one
-    // channel per path. Locked into the payload on the first transmission so entry/exit refractions
-    // of the same object stay consistent. dispersion == 0 keeps the scalar-ior path unchanged.
+    // chromatic dispersion (glTF KHR_materials_dispersion): sample a single continuous wavelength
+    // per path and refract with a Cauchy eta(lambda). Locked into the payload on the first
+    // transmission so entry/exit refractions of the same object stay consistent. dispersion == 0
+    // keeps the scalar-ior path unchanged.
     bool dispersive = material.dispersion > 0.0 && material.transmission > 0.0;
-    int disp_channel = payload.disp_channel;
-    if(dispersive && disp_channel < 0) { disp_channel = min(int(utils::rnd(rng_state) * 3.0), 2); }
-    float surf_ior = material.ior;
-    if(dispersive)
-    {
-        float half_spread = (material.ior - 1.0) * 0.025 * material.dispersion;
-        float3 iors = float3(material.ior - half_spread, material.ior, material.ior + half_spread);
-        surf_ior = iors[disp_channel];
-    }
+    float disp_lambda = payload.disp_lambda;
+    if(dispersive && disp_lambda < 0.0) { disp_lambda = lerp(400.0, 700.0, utils::rnd(rng_state)); }
+    float surf_ior = dispersive ? utils::cauchy_ior(material.ior, material.dispersion, disp_lambda) : material.ior;
 
     float eta = backface ? surf_ior / payload.last_ior : payload.media.ior / surf_ior;
     eta += ray::EPS;
@@ -509,12 +502,13 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
 
         if(bsdf_sample.transmission)
         {
-            // lock the dispersion channel on the first transmission and tint throughput by
-            // 3 x one-hot mask (the 3x compensates for the 1/3 channel-selection probability)
-            if(dispersive && payload.disp_channel < 0)
+            // lock the sampled wavelength on the first transmission and tint throughput by its
+            // RGB color. LAMBDA_RGB_NORM white-balances a uniform-lambda average back to white
+            // (it absorbs the constant 1/300 nm pdf), so neutral dispersive glass stays neutral.
+            if(dispersive && payload.disp_lambda < 0.0)
             {
-                payload.disp_channel = disp_channel;
-                payload.beta *= 3.0 * channel_mask(disp_channel);
+                payload.disp_lambda = disp_lambda;
+                payload.beta *= utils::LAMBDA_RGB_NORM * utils::lambda_to_rgb(disp_lambda);
             }
 
             // examine next media-op, limit ray.tmax when entering a volume

--- a/shaders/slang/utils/bsdf.slang
+++ b/shaders/slang/utils/bsdf.slang
@@ -54,6 +54,41 @@ static const float3x3 XYZ_TO_REC709 =
         float3x3(float3(3.2404542, -0.9692660, 0.0556434), float3(-1.5371385, 1.8760108, -0.2040259),
                  float3(-0.4985314, 0.0415560, 1.0572252));
 
+// piecewise-Gaussian lobe used by the analytic CIE color-matching fit (Wyman 2013)
+float gaussian_lobe(float x, float mu, float sigma1, float sigma2)
+{
+    float t = (x - mu) * ((x < mu) ? 1.0 / sigma1 : 1.0 / sigma2);
+    return exp(-0.5 * t * t);
+}
+
+//! single-wavelength (nm) -> linear Rec.709 RGB via the analytic multi-Gaussian fit to the
+//! CIE 1931 XYZ color-matching functions (Wyman, Sloan & Shirley, JCGT 2013).
+public float3 lambda_to_rgb(float lambda)
+{
+    float x = 1.056 * gaussian_lobe(lambda, 599.8, 37.9, 31.0) + 0.362 * gaussian_lobe(lambda, 442.0, 16.0, 26.7)
+            - 0.065 * gaussian_lobe(lambda, 501.1, 20.4, 26.2);
+    float y = 0.821 * gaussian_lobe(lambda, 568.8, 46.9, 40.5) + 0.286 * gaussian_lobe(lambda, 530.9, 16.3, 31.1);
+    float z = 1.217 * gaussian_lobe(lambda, 437.0, 11.8, 36.0) + 0.681 * gaussian_lobe(lambda, 459.0, 26.0, 13.8);
+    // clamp out-of-gamut negatives: saturated spectral colors lie outside sRGB, and any negative
+    // throughput gets clipped downstream (accumulation/denoiser), which would bias the average.
+    return max(mul(XYZ_TO_REC709, float3(x, y, z)), float3(0.0));
+}
+
+//! per-channel white balance: a uniform-lambda average of LAMBDA_RGB_NORM * lambda_to_rgb() over
+//! [400, 700] nm integrates back to white (1,1,1). Baked by tasks/dispersion_constants.py.
+public static const float3 LAMBDA_RGB_NORM = float3(1.703734, 2.601105, 2.757475);
+
+//! Cauchy dispersion n(lambda) = A + B/lambda^2, with B fit to the glTF KHR_materials_dispersion
+//! spread at the F/C reference lines and A anchored so n(d-line) == ior. lambda in nm.
+public float cauchy_ior(float ior, float dispersion, float lambda)
+{
+    const float lambda_d = 587.6; // sodium d-line (nm)
+    float half_spread = (ior - 1.0) * 0.025 * dispersion;
+    float B = 1046907.5 * half_spread;            // 2 * half_spread / (1/486.1^2 - 1/656.3^2)
+    float A = ior - B / (lambda_d * lambda_d);
+    return A + B / (lambda * lambda);
+}
+
 public float3 evalSensitivity(float OPD, float3 shift)
 {
     float phase = 2.0 * PI * OPD * 1.0e-9;

--- a/shaders/slang/utils/bsdf.slang
+++ b/shaders/slang/utils/bsdf.slang
@@ -69,9 +69,10 @@ public float3 lambda_to_rgb(float lambda)
             - 0.065 * gaussian_lobe(lambda, 501.1, 20.4, 26.2);
     float y = 0.821 * gaussian_lobe(lambda, 568.8, 46.9, 40.5) + 0.286 * gaussian_lobe(lambda, 530.9, 16.3, 31.1);
     float z = 1.217 * gaussian_lobe(lambda, 437.0, 11.8, 36.0) + 0.681 * gaussian_lobe(lambda, 459.0, 26.0, 13.8);
+
     // clamp out-of-gamut negatives: saturated spectral colors lie outside sRGB, and any negative
     // throughput gets clipped downstream (accumulation/denoiser), which would bias the average.
-    return max(mul(XYZ_TO_REC709, float3(x, y, z)), float3(0.0));
+    return max(mul(float3(x, y, z), XYZ_TO_REC709), float3(0.0));
 }
 
 //! per-channel white balance: a uniform-lambda average of LAMBDA_RGB_NORM * lambda_to_rgb() over
@@ -101,7 +102,7 @@ public float3 evalSensitivity(float OPD, float3 shift)
     xyz.x += 9.7470e-14 * sqrt(2.0 * PI * 4.5282e+09) * cos(2.2399e+06 * phase + shift.x) * exp(-4.5282e+09 * phase2);
     xyz /= 1.0685e-7;
 
-    return mul(XYZ_TO_REC709, xyz);
+    return mul(xyz, XYZ_TO_REC709);
 }
 
 public float3 iridescent_fresnel(float outsideIOR, float iridescenceIOR, float3 baseF0, float iridescenceThickness,


### PR DESCRIPTION
previously we used a stochastic channel-selection with one-hot channels, yielding discrete RGB:

<img width="2048" height="1267" alt="image" src="https://github.com/user-attachments/assets/fd9f57e8-c217-4471-8d46-79d3ae73b3bc" />

using a cauchy-eta we can do better with marginal additional cost:

<img width="2048" height="1267" alt="image" src="https://github.com/user-attachments/assets/14f91098-7291-4eea-b26e-e58a91a6cec8" />
