### PR TITLE
Extract asset store from Scene into AssetProvider

### DIFF
--- a/include/vierkant/AssetProvider.hpp
+++ b/include/vierkant/AssetProvider.hpp
@@ -1,0 +1,78 @@
+#pragma once
+
+#include <unordered_map>
+#include <unordered_set>
+
+#include <vierkant/Device.hpp>
+#include <vierkant/Image.hpp>
+#include <vierkant/Material.hpp>
+#include <vierkant/mesh_component.hpp>
+#include <vierkant/model/model_loading.hpp>
+
+namespace vierkant
+{
+
+DEFINE_CLASS_PTR(AssetProvider)
+
+//! live-id set gathered by a Scene graph-walk and handed to AssetProvider::prune
+struct asset_live_set_t
+{
+    std::unordered_set<vierkant::MaterialId> materials;
+    std::unordered_set<vierkant::texture_key_t> textures;
+    std::unordered_set<vierkant::SamplerId> samplers;
+    std::unordered_set<vierkant::MeshId> meshes;
+};
+
+/**
+ * @brief   AssetProvider owns the runtime (GPU) assets consumed during rendering:
+ *          materials, textures (keyed by {texture_id, sampler_id}), samplers and meshes.
+ *
+ * Mutation (populate/prune) happens on the render-thread at a defined sync-point; reads borrow whole
+ * maps by pointer during culling. There is no internal locking - see project notes (W2 #6).
+ */
+class AssetProvider
+{
+public:
+    static AssetProviderPtr create(vierkant::DevicePtr device);
+
+    // materials
+    void add_material(material_t m);
+    [[nodiscard]] const material_t *material(const MaterialId &id) const;
+    material_t *material(const MaterialId &id);
+
+    // textures (GPU), keyed by {texture_id, sampler_id}
+    void add_texture(const texture_key_t &key, ImagePtr img);
+    [[nodiscard]] ImagePtr texture(const texture_key_t &key) const;
+
+    // samplers (GPU) - owner + dedup by SamplerId
+    [[nodiscard]] VkSamplerPtr sampler(const SamplerId &id) const;
+    VkSamplerPtr get_or_create_sampler(const SamplerId &id, const texture_sampler_t &ts, uint32_t mip_levels);
+
+    // meshes
+    [[nodiscard]] const mesh_asset_t *mesh_asset(const MeshId &id) const;
+    void add_mesh(const MeshId &id, mesh_asset_t asset);
+
+    //! bulk-merge a finished load (render-thread; see W2 #6)
+    void populate(const model::load_mesh_result_t &result);
+
+    //! mark-sweep (render-thread); reaps materials + textures + samplers + meshes
+    void prune(const asset_live_set_t &live);
+
+    // borrowed whole-map access for cull/imgui (render-thread only)
+    [[nodiscard]] const std::unordered_map<MaterialId, material_t> &materials() const { return m_materials; }
+    [[nodiscard]] const std::unordered_map<texture_key_t, ImagePtr> &textures() const { return m_textures; }
+
+    //! adapter satisfying physics' mesh_provider_fn
+    [[nodiscard]] std::function<const mesh_asset_t *(MeshId)> mesh_provider() const;
+
+private:
+    explicit AssetProvider(vierkant::DevicePtr device) : m_device(std::move(device)) {}
+
+    vierkant::DevicePtr m_device;
+    std::unordered_map<MaterialId, material_t> m_materials;
+    std::unordered_map<texture_key_t, ImagePtr> m_textures;
+    std::unordered_map<SamplerId, VkSamplerPtr> m_samplers;
+    mesh_map_t m_meshes;
+};
+
+}// namespace vierkant

--- a/include/vierkant/Material.hpp
+++ b/include/vierkant/Material.hpp
@@ -10,6 +10,7 @@
 #include <vierkant/Geometry.hpp>
 #include <vierkant/Image.hpp>
 #include <vierkant/Pipeline.hpp>
+#include <vierkant/hash.hpp>
 #include <vierkant/texture_block_compression.hpp>
 
 namespace vierkant
@@ -19,6 +20,14 @@ namespace vierkant
 DEFINE_NAMED_UUID(MaterialId)
 DEFINE_NAMED_UUID(TextureId)
 DEFINE_NAMED_UUID(SamplerId)
+
+//! composite key: a texture id paired with the sampler it is realized with
+struct texture_key_t
+{
+    vierkant::TextureId texture_id = vierkant::TextureId::nil();
+    vierkant::SamplerId sampler_id = vierkant::SamplerId::nil();
+    bool operator==(const texture_key_t &) const = default;
+};
 
 enum class BlendMode : uint8_t
 {
@@ -196,5 +205,17 @@ template<>
 struct hash<vierkant::material_t>
 {
     size_t operator()(vierkant::material_t const &m) const noexcept;
+};
+
+template<>
+struct hash<vierkant::texture_key_t>
+{
+    size_t operator()(vierkant::texture_key_t const &key) const noexcept
+    {
+        size_t h = 0;
+        vierkant::hash_combine(h, key.texture_id);
+        vierkant::hash_combine(h, key.sampler_id);
+        return h;
+    }
 };
 }// namespace std

--- a/include/vierkant/Scene.hpp
+++ b/include/vierkant/Scene.hpp
@@ -4,6 +4,7 @@
 
 #include <crocore/ThreadPool.hpp>
 
+#include <vierkant/AssetProvider.hpp>
 #include <vierkant/Image.hpp>
 #include <vierkant/Mesh.hpp>
 #include <vierkant/Object3D.hpp>
@@ -28,7 +29,8 @@ class Scene
 public:
     virtual ~Scene() = default;
 
-    static ScenePtr create(const std::shared_ptr<vierkant::ObjectStore> &object_store = {});
+    static ScenePtr create(const std::shared_ptr<vierkant::ObjectStore> &object_store = {},
+                           const vierkant::AssetProviderPtr &asset_provider = {});
 
     virtual void add_object(const Object3DPtr &object);
 
@@ -77,43 +79,24 @@ public:
     vierkant::Object3DPtr
     create_camera(const vierkant::camera_params_variant_t &params = vierkant::physical_camera_params_t{});
 
-    // TODO: rework this entire material-storage thingy as separate module
-
-    void add_material(material_t material);
-
-    const material_t *material(const vierkant::MaterialId &material_id) const;
-
-    material_t *material(const vierkant::MaterialId &material_id);
-
-    const mesh_asset_t *mesh_asset(const vierkant::MeshId &mesh_id);
-
-    void add_texture(const vierkant::TextureId &texture_id, const vierkant::ImagePtr &tex);
-
-    vierkant::ImagePtr texture(const vierkant::TextureId &texture_id) const;
-
-    const vierkant::material_data_t *material_data() const { return &m_material_data; }
-
-    const std::unordered_map<vierkant::TextureId, vierkant::ImagePtr> *texture_store() const
-    { return &m_texture_store; }
+    [[nodiscard]] const vierkant::AssetProviderPtr &asset_provider() const { return m_asset_provider; }
 
     /**
-     * @brief   prune_unused_material_data iterates all scene-graph nodes, identifies all live material/texture-data
-     *          and updates internal material/texture store.
-     *          this result in a pruning-operation, leaving only required data.
+     * @brief   prune_assets walks the scene-graph, collects the live material/texture/sampler/mesh ids
+     *          and hands them to the AssetProvider, which reaps everything else.
      */
-    void prune_unused_material_data();
-
-    vierkant::material_data_t m_material_data;
-    std::unordered_map<vierkant::TextureId, vierkant::ImagePtr> m_texture_store;
-    vierkant::mesh_map_t m_mesh_map;
+    void prune_assets();
 
 protected:
-    explicit Scene(const std::shared_ptr<vierkant::ObjectStore> &object_store);
+    explicit Scene(const std::shared_ptr<vierkant::ObjectStore> &object_store,
+                   const vierkant::AssetProviderPtr &asset_provider);
 
 private:
     static constexpr char s_scene_root_name[] = "scene root";
 
     std::shared_ptr<vierkant::ObjectStore> m_object_store;
+
+    vierkant::AssetProviderPtr m_asset_provider;
 
     vierkant::ImagePtr m_skybox = nullptr;
 

--- a/include/vierkant/drawable.hpp
+++ b/include/vierkant/drawable.hpp
@@ -13,6 +13,8 @@
 namespace vierkant
 {
 
+class AssetProvider;
+
 struct matrix_struct_t
 {
     glm::mat4 projection = glm::mat4(1);
@@ -121,8 +123,7 @@ struct create_mesh_drawables_params_t
 {
     vierkant::transform_t transform = {};
 
-    const vierkant::material_data_t *material_data = nullptr;
-    const std::unordered_map<vierkant::TextureId, vierkant::ImagePtr> *texture_store = nullptr;
+    const vierkant::AssetProvider *assets = nullptr;
 
     // set lod-index, default: 0 (highest lod). use negative values to count backwards from lowest lod
     int32_t lod_index = 0;

--- a/include/vierkant/mesh_component.hpp
+++ b/include/vierkant/mesh_component.hpp
@@ -33,7 +33,7 @@ struct mesh_asset_t
     vierkant::MeshPtr mesh;
 
     //! optional, persist-able bundle-version
-    std::optional<vierkant::mesh_buffer_bundle_t> bundle;
+    std::optional<vierkant::mesh_buffer_bundle_t> bundle = {};
 };
 using mesh_map_t = std::unordered_map<vierkant::MeshId, mesh_asset_t>;
 

--- a/include/vierkant/model/model_loading.hpp
+++ b/include/vierkant/model/model_loading.hpp
@@ -185,7 +185,8 @@ struct load_mesh_result_t
     vierkant::MeshPtr mesh;
     std::unordered_map<vierkant::MaterialId, vierkant::material_t> materials;
 
-    std::unordered_map<vierkant::TextureId, vierkant::ImagePtr> textures;
+    //! GPU-textures keyed by {texture_id, sampler_id}; an entry per realized texture/sampler combination
+    std::unordered_map<vierkant::texture_key_t, vierkant::ImagePtr> textures;
     std::unordered_map<vierkant::SamplerId, vierkant::VkSamplerPtr> samplers;
 
     //! CPU-side OMM data; caller accumulates into a scene-level cache and passes to RayBuilder
@@ -250,5 +251,16 @@ vierkant::ImagePtr create_texture(const vierkant::DevicePtr &device, const croco
 vierkant::ImagePtr create_compressed_texture(const vierkant::DevicePtr &device,
                                              const vierkant::bcn::compress_result_t &compression_result,
                                              vierkant::Image::Format format, VkQueue load_queue);
+
+/**
+ * @brief   create_sampler creates a VkSampler from a texture_sampler_t descriptor.
+ *
+ * @param   device      handle to a vierkant::Device
+ * @param   ts          a texture_sampler_t descriptor
+ * @param   num_mips    number of mip-levels the sampler should address
+ * @return  a newly created, ref-counted VkSampler
+ */
+vierkant::VkSamplerPtr create_sampler(const vierkant::DevicePtr &device, const vierkant::texture_sampler_t &ts,
+                                      uint32_t num_mips);
 
 }// namespace vierkant::model

--- a/include/vierkant/physics_context.hpp
+++ b/include/vierkant/physics_context.hpp
@@ -430,7 +430,8 @@ class PhysicsScene : public vierkant::Scene
 public:
     ~PhysicsScene() override = default;
 
-    static std::shared_ptr<PhysicsScene> create(const std::shared_ptr<vierkant::ObjectStore> &object_store = {});
+    static std::shared_ptr<PhysicsScene> create(const std::shared_ptr<vierkant::ObjectStore> &object_store = {},
+                                                const vierkant::AssetProviderPtr &asset_provider = {});
 
     void add_object(const Object3DPtr &object) override;
 
@@ -444,7 +445,8 @@ public:
     [[nodiscard]] const vierkant::PhysicsContext &physics_context() const { return m_context; };
 
 private:
-    explicit PhysicsScene(const std::shared_ptr<vierkant::ObjectStore> &object_store);
+    explicit PhysicsScene(const std::shared_ptr<vierkant::ObjectStore> &object_store,
+                          const vierkant::AssetProviderPtr &asset_provider);
 
     crocore::ThreadPool m_thread_pool{std::thread::hardware_concurrency() - 1};
     vierkant::PhysicsContext m_context{&m_thread_pool};

--- a/src/AssetProvider.cpp
+++ b/src/AssetProvider.cpp
@@ -1,0 +1,78 @@
+#include <vierkant/AssetProvider.hpp>
+
+namespace vierkant
+{
+
+AssetProviderPtr AssetProvider::create(vierkant::DevicePtr device)
+{
+    return AssetProviderPtr(new AssetProvider(std::move(device)));
+}
+
+void AssetProvider::add_material(material_t m) { m_materials[m.id] = std::move(m); }
+
+const material_t *AssetProvider::material(const MaterialId &id) const
+{
+    auto it = m_materials.find(id);
+    return it != m_materials.end() ? &it->second : nullptr;
+}
+
+material_t *AssetProvider::material(const MaterialId &id)
+{
+    auto it = m_materials.find(id);
+    return it != m_materials.end() ? &it->second : nullptr;
+}
+
+void AssetProvider::add_texture(const texture_key_t &key, ImagePtr img) { m_textures[key] = std::move(img); }
+
+ImagePtr AssetProvider::texture(const texture_key_t &key) const
+{
+    auto it = m_textures.find(key);
+    return it != m_textures.end() ? it->second : nullptr;
+}
+
+VkSamplerPtr AssetProvider::sampler(const SamplerId &id) const
+{
+    auto it = m_samplers.find(id);
+    return it != m_samplers.end() ? it->second : nullptr;
+}
+
+VkSamplerPtr AssetProvider::get_or_create_sampler(const SamplerId &id, const texture_sampler_t &ts, uint32_t mip_levels)
+{
+    if(auto it = m_samplers.find(id); it != m_samplers.end()) { return it->second; }
+    auto sampler = model::create_sampler(m_device, ts, mip_levels);
+    m_samplers[id] = sampler;
+    return sampler;
+}
+
+const mesh_asset_t *AssetProvider::mesh_asset(const MeshId &id) const
+{
+    auto it = m_meshes.find(id);
+    return it != m_meshes.end() ? &it->second : nullptr;
+}
+
+void AssetProvider::add_mesh(const MeshId &id, mesh_asset_t asset) { m_meshes[id] = std::move(asset); }
+
+void AssetProvider::populate(const model::load_mesh_result_t &result)
+{
+    for(const auto &[id, mat]: result.materials) { m_materials[id] = mat; }
+    for(const auto &[key, img]: result.textures) { m_textures[key] = img; }
+    for(const auto &[id, vk_sampler]: result.samplers) { m_samplers[id] = vk_sampler; }
+
+    // attach mesh without a bundle; callers needing the persist-able bundle (physics) add_mesh afterwards
+    if(result.mesh) { m_meshes[result.mesh->id] = {.mesh = result.mesh}; }
+}
+
+void AssetProvider::prune(const asset_live_set_t &live)
+{
+    std::erase_if(m_materials, [&live](const auto &p) { return !live.materials.contains(p.first); });
+    std::erase_if(m_textures, [&live](const auto &p) { return !live.textures.contains(p.first); });
+    std::erase_if(m_samplers, [&live](const auto &p) { return !live.samplers.contains(p.first); });
+    std::erase_if(m_meshes, [&live](const auto &p) { return !live.meshes.contains(p.first); });
+}
+
+std::function<const mesh_asset_t *(MeshId)> AssetProvider::mesh_provider() const
+{
+    return [this](MeshId id) -> const mesh_asset_t * { return mesh_asset(id); };
+}
+
+}// namespace vierkant

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -398,7 +398,7 @@ void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr
                         const auto &material_ids =
                                 mesh_component->material_ids ? *mesh_component->material_ids : mesh->material_ids;
                         const auto &material_id = material_ids[entry.material_index];
-                        const auto *material = scene->material(material_id);
+                        const auto *material = scene->asset_provider()->material(material_id);
                         vierkant::update_material(material, drawable.material);
                     }
                 }

--- a/src/RayBuilder.cpp
+++ b/src/RayBuilder.cpp
@@ -165,7 +165,7 @@ RayBuilder::build_result_t RayBuilder::create_mesh_structures(const SceneConstPt
         if(entry.material_index < params.mesh->material_ids.size())
         {
             const auto &mesh_material_id = params.mesh->material_ids[entry.material_index];
-            material = scene->material(mesh_material_id);
+            material = scene->asset_provider()->material(mesh_material_id);
         }
 
         // throw on non-triangle entries
@@ -497,7 +497,7 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
             if(mesh_entry.material_index < material_ids.size())
             {
                 mesh_material_id = material_ids[mesh_entry.material_index];
-                mat = params.scene->material(mesh_material_id);
+                mat = params.scene->asset_provider()->material(mesh_material_id);
             }
 
             const auto &asset = acceleration_assets[i];
@@ -571,7 +571,7 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
 
                     for(const auto &[type_flag, tex_data]: mat->texture_data)
                     {
-                        const auto &tex = params.scene->texture(tex_data.texture_id);
+                        const auto &tex = params.scene->asset_provider()->texture({tex_data.texture_id, tex_data.sampler_id});
 
                         material.texture_type_flags |= static_cast<uint32_t>(type_flag);
 
@@ -881,7 +881,7 @@ RayBuilder::build_scene_acceleration(const scene_acceleration_context_ptr &conte
             if(!scene || !mesh || entry_index >= mesh->entries.size()) { return vierkant::TextureId::nil(); }
             const auto &entry = mesh->entries[entry_index];
             if(entry.material_index >= mesh->material_ids.size()) { return vierkant::TextureId::nil(); }
-            const auto *material = scene->material(mesh->material_ids[entry.material_index]);
+            const auto *material = scene->asset_provider()->material(mesh->material_ids[entry.material_index]);
             if(!material) { return vierkant::TextureId::nil(); }
             auto it = material->texture_data.find(vierkant::TextureType::Color);
             return it != material->texture_data.end() ? it->second.texture_id : vierkant::TextureId::nil();

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -60,15 +60,18 @@ vierkant::Object3DPtr Scene::create_camera(const vierkant::camera_params_variant
 }
 
 
-Scene::Scene(const std::shared_ptr<vierkant::ObjectStore> &object_store)
-    : m_object_store(object_store ? object_store : create_object_store())
+Scene::Scene(const std::shared_ptr<vierkant::ObjectStore> &object_store,
+             const vierkant::AssetProviderPtr &asset_provider)
+    : m_object_store(object_store ? object_store : create_object_store()),
+      m_asset_provider(asset_provider ? asset_provider : vierkant::AssetProvider::create({}))
 {
     m_root = m_object_store->create_object();
     m_root->name = s_scene_root_name;
 }
 
-ScenePtr Scene::create(const std::shared_ptr<vierkant::ObjectStore> &object_store)
-{ return ScenePtr(new Scene(object_store)); }
+ScenePtr Scene::create(const std::shared_ptr<vierkant::ObjectStore> &object_store,
+                       const vierkant::AssetProviderPtr &asset_provider)
+{ return ScenePtr(new Scene(object_store, asset_provider)); }
 
 void Scene::add_object(const Object3DPtr &object) { m_root->add_child(object); }
 
@@ -80,90 +83,35 @@ void Scene::clear()
     m_root->name = s_scene_root_name;
 }
 
-void Scene::add_material(material_t material) { m_material_data.materials[material.id] = std::move(material); }
-
-const material_t *Scene::material(const vierkant::MaterialId &material_id) const
+void Scene::prune_assets()
 {
-    if(const auto it = m_material_data.materials.find(material_id); it != m_material_data.materials.end())
-    {
-        return &it->second;
-    }
-    return nullptr;
-}
-
-material_t *Scene::material(const vierkant::MaterialId &material_id)
-{
-    if(const auto it = m_material_data.materials.find(material_id); it != m_material_data.materials.end())
-    {
-        return &it->second;
-    }
-    return nullptr;
-}
-
-const mesh_asset_t *Scene::mesh_asset(const vierkant::MeshId &mesh_id)
-{
-    if(const auto it = m_mesh_map.find(mesh_id); it != m_mesh_map.end()) { return &it->second; }
-    return nullptr;
-}
-
-void Scene::add_texture(const vierkant::TextureId &texture_id, const vierkant::ImagePtr &tex)
-{
-    // TODO: mutex?
-    m_texture_store[texture_id] = tex;
-}
-
-vierkant::ImagePtr Scene::texture(const vierkant::TextureId &texture_id) const
-{
-    if(const auto it = m_texture_store.find(texture_id); it != m_texture_store.end()) { return it->second; }
-    return nullptr;
-}
-
-void Scene::prune_unused_material_data()
-{
-    std::unordered_map<vierkant::MaterialId, vierkant::material_t> pruned_materials;
+    vierkant::asset_live_set_t live;
 
     LambdaVisitor visitor;
-    visitor.traverse(*root(), [this, &pruned_materials](auto &obj) {
+    visitor.traverse(*root(), [this, &live](auto &obj) {
         if(auto *mesh_cmp = obj.template get_component_ptr<vierkant::mesh_component_t>(); mesh_cmp && mesh_cmp->mesh)
         {
-            auto &material_ids = mesh_cmp->material_ids ? *mesh_cmp->material_ids : mesh_cmp->mesh->material_ids;
+            live.meshes.insert(mesh_cmp->mesh->id);
+
+            const auto &material_ids = mesh_cmp->material_ids ? *mesh_cmp->material_ids : mesh_cmp->mesh->material_ids;
             for(const auto &mat_id: material_ids)
             {
-                if(!pruned_materials.contains(mat_id))
+                if(!live.materials.insert(mat_id).second) { continue; }
+
+                if(const auto *mat = m_asset_provider->material(mat_id))
                 {
-                    if(auto *scene_mat = material(mat_id)) pruned_materials[mat_id] = std::move(*scene_mat);
+                    for(const auto &tex_data: mat->texture_data | std::views::values)
+                    {
+                        live.textures.insert({tex_data.texture_id, tex_data.sampler_id});
+                        if(tex_data.sampler_id) { live.samplers.insert(tex_data.sampler_id); }
+                    }
                 }
             }
         }
         return true;
     });
 
-    std::unordered_map<vierkant::TextureId, vierkant::texture_variant_t> pruned_textures;
-    std::unordered_map<vierkant::TextureId, vierkant::ImagePtr> pruned_tex_store;
-
-    for(const auto &mat: pruned_materials | std::views::values)
-    {
-        for(const auto &tex_data: mat.texture_data | std::views::values)
-        {
-            if(!pruned_tex_store.contains(tex_data.texture_id))
-            {
-                if(auto tex = texture(tex_data.texture_id))
-                {
-                    if(m_material_data.textures.contains(tex_data.texture_id))
-                    {
-                        pruned_textures[tex_data.texture_id] = m_material_data.textures[tex_data.texture_id];
-                    }
-
-                    pruned_tex_store[tex_data.texture_id] = std::move(tex);
-                }
-            }
-        }
-    }
-
-    // move back
-    m_material_data.materials = std::move(pruned_materials);
-    m_material_data.textures = std::move(pruned_textures);
-    m_texture_store = std::move(pruned_tex_store);
+    m_asset_provider->prune(live);
 }
 
 void Scene::update(double time_delta)

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -48,8 +48,7 @@ public:
 
                 // create drawables
                 vierkant::create_mesh_drawables_params_t drawable_params = {};
-                drawable_params.material_data = m_scene->material_data();
-                drawable_params.texture_store = m_scene->texture_store();
+                drawable_params.assets = m_scene->asset_provider().get();
                 drawable_params.transform = model_view;
 
                 if(object.has_component<animation_component_t>())

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -2,6 +2,7 @@
 // Created by crocdialer on 04.10.22.
 //
 
+#include <vierkant/AssetProvider.hpp>
 #include <vierkant/Rasterizer.hpp>
 #include <vierkant/drawable.hpp>
 
@@ -76,14 +77,10 @@ std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_com
         auto mesh_material_id = MaterialId::nil();
 
         // sanity check material-index
-        if(params.material_data && entry.material_index < material_ids.size())
+        if(params.assets && entry.material_index < material_ids.size())
         {
             mesh_material_id = material_ids[entry.material_index];
-            if(auto mat_it = params.material_data->materials.find(mesh_material_id);
-               mat_it != params.material_data->materials.end())
-            {
-                material = &mat_it->second;
-            }
+            material = params.assets->material(mesh_material_id);
         }
 
         // acquire ref for mesh-drawable
@@ -160,10 +157,10 @@ std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_com
 
             for(auto &[type_flag, tex_data]: material->texture_data)
             {
-                if(auto tex_it = params.texture_store->find(tex_data.texture_id); tex_it != params.texture_store->end())
+                if(auto tex = params.assets->texture({tex_data.texture_id, tex_data.sampler_id}))
                 {
                     drawable.material.texture_type_flags |= static_cast<uint32_t>(type_flag);
-                    desc_texture.images.push_back(tex_it->second);
+                    desc_texture.images.push_back(tex);
                 }
             }
         }

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -3,6 +3,7 @@
 //
 
 #include <cmath>
+#include <ranges>
 
 
 #include <vierkant/PBRDeferred.hpp>
@@ -588,16 +589,18 @@ void draw_scene_ui(const ScenePtr &scene, Object3DPtr &camera, std::set<vierkant
     }
     if(ImGui::BeginTabItem("materials"))
     {
-        if(ImGui::Button("prune unused")) { scene->prune_unused_material_data(); }
+        if(ImGui::Button("prune unused")) { scene->prune_assets(); }
 
-        for(auto &[mat_id, mat]: scene->m_material_data.materials)
+        for(const auto &mat_id: std::views::keys(scene->asset_provider()->materials()))
         {
+            auto &mat = *scene->asset_provider()->material(mat_id);
+
             auto draw_texture = [&scene, &mat](vierkant::TextureType type, const std::string &text) {
                 if(const auto it = mat.texture_data.find(type); it != mat.texture_data.end())
                 {
                     const auto &tex_data = it->second;
 
-                    if(const auto img = scene->texture(tex_data.texture_id))
+                    if(const auto img = scene->asset_provider()->texture({tex_data.texture_id, tex_data.sampler_id}))
                     {
                         constexpr uint32_t buf_size = 16;
                         char buf[buf_size];
@@ -644,8 +647,18 @@ void draw_scene_ui(const ScenePtr &scene, Object3DPtr &camera, std::set<vierkant
         const float cell_width = thumb_size + thumb_padding;
         const int cols = std::max(1, static_cast<int>(ImGui::GetContentRegionAvail().x / cell_width));
 
+        // dedupe the composite-keyed store by texture-id; prefer the {id, nil} base representative
+        std::map<vierkant::TextureId, vierkant::ImagePtr> unique_textures;
+        for(const auto &[key, texture]: scene->asset_provider()->textures())
+        {
+            if(!unique_textures.contains(key.texture_id) || !key.sampler_id)
+            {
+                unique_textures[key.texture_id] = texture;
+            }
+        }
+
         int col = 0;
-        for(const auto &[texture_id, texture]: scene->m_texture_store)
+        for(const auto &[texture_id, texture]: unique_textures)
         {
             if(col > 0) { ImGui::SameLine(0.0f, thumb_padding); }
 
@@ -681,7 +694,7 @@ void draw_scene_ui(const ScenePtr &scene, Object3DPtr &camera, std::set<vierkant
         }
         ImGui::PopStyleVar(2);
 
-        if(const auto it = scene->m_texture_store.find(selected_texture_id); it != scene->m_texture_store.end())
+        if(const auto it = unique_textures.find(selected_texture_id); it != unique_textures.end())
         {
             const auto &[texture_id, texture] = *it;
             ImGui::Separator();
@@ -789,8 +802,11 @@ bool draw_material_ui(vierkant::material_t &material,
         if(ImGui::InputText("texture-id:", text_buf, buf_size, ImGuiInputTextFlags_EnterReturnsTrue))
         {
             changed = true;
-            auto new_tex_id = TextureId::from_string(text_buf);
-            material.texture_data[type].texture_id = new_tex_id;
+            auto &tex_data = material.texture_data[type];
+            tex_data.texture_id = TextureId::from_string(text_buf);
+
+            // a hand-assigned raw texture has no realized sampler-permutation -> resolve to the {id, nil} base
+            tex_data.sampler_id = SamplerId::nil();
         }
         ImGui::PopID();
     };
@@ -921,14 +937,14 @@ bool draw_material_ui(vierkant::material_t &material,
 bool draw_material_ui(const vierkant::ScenePtr &scene, const MaterialId &material_id)
 {
     const float w = ImGui::GetContentRegionAvail().x;
-    auto *material = scene->material(material_id);
+    auto *material = scene->asset_provider()->material(material_id);
 
     auto draw_texture = [&scene, material, w](vierkant::TextureType type, const std::string &text) {
         if(const auto it = material->texture_data.find(type); it != material->texture_data.end())
         {
             const auto &tex_data = it->second;
 
-            if(const auto img = scene->texture(tex_data.texture_id))
+            if(const auto img = scene->asset_provider()->texture({tex_data.texture_id, tex_data.sampler_id}))
             {
                 constexpr uint32_t buf_size = 16;
                 char buf[buf_size];
@@ -1063,7 +1079,7 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
                     auto new_mat_id = vierkant::MaterialId::from_string(text_buf);
 
                     // check if material is defined
-                    if(scene->material(new_mat_id))
+                    if(scene->asset_provider()->material(new_mat_id))
                     {
                         // create material_id override, if necessary
                         if(!mesh_component.material_ids)
@@ -1101,7 +1117,7 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
         {
             const auto &mesh_material_id = material_ids[i];
 
-            if(const auto *mat = scene->material(mesh_material_id))
+            if(const auto *mat = scene->asset_provider()->material(mesh_material_id))
             {
                 auto mat_name = mat->name.empty() ? std::to_string(i) : mat->name;
 

--- a/src/model/model_loading.cpp
+++ b/src/model/model_loading.cpp
@@ -332,29 +332,25 @@ model::load_mesh_result_t load_mesh(const load_mesh_params_t &params,
     // node animations
     ret.mesh->node_animations = mesh_assets.node_animations;
 
-    // generate textures with default samplers
+    // generate base-textures under their default-sampler key {texture_id, nil}
     for(const auto &[id, tex_variant]: mesh_assets.textures)
     {
         std::visit(
                 [&params, tex_id = id, &ret, &create_texture](auto &&img) {
                     using T = std::decay_t<decltype(img)>;
+                    texture_key_t key = {tex_id, vierkant::SamplerId::nil()};
 
-                    if constexpr(std::is_same_v<T, crocore::ImagePtr>) { ret.textures[tex_id] = create_texture(img); }
+                    if constexpr(std::is_same_v<T, crocore::ImagePtr>) { ret.textures[key] = create_texture(img); }
                     else if constexpr(std::is_same_v<T, vierkant::bcn::compress_result_t>)
                     {
                         vierkant::Image::Format fmt;
                         fmt.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
                         fmt.max_anisotropy = params.device->properties().core.limits.maxSamplerAnisotropy;
-                        ret.textures[tex_id] = create_compressed_texture(params.device, img, fmt, params.load_queue);
+                        ret.textures[key] = create_compressed_texture(params.device, img, fmt, params.load_queue);
                     }
                 },
                 tex_variant);
     }
-
-    // cache required texture/sampler combinations
-    std::unordered_map<std::pair<TextureId, SamplerId>, std::pair<TextureId, ImagePtr>,
-                       vierkant::pair_hash<TextureId, SamplerId>>
-            id_permutation_cache;
 
     ret.mesh->material_ids.resize(mesh_assets.materials.size());
 
@@ -363,53 +359,44 @@ model::load_mesh_result_t load_mesh(const load_mesh_params_t &params,
         const auto &asset_mat = mesh_assets.materials[i];
         ret.mesh->material_ids[i] = asset_mat.id;
 
-        auto &material = ret.materials[asset_mat.id];
-        material = asset_mat;
+        // no material-mutation: ids stay stable, drawable resolves textures by {texture_id, sampler_id}
+        ret.materials[asset_mat.id] = asset_mat;
 
-        for(auto &[tex_type, tex_data]: material.texture_data)
+        for(const auto &[tex_type, tex_data]: asset_mat.texture_data)
         {
-            // optional sampler-override
-            if(tex_data.sampler_id)
+            // sampler_id nil -> base image under {texture_id, nil} already exists
+            if(!tex_data.sampler_id) { continue; }
+
+            texture_key_t key = {tex_data.texture_id, tex_data.sampler_id};
+            if(ret.textures.contains(key)) { continue; }
+
+            auto base_it = ret.textures.find({tex_data.texture_id, vierkant::SamplerId::nil()});
+            if(base_it == ret.textures.end()) { continue; }
+            auto base_img = base_it->second;
+
+            // get-or-create one VkSampler per SamplerId
+            vierkant::VkSamplerPtr vk_sampler;
+            if(auto sampler_it = ret.samplers.find(tex_data.sampler_id); sampler_it != ret.samplers.end())
             {
-                auto vk_img = ret.textures[tex_data.texture_id];
-                auto tex_id = tex_data.texture_id;
-                auto cache_key = std::make_pair(tex_data.texture_id, tex_data.sampler_id);
-
-                // check cache-entry, clone img if necessary
-                if(auto cache_it = id_permutation_cache.find(cache_key); cache_it != id_permutation_cache.end())
-                {
-                    const auto &[cache_id, cache_img] = cache_it->second;
-                    vk_img = cache_img;
-                    tex_id = cache_id;
-                }
-                else
-                {
-                    vk_img = ret.textures[tex_data.texture_id]->clone();
-                    tex_id = TextureId::random();
-
-                    // store in cache
-                    id_permutation_cache[cache_key] = {tex_id, vk_img};
-
-                    // store permutation with new id
-                    ret.textures[tex_id] = vk_img;
-
-                    // overwrite original texture-id here, not sure
-                    // tex_data.texture_id = tex_id;
-
-                    if(auto sampler_it = mesh_assets.texture_samplers.find(tex_data.sampler_id);
-                       sampler_it != mesh_assets.texture_samplers.end())
-                    {
-                        auto vk_sampler = create_sampler(params.device, sampler_it->second, vk_img->num_mip_levels());
-                        vk_img->set_sampler(vk_sampler);
-                        ret.samplers[tex_data.sampler_id] = vk_sampler;
-                    }
-                    else
-                    {
-                        spdlog::warn("material '{}' references sampler '{}', but could not find in bundle",
-                                     asset_mat.name, tex_data.sampler_id.str());
-                    }
-                }
+                vk_sampler = sampler_it->second;
             }
+            else if(auto desc_it = mesh_assets.texture_samplers.find(tex_data.sampler_id);
+                    desc_it != mesh_assets.texture_samplers.end())
+            {
+                vk_sampler = create_sampler(params.device, desc_it->second, base_img->num_mip_levels());
+                ret.samplers[tex_data.sampler_id] = vk_sampler;
+            }
+            else
+            {
+                spdlog::warn("material '{}' references sampler '{}', but could not find in bundle", asset_mat.name,
+                             tex_data.sampler_id.str());
+                continue;
+            }
+
+            // realize the sampled permutation under the composite key
+            auto vk_img = base_img->clone();
+            vk_img->set_sampler(vk_sampler);
+            ret.textures[key] = vk_img;
         }
     }
 

--- a/src/physics_context.cpp
+++ b/src/physics_context.cpp
@@ -1608,10 +1608,14 @@ void PhysicsScene::update(double time_delta)
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-std::shared_ptr<PhysicsScene> PhysicsScene::create(const std::shared_ptr<vierkant::ObjectStore> &object_store)
-{ return std::shared_ptr<PhysicsScene>(new PhysicsScene(object_store)); }
+std::shared_ptr<PhysicsScene> PhysicsScene::create(const std::shared_ptr<vierkant::ObjectStore> &object_store,
+                                                   const vierkant::AssetProviderPtr &asset_provider)
+{ return std::shared_ptr<PhysicsScene>(new PhysicsScene(object_store, asset_provider)); }
 
-PhysicsScene::PhysicsScene(const std::shared_ptr<vierkant::ObjectStore> &object_store) : Scene(object_store) {}
+PhysicsScene::PhysicsScene(const std::shared_ptr<vierkant::ObjectStore> &object_store,
+                           const vierkant::AssetProviderPtr &asset_provider)
+    : Scene(object_store, asset_provider)
+{}
 
 }//namespace vierkant
 

--- a/tests/TestAssetProvider.cpp
+++ b/tests/TestAssetProvider.cpp
@@ -1,0 +1,120 @@
+#include "test_context.hpp"
+#include "vierkant/AssetProvider.hpp"
+#include "vierkant/PBRDeferred.hpp"
+#include "vierkant/model/model_loading.hpp"
+#include "vierkant/vierkant.hpp"
+
+//! build a minimal model_assets_t: a box + one generated texture + a material referencing it
+//! with a non-default sampler-override.
+static vierkant::model::model_assets_t create_test_assets(vierkant::TextureId tex_id, vierkant::SamplerId sampler_id,
+                                                          vierkant::MaterialId mat_id)
+{
+    vierkant::model::model_assets_t assets = {};
+
+    vierkant::Mesh::entry_create_info_t entry_info = {};
+    entry_info.geometry = vierkant::Geometry::Box();
+    entry_info.material_index = 0;
+    assets.geometry_data = std::vector{entry_info};
+
+    // one generated texture
+    assets.textures[tex_id] = crocore::Image_<uint8_t>::create(4, 4, 4);
+
+    // a non-default sampler (default address-mode is REPEAT)
+    vierkant::texture_sampler_t sampler = {};
+    sampler.address_mode_u = vierkant::texture_sampler_t::AddressMode::CLAMP_TO_EDGE;
+    sampler.address_mode_v = vierkant::texture_sampler_t::AddressMode::CLAMP_TO_EDGE;
+    assets.texture_samplers[sampler_id] = sampler;
+
+    // a material referencing the texture with the sampler-override
+    vierkant::material_t material = {};
+    material.id = mat_id;
+    material.texture_data[vierkant::TextureType::Color] = {.texture_id = tex_id, .sampler_id = sampler_id};
+    assets.materials = {material};
+
+    return assets;
+}
+
+// exercises the load -> populate seam in-repo and regression-guards the {texture_id, sampler_id} store
+TEST(TestAssetProvider, populate_sampler_override)
+{
+    vulkan_test_context_t test_context;
+
+    const auto tex_id = vierkant::TextureId::random();
+    const auto sampler_id = vierkant::SamplerId::random();
+    const auto mat_id = vierkant::MaterialId::random();
+    auto assets = create_test_assets(tex_id, sampler_id, mat_id);
+
+    vierkant::model::load_mesh_params_t load_params = {};
+    load_params.device = test_context.device;
+    load_params.load_queue = test_context.device->queue();
+    auto result = vierkant::model::load_mesh(load_params, assets);
+    ASSERT_TRUE(result.mesh);
+
+    // load_mesh should realize both the base {tex, nil} and the sampled permutation {tex, sampler}
+    const vierkant::texture_key_t base_key = {tex_id, vierkant::SamplerId::nil()};
+    const vierkant::texture_key_t sampled_key = {tex_id, sampler_id};
+    ASSERT_TRUE(result.textures.contains(base_key));
+    ASSERT_TRUE(result.textures.contains(sampled_key));
+    ASSERT_TRUE(result.samplers.contains(sampler_id));
+
+    auto provider = vierkant::AssetProvider::create(test_context.device);
+    provider->populate(result);
+
+    // material survived the merge unmodified
+    const auto *material = provider->material(mat_id);
+    ASSERT_NE(material, nullptr);
+    EXPECT_EQ(material->texture_data.at(vierkant::TextureType::Color).texture_id, tex_id);
+    EXPECT_EQ(material->texture_data.at(vierkant::TextureType::Color).sampler_id, sampler_id);
+
+    // both texture variants live in the provider, and the override is a distinct image/sampler
+    auto base_img = provider->texture(base_key);
+    auto sampled_img = provider->texture(sampled_key);
+    ASSERT_TRUE(base_img);
+    ASSERT_TRUE(sampled_img);
+    EXPECT_NE(base_img, sampled_img);
+    EXPECT_TRUE(sampled_img->sampler());
+    EXPECT_NE(base_img->sampler(), sampled_img->sampler());
+
+    // the provider owns the get-or-create'd sampler, baked onto the sampled image
+    EXPECT_EQ(provider->sampler(sampler_id), sampled_img->sampler());
+
+    // g-buffer uses fragment-shader barycentric intrinsics; drivers lacking it (e.g. lavapipe) coredump
+    if(!vierkant::check_device_extension_support(test_context.instance.physical_devices()[0],
+                                                 {VK_KHR_FRAGMENT_SHADER_BARYCENTRIC_EXTENSION_NAME}))
+    {
+        GTEST_SKIP() << "device lacks VK_KHR_fragment_shader_barycentric; skipping render";
+    }
+
+    // drive the loaded assets through one PBRDeferred::render_scene
+    const glm::vec2 res(512, 512);
+    vierkant::Rasterizer::create_info_t rasterizer_info = {};
+    rasterizer_info.num_frames_in_flight = 1;
+    rasterizer_info.sample_count = VK_SAMPLE_COUNT_1_BIT;
+    rasterizer_info.viewport = {0.f, 0.f, res.x, res.y, 0.f, 1.f};
+    auto renderer = vierkant::Rasterizer(test_context.device, rasterizer_info);
+
+    auto scene = vierkant::Scene::create({}, provider);
+    auto cam = scene->create_object();
+    cam->add_component<vierkant::camera_component_t>({vierkant::physical_camera_params_t{}});
+    auto mesh_node = scene->create_mesh_object({result.mesh});
+    scene->add_object(mesh_node);
+
+    vierkant::PBRDeferred::create_info_t pbr_render_info = {};
+    pbr_render_info.num_frames_in_flight = 2;
+    pbr_render_info.settings.resolution = res;
+    pbr_render_info.settings.indirect_draw = false;
+    auto pbr_renderer = vierkant::PBRDeferred::create(test_context.device, pbr_render_info);
+    ASSERT_TRUE(pbr_renderer);
+
+    vierkant::Framebuffer::create_info_t framebuffer_info = {};
+    framebuffer_info.size = {static_cast<uint32_t>(res.x), static_cast<uint32_t>(res.y), 1};
+    vierkant::Framebuffer framebuffer(test_context.device, framebuffer_info);
+
+    auto render_result = pbr_renderer->render_scene(renderer, scene, cam, {});
+    VkCommandBuffer cmd_buffer = renderer.render(framebuffer);
+    EXPECT_EQ(render_result.num_draws, 1);
+    ASSERT_TRUE(cmd_buffer);
+
+    framebuffer.submit({cmd_buffer}, test_context.device->queue(), render_result.semaphore_infos);
+    framebuffer.wait_fence();
+}


### PR DESCRIPTION
- new AssetProvider: owns materials/textures/samplers/meshes (GPU-side)
- textures keyed by {texture_id, sampler_id}; finishes sampler-override path in load_mesh (fixes override never rendering)
- Scene holds injectable AssetProvider, drops m_material_data/ m_texture_store/m_mesh_map; prune_unused_material_data -> prune_assets (reaps samplers + meshes too)
- drawable/culling/RayBuilder/PBRDeferred/imgui resolve via provider
- physics meshes via provider->mesh_provider()
- imgui textures-tab dedupes by texture-id; paste clears sampler_id
- texture_key_t + hash in Material.hpp; export model::create_sampler
- tests: TestAssetProvider covers load -> populate -> render