### PR TITLE
Add support for KHR_materials_diffuse_transmission

### DIFF
--- a/include/vierkant/Material.hpp
+++ b/include/vierkant/Material.hpp
@@ -51,7 +51,9 @@ enum class TextureType : uint32_t
     IridescenceThickness = 0x800,
     Specular = 0x1000,
     SpecularColor = 0x2000,
-    Environment = 0x4000
+    Environment = 0x4000,
+    DiffuseTransmission = 0x8000,
+    DiffuseTransmissionColor = 0x10000
 };
 
 struct texture_data_t
@@ -105,6 +107,12 @@ struct material_t
 
     // multi-scatter albedo / scattering tint (glTF multiscatterColorFactor)
     glm::vec3 scatter_color = glm::vec3(1.f);
+
+    // diffuse (Lambertian) transmission strength (glTF KHR_materials_diffuse_transmission)
+    float diffuse_transmission = 0.f;
+
+    // tint for diffuse-transmitted light (glTF diffuseTransmissionColorFactor)
+    glm::vec3 diffuse_transmission_color = glm::vec3(1.f);
 
     // idk rasterizer only thingy
     float thickness = 1.f;

--- a/include/vierkant/Material.hpp
+++ b/include/vierkant/Material.hpp
@@ -52,8 +52,7 @@ enum class TextureType : uint32_t
     Specular = 0x1000,
     SpecularColor = 0x2000,
     Environment = 0x4000,
-    DiffuseTransmission = 0x8000,
-    DiffuseTransmissionColor = 0x10000
+    DiffuseTransmission = 0x8000
 };
 
 struct texture_data_t

--- a/include/vierkant/RayBuilder.hpp
+++ b/include/vierkant/RayBuilder.hpp
@@ -101,6 +101,12 @@ public:
 
         //! multi-scatter albedo / scattering tint (glTF multiscatterColorFactor)
         glm::vec3 scatter_color = glm::vec3(1.f);
+
+        //! diffuse (Lambertian) transmission strength (glTF KHR_materials_diffuse_transmission)
+        float diffuse_transmission = 0.f;
+
+        //! tint for diffuse-transmitted light (glTF diffuseTransmissionColorFactor)
+        glm::vec3 diffuse_transmission_color = glm::vec3(1.f);
     };
 
     //! used for both bottom and toplevel acceleration-structures

--- a/include/vierkant/RayBuilder.hpp
+++ b/include/vierkant/RayBuilder.hpp
@@ -107,6 +107,9 @@ public:
 
         //! tint for diffuse-transmitted light (glTF diffuseTransmissionColorFactor)
         glm::vec3 diffuse_transmission_color = glm::vec3(1.f);
+
+        //! shared texture: rgb = color tint, alpha = transmission factor (glTF combined texture)
+        uint32_t diffuse_transmission_index = 0;
     };
 
     //! used for both bottom and toplevel acceleration-structures

--- a/shaders/slang/ray/bsdf_disney.slang
+++ b/shaders/slang/ray/bsdf_disney.slang
@@ -232,11 +232,27 @@ public bsdf_sample_t sample_disney(material_t material, float3 N, float3 V, floa
         // diffuse
         if(utils::rnd(rng_state) < diffuseRatio)
         {
-            ret.direction = mul(utils::sample_hemisphere_cosine(Xi), frame);
-            float3 H = normalize(ret.direction + V);
-            ret.F = EvalDiffuse(material.roughness, material.sheen_roughness, material.color.rgb,
-                                material.sheen_color.rgb, material.metalness, V, N, ret.direction, H, ret.pdf);
-            ret.pdf *= diffuseRatio;
+            // split the diffuse base into reflection (BRDF) and Lambertian transmission (BTDF).
+            // dt == 0 short-circuits -> no extra rng, opaque path stays bit-identical.
+            float dt = material.diffuse_transmission;
+            if(dt > 0.0 && utils::rnd(rng_state) < dt)
+            {
+                // cosine lobe on the opposite hemisphere (no Snell bend, no Fresnel)
+                float3 local = utils::sample_hemisphere_cosine(Xi);
+                ret.direction = mul(float3(local.xy, -local.z), frame);
+                ret.F = dt * material.diffuse_transmission_color * utils::ONE_OVER_PI;
+                ret.pdf = local.z * utils::ONE_OVER_PI * diffuseRatio * dt;
+                ret.transmission = true;
+            }
+            else
+            {
+                ret.direction = mul(utils::sample_hemisphere_cosine(Xi), frame);
+                float3 H = normalize(ret.direction + V);
+                ret.F = (1.0 - dt) * EvalDiffuse(material.roughness, material.sheen_roughness, material.color.rgb,
+                                                 material.sheen_color.rgb, material.metalness, V, N, ret.direction, H,
+                                                 ret.pdf);
+                ret.pdf *= diffuseRatio * (1.0 - dt);
+            }
         }
         else// specular
         {
@@ -327,9 +343,19 @@ public float3 eval_disney(material_t material, float3 L, float3 N, float3 V, flo
 
     if(trans_weight < 1.0)
     {
-        brdf += EvalDiffuse(material.roughness, material.sheen_roughness, material.color.rgb, material.sheen_color.rgb,
-                            material.metalness, V, N, L, H, m_pdf);
-        brdfPdf += m_pdf * diffuseRatio;
+        float dt = material.diffuse_transmission;
+
+        brdf += (1.0 - dt) * EvalDiffuse(material.roughness, material.sheen_roughness, material.color.rgb,
+                                         material.sheen_color.rgb, material.metalness, V, N, L, H, m_pdf);
+        brdfPdf += m_pdf * diffuseRatio * (1.0 - dt);
+
+        // Lambertian transmission: cosine lobe on the opposite hemisphere (L below surface)
+        if(dt > 0.0 && !refl)
+        {
+            float cosT = -dot(N, L);
+            brdf += dt * material.diffuse_transmission_color * utils::ONE_OVER_PI;
+            brdfPdf += cosT * utils::ONE_OVER_PI * diffuseRatio * dt;
+        }
 
         brdf += EvalSpecular(material.roughness, spec_color, V, N, L, H, m_pdf) * (1.0 - material.iridescence_strength);
         brdfPdf += m_pdf * primarySpecRatio * (1.0 - diffuseRatio) * (1.0 - material.iridescence_strength);

--- a/shaders/slang/ray/types.slang
+++ b/shaders/slang/ray/types.slang
@@ -46,6 +46,7 @@ public enum TextureTypeBits : uint
     SheenRoughness = 0x200,
     Iridescence = 0x400,
     Environment = 0x800,
+    DiffuseTransmission = 0x8000,
 };
 
 public uint tex_offset(uint type, uint flags) { return countbits(flags & (type - 1)); }
@@ -98,7 +99,7 @@ public struct material_t
     public float3 scatter_color;
     public float diffuse_transmission;
     public float3 diffuse_transmission_color;
-    private uint padding;
+    public uint diffuse_transmission_index;
 };
 
 }// namespace ray

--- a/shaders/slang/ray/types.slang
+++ b/shaders/slang/ray/types.slang
@@ -96,6 +96,8 @@ public struct material_t
     public float dispersion;
 
     public float3 scatter_color;
+    public float diffuse_transmission;
+    public float3 diffuse_transmission_color;
     private uint padding;
 };
 

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -416,8 +416,14 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
     payload.media.phase_g = material.phase_asymmetry_g;
     payload.media.ior = sample_surface ? material.ior : payload.media.ior;
 
-    // determine next media-op
-    payload.media_op = sample_medium ? ray::MediaOp::NoOp : (backface ? ray::MediaOp::Leave : ray::MediaOp::Enter);
+    // determine next media-op. a transmission event touches the media stack only when it crosses a
+    // real boundary: a volume (Beer-Lambert / scattering interior) or a specular-refractive surface
+    // (IOR tracking for eta). thin-walled diffuse transmission (no volume, no specular) just crosses.
+    bool has_volume = !isinf(material.attenuation_distance);
+    bool media_boundary = has_volume || material.transmission > 0.0;
+    payload.media_op = (sample_medium || !media_boundary)
+                               ? ray::MediaOp::NoOp
+                               : (backface ? ray::MediaOp::Leave : ray::MediaOp::Enter);
 
     if(sample_surface)
     {

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -486,6 +486,15 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
                             .x;
         }
 
+        // combined diffuse-transmission texture: alpha scales the factor, rgb tints the color
+        if((material.texture_type_flags & uint(ray::TextureTypeBits::DiffuseTransmission)) != 0)
+        {
+            float4 dt_tex = sample_texture_lod(u_textures[NonUniformResourceIndex(material.diffuse_transmission_index)],
+                                               v.tex_coord, NoV, payload.cone.width, triangle_lod);
+            material.diffuse_transmission *= dt_tex.a;
+            material.diffuse_transmission_color *= dt_tex.rgb;
+        }
+
         payload.cone = propagate(payload.cone, 0.0, RayTCurrent());
 
         // increase material-roughness for longer paths, reduce fireflies

--- a/src/RayBuilder.cpp
+++ b/src/RayBuilder.cpp
@@ -605,6 +605,12 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
                             case vierkant::TextureType::Transmission:
                                 material.transmission_index = texture_index;
                                 break;
+
+                            // combined glTF texture: rgb = color tint, alpha = transmission factor.
+                            // both extension-textures share one index (same image in practice).
+                            case vierkant::TextureType::DiffuseTransmission:
+                                material.diffuse_transmission_index = texture_index;
+                                break;
                             default: break;
                         }
                     }

--- a/src/RayBuilder.cpp
+++ b/src/RayBuilder.cpp
@@ -562,6 +562,8 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
                     material.phase_asymmetry_g = mat->phase_asymmetry_g;
                     material.scatter_factor = mat->scatter_factor;
                     material.scatter_color = mat->scatter_color;
+                    material.diffuse_transmission = mat->diffuse_transmission;
+                    material.diffuse_transmission_color = mat->diffuse_transmission_color;
 
                     material.iridescence_strength = mat->iridescence_factor;
                     material.iridescence_ior = mat->iridescence_ior;

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -862,6 +862,11 @@ bool draw_material_ui(vierkant::material_t &material,
     changed |= ImGui::SliderFloat("transmission", &material.transmission, 0.f, 1.f);
     if(draw_texture_fn) { draw_texture_fn(vierkant::TextureType::Transmission, "transmission"); }
 
+    // diffuse (Lambertian) transmission (glTF KHR_materials_diffuse_transmission)
+    changed |= ImGui::SliderFloat("diffuse_transmission", &material.diffuse_transmission, 0.f, 1.f);
+    changed |= ImGui::ColorEdit3("diffuse_transmission_color", glm::value_ptr(material.diffuse_transmission_color));
+    if(draw_texture_fn) { draw_texture_fn(vierkant::TextureType::DiffuseTransmission, "diffuse_transmission"); }
+
     // attenuation distance
     changed |= ImGui::InputFloat("attenuation distance", &material.attenuation_distance);
 

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -616,18 +616,17 @@ vierkant::material_t convert_material(const tinygltf::Material &tiny_mat, const 
                         c.Get(0).GetNumberAsDouble(), c.Get(1).GetNumberAsDouble(), c.Get(2).GetNumberAsDouble());
             }
 
-            // alpha channel scales diffuse_transmission
+            // combined texture: alpha scales the factor, rgb (sRGB) tints the color. both glTF
+            // texture fields share one slot (same image in practice).
             if(value.Has(ext_diffuse_transmission_texture))
             {
                 const auto &tex = value.Get(ext_diffuse_transmission_texture);
                 insert_texture(tex.Get("index").GetNumberAsInt(), TextureType::DiffuseTransmission);
             }
-
-            // sRGB tint for diffuse_transmission_color
             if(value.Has(ext_diffuse_transmission_color_texture))
             {
                 const auto &tex = value.Get(ext_diffuse_transmission_color_texture);
-                insert_texture(tex.Get("index").GetNumberAsInt(), TextureType::DiffuseTransmissionColor);
+                insert_texture(tex.Get("index").GetNumberAsInt(), TextureType::DiffuseTransmission);
             }
         }
         else if(ext == KHR_materials_volume_scatter || ext == KHR_materials_scatter)

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -101,6 +101,9 @@ constexpr char ext_iridescence_thickness_texture[] = "iridescenceThicknessTextur
 
 // KHR_materials_diffuse_transmission
 constexpr char ext_diffuse_transmission_factor[] = "diffuseTransmissionFactor";
+constexpr char ext_diffuse_transmission_texture[] = "diffuseTransmissionTexture";
+constexpr char ext_diffuse_transmission_color_factor[] = "diffuseTransmissionColorFactor";
+constexpr char ext_diffuse_transmission_color_texture[] = "diffuseTransmissionColorTexture";
 
 // KHR_materials_volume_scatter / KHR_materials_scatter
 constexpr char ext_scatter_multiscatter_color_factor[] = "multiscatterColorFactor";
@@ -600,13 +603,31 @@ vierkant::material_t convert_material(const tinygltf::Material &tiny_mat, const 
         }
         else if(ext == KHR_materials_diffuse_transmission)
         {
-            // Step 1: treat diffuse-transmission as plain transmission. For the volumetric,
-            // dense-subsurface case this matches the unified KHR_materials_scatter volumetric
-            // mode (specular transmission surface + scattering interior) and reuses the
-            // existing transmission path. diffuseTransmissionColor is ignored for now.
             if(value.Has(ext_diffuse_transmission_factor))
             {
-                ret.transmission = static_cast<float>(value.Get(ext_diffuse_transmission_factor).GetNumberAsDouble());
+                ret.diffuse_transmission =
+                        static_cast<float>(value.Get(ext_diffuse_transmission_factor).GetNumberAsDouble());
+            }
+
+            if(value.Has(ext_diffuse_transmission_color_factor))
+            {
+                const auto &c = value.Get(ext_diffuse_transmission_color_factor);
+                ret.diffuse_transmission_color = glm::dvec3(
+                        c.Get(0).GetNumberAsDouble(), c.Get(1).GetNumberAsDouble(), c.Get(2).GetNumberAsDouble());
+            }
+
+            // alpha channel scales diffuse_transmission
+            if(value.Has(ext_diffuse_transmission_texture))
+            {
+                const auto &tex = value.Get(ext_diffuse_transmission_texture);
+                insert_texture(tex.Get("index").GetNumberAsInt(), TextureType::DiffuseTransmission);
+            }
+
+            // sRGB tint for diffuse_transmission_color
+            if(value.Has(ext_diffuse_transmission_color_texture))
+            {
+                const auto &tex = value.Get(ext_diffuse_transmission_color_texture);
+                insert_texture(tex.Get("index").GetNumberAsInt(), TextureType::DiffuseTransmissionColor);
             }
         }
         else if(ext == KHR_materials_volume_scatter || ext == KHR_materials_scatter)


### PR DESCRIPTION
<img width="3434" height="1800" alt="image" src="https://github.com/user-attachments/assets/c322c979-bd10-4cab-bb90-a94d1f49c7ae" />

Path-traced KHR_materials_diffuse_transmission (thin-walled diffuse transmission)

Adds a proper diffuse-transmission BSDF lobe so thin-walled translucent assets (MandarinOrange, DiffuseTransmissionPlant, DiffuseTransmissionTeacup) render correctly instead of as specular glass. Previously diffuse-transmission was hijacked onto the specular transmission path, which bends light (Snell, IOR 1.5) and adds a Fresnel rim — wrong for matte translucency.

- Parse the extension into dedicated fields — diffuse_transmission + diffuse_transmission_color (+ combined texture), no longer mapped onto specular transmission.
- New Lambertian BTDF lobe in the Disney BSDF — splits the diffuse base into reflection (BRDF) and opposite-hemisphere transmission (BTDF) by diffuse_transmission, in both sample_disney and eval_disney; MIS-consistent energy/selection split. dt == 0 short-circuits, so opaque/glass paths stay bit-identical (no perturbed RNG, no extra cost).
- Media-op regating — Enter/Leave now fires on a real boundary (has_volume || transmission > 0), not on bare transmission. Thin-walled diffuse transmission crosses without entering a medium (no tmax clamp); the ScatteringSkull keeps its volume entry via the diffuse BTDF; volume-less specular glass keeps its IOR tracking.
- Combined texture support — one DiffuseTransmission slot (rgb = color tint, alpha = factor), single fetch in-shader.
- GPU material plumbing — new fields appended to the path-tracer material_t honoring std430 (struct stays 192 B; index reuses the color-vec3's 4th lane).
- imgui — material editor exposes the new slider / color / texture controls.

Validation

- ScatteringSkull: no regression (volume entry now via diffuse BTDF).
- MandarinOrange / Plant / Teacup: now render as diffuse translucency.

Notes

- Out of scope: the generalized anisotropic scatter_bsdf (forward/backward split by g) and the unified KHR_materials_scatter thin-walled scatterFactor lerp — no sample asset exercises them.
- Combined-texture caveat: assets providing only one of the two glTF textures (teacup = alpha-only, plant = rgb-only) rely on the unused channels being neutral.