### PR TITLE
Add glTF scatter / diffuse-transmission support

### DIFF
--- a/include/vierkant/Material.hpp
+++ b/include/vierkant/Material.hpp
@@ -97,10 +97,14 @@ struct material_t
     float attenuation_distance = std::numeric_limits<float>::infinity();
 
     // phase-function asymmetry parameter (forward- vs. back-scattering) [-1, 1]
+    // (glTF KHR_materials_(volume_)scatter scatterAnisotropy)
     float phase_asymmetry_g = 0.f;
 
-    // ratio of scattering vs. absorption (sigma_s / sigma_t)
-    float scattering_ratio = 0.f;
+    // overall scattering strength [0, 1] (glTF KHR_materials_scatter scatterFactor)
+    float scatter_factor = 0.f;
+
+    // multi-scatter albedo / scattering tint (glTF multiscatterColorFactor)
+    glm::vec3 scatter_color = glm::vec3(1.f);
 
     // idk rasterizer only thingy
     float thickness = 1.f;

--- a/include/vierkant/PBRDeferred.hpp
+++ b/include/vierkant/PBRDeferred.hpp
@@ -14,6 +14,7 @@
 #include <vierkant/ambient_occlusion.hpp>
 #include <vierkant/culling.hpp>
 #include <vierkant/gpu_culling.hpp>
+#include <vierkant/mesh_compute.hpp>
 
 namespace vierkant
 {

--- a/include/vierkant/RayBuilder.hpp
+++ b/include/vierkant/RayBuilder.hpp
@@ -3,13 +3,10 @@
 //
 #pragma once
 
-#include <crocore/Cache.hpp>
-
 #include <vierkant/Device.hpp>
 #include <vierkant/Mesh.hpp>
 #include <vierkant/Scene.hpp>
 #include <vierkant/descriptor.hpp>
-#include <vierkant/mesh_compute.hpp>
 #include <vierkant/micromap_compute.hpp>
 #include <vierkant/transform.hpp>
 
@@ -96,11 +93,14 @@ public:
         //! phase-function asymmetry parameter (forward- vs. back-scattering) [-1, 1]
         float phase_asymmetry_g = 0.f;
 
-        //! ratio of scattering vs. absorption (sigma_s / sigma_t)
-        float scattering_ratio = 0.f;
+        //! overall scattering strength [0, 1] (glTF KHR_materials_scatter scatterFactor)
+        float scatter_factor = 0.f;
 
         //! chromatic dispersion strength (glTF KHR_materials_dispersion; 0 = none)
         float dispersion = 0.f;
+
+        //! multi-scatter albedo / scattering tint (glTF multiscatterColorFactor)
+        glm::vec3 scatter_color = glm::vec3(1.f);
     };
 
     //! used for both bottom and toplevel acceleration-structures

--- a/shaders/slang/ray/types.slang
+++ b/shaders/slang/ray/types.slang
@@ -91,9 +91,12 @@ public struct material_t
 
     public bool two_sided;
     public float phase_asymmetry_g;
-    public float scattering_ratio;
+    public float scatter_factor;
 
     public float dispersion;
+
+    public float3 scatter_color;
+    private uint padding;
 };
 
 }// namespace ray

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -403,8 +403,16 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
 
     sigma_t = -log(material.attenuation_color.rgb) / material.attenuation_distance;
     sigma_t = backface ? float3(0) : sigma_t;
-    payload.media.sigma_s = material.scattering_ratio * sigma_t;
-    payload.media.sigma_a = (1 - material.scattering_ratio) * sigma_t;
+
+    // volumetric scattering (glTF KHR_materials_scatter / KHR_materials_volume_scatter):
+    // attenuation_color/distance give the total extinction sigma_t. scatter_color is the
+    // multi-scatter albedo (rho_ms), scaled by scatter_factor; convert to the single-scatter
+    // albedo (rho_ss) the medium needs via the Kulla-Conty (2017) inversion, per channel.
+    float3 rho_ms = material.scatter_factor * material.scatter_color;
+    float3 kc = 4.09712 + 4.20863 * rho_ms - sqrt(9.59217 + 41.6808 * rho_ms + 17.7126 * rho_ms * rho_ms);
+    float3 rho_ss = 1.0 - kc * kc;
+    payload.media.sigma_s = rho_ss * sigma_t;
+    payload.media.sigma_a = (1.0 - rho_ss) * sigma_t;
     payload.media.phase_g = material.phase_asymmetry_g;
     payload.media.ior = sample_surface ? material.ior : payload.media.ior;
 

--- a/src/Material.cpp
+++ b/src/Material.cpp
@@ -29,7 +29,8 @@ size_t std::hash<vierkant::material_t>::operator()(vierkant::material_t const &m
     hash_combine(h, m.alpha_cutoff);
     hash_combine(h, m.transmission);
     hash_combine(h, m.phase_asymmetry_g);
-    hash_combine(h, m.scattering_ratio);
+    hash_combine(h, m.scatter_factor);
+    hash_combine(h, m.scatter_color);
     hash_combine(h, m.attenuation_color);
     hash_combine(h, m.attenuation_distance);
     hash_combine(h, m.ior);

--- a/src/RayBuilder.cpp
+++ b/src/RayBuilder.cpp
@@ -2,6 +2,7 @@
 #include <vierkant/RayBuilder.hpp>
 #include <vierkant/Visitor.hpp>
 #include <vierkant/gpu_timestamp_util.hpp>
+#include <vierkant/mesh_compute.hpp>
 #include <vierkant/micromap_compute.hpp>
 
 namespace vierkant
@@ -559,7 +560,8 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
                     material.two_sided = mat->twosided;
                     material.null_surface = mat->null_surface;
                     material.phase_asymmetry_g = mat->phase_asymmetry_g;
-                    material.scattering_ratio = mat->scattering_ratio;
+                    material.scatter_factor = mat->scatter_factor;
+                    material.scatter_color = mat->scatter_color;
 
                     material.iridescence_strength = mat->iridescence_factor;
                     material.iridescence_ior = mat->iridescence_ior;

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -871,8 +871,11 @@ bool draw_material_ui(vierkant::material_t &material,
     // phase_asymmetry_g
     changed |= ImGui::SliderFloat("phase_asymmetry_g", &material.phase_asymmetry_g, -1.f, 1.f);
 
-    // scattering_ratio
-    changed |= ImGui::SliderFloat("scattering_ratio", &material.scattering_ratio, 0.f, 1.f);
+    // scatter_factor
+    changed |= ImGui::SliderFloat("scatter_factor", &material.scatter_factor, 0.f, 1.f);
+
+    // scatter_color (multi-scatter albedo)
+    changed |= ImGui::ColorEdit3("scatter_color", glm::value_ptr(material.scatter_color));
 
     // index of refraction - ior
     changed |= ImGui::InputFloat("ior", &material.ior);

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -56,6 +56,9 @@ constexpr char KHR_materials_dispersion[] = "KHR_materials_dispersion";
 constexpr char KHR_materials_clearcoat[] = "KHR_materials_clearcoat";
 constexpr char KHR_materials_sheen[] = "KHR_materials_sheen";
 constexpr char KHR_materials_iridescence[] = "KHR_materials_iridescence";
+constexpr char KHR_materials_diffuse_transmission[] = "KHR_materials_diffuse_transmission";
+constexpr char KHR_materials_volume_scatter[] = "KHR_materials_volume_scatter";
+constexpr char KHR_materials_scatter[] = "KHR_materials_scatter";
 constexpr char KHR_texture_transform[] = "KHR_texture_transform";
 constexpr char KHR_lights_punctual[] = "KHR_lights_punctual";
 
@@ -95,6 +98,14 @@ constexpr char ext_iridescence_ior[] = "iridescenceIOR";
 constexpr char ext_iridescence_thickness_min[] = "iridescenceThicknessMinimum";
 constexpr char ext_iridescence_thickness_max[] = "iridescenceThicknessMaximum";
 constexpr char ext_iridescence_thickness_texture[] = "iridescenceThicknessTexture";
+
+// KHR_materials_diffuse_transmission
+constexpr char ext_diffuse_transmission_factor[] = "diffuseTransmissionFactor";
+
+// KHR_materials_volume_scatter / KHR_materials_scatter
+constexpr char ext_scatter_multiscatter_color_factor[] = "multiscatterColorFactor";
+constexpr char ext_scatter_anisotropy[] = "scatterAnisotropy";
+constexpr char ext_scatter_factor[] = "scatterFactor";
 
 // KHR_texture_transform
 constexpr char ext_texture_offset[] = "offset";
@@ -585,6 +596,41 @@ vierkant::material_t convert_material(const tinygltf::Material &tiny_mat, const 
                         for(; ptr < end; ptr += c) { ptr[0] = 255; }
                     }
                 }//} || img_iridescence_thickness == ret.img_iridescence);
+            }
+        }
+        else if(ext == KHR_materials_diffuse_transmission)
+        {
+            // Step 1: treat diffuse-transmission as plain transmission. For the volumetric,
+            // dense-subsurface case this matches the unified KHR_materials_scatter volumetric
+            // mode (specular transmission surface + scattering interior) and reuses the
+            // existing transmission path. diffuseTransmissionColor is ignored for now.
+            if(value.Has(ext_diffuse_transmission_factor))
+            {
+                ret.transmission = static_cast<float>(value.Get(ext_diffuse_transmission_factor).GetNumberAsDouble());
+            }
+        }
+        else if(ext == KHR_materials_volume_scatter || ext == KHR_materials_scatter)
+        {
+            // multi-scatter albedo (scattering tint), inverted to single-scatter albedo on the GPU
+            if(value.Has(ext_scatter_multiscatter_color_factor))
+            {
+                const auto &c = value.Get(ext_scatter_multiscatter_color_factor);
+                ret.scatter_color = glm::dvec3(c.Get(0).GetNumberAsDouble(), c.Get(1).GetNumberAsDouble(),
+                                               c.Get(2).GetNumberAsDouble());
+            }
+
+            // Henyey-Greenstein asymmetry for volumetric scattering events
+            if(value.Has(ext_scatter_anisotropy))
+            {
+                ret.phase_asymmetry_g = static_cast<float>(value.Get(ext_scatter_anisotropy).GetNumberAsDouble());
+            }
+
+            // scatterFactor only exists on the unified KHR_materials_scatter (default 0).
+            // The legacy KHR_materials_volume_scatter has no such weight -> implicit 1.0.
+            ret.scatter_factor = (ext == KHR_materials_scatter) ? 0.f : 1.f;
+            if(value.Has(ext_scatter_factor))
+            {
+                ret.scatter_factor = static_cast<float>(value.Get(ext_scatter_factor).GetNumberAsDouble());
             }
         }
     }


### PR DESCRIPTION
- parse KHR_materials_diffuse_transmission, KHR_materials_volume_scatter and KHR_materials_scatter into the path-tracer material.
- treat diffuse-transmission as plain transmission (matches the unified KHR_materials_scatter volumetric mode), so no new BSDF lobe is needed.

- material: rename scattering_ratio -> scatter_factor, add RGB scatter_color (multi-scatter albedo), propagate through Material, RayBuilder, imgui
- raypipeline: derive single-scatter albedo from the multi-scatter albedo via the Kulla-Conty (2017) inversion; sigma_s/sigma_a now RGB

<img width="1830" height="1710" alt="image" src="https://github.com/user-attachments/assets/07957ad5-2048-4241-b98d-8ab9dcaff442" />
