### PR TITLE
Camera/Media support

### DIFF
--- a/include/vierkant/PBRPathTracer.hpp
+++ b/include/vierkant/PBRPathTracer.hpp
@@ -312,7 +312,8 @@ private:
     void update_acceleration_structures(frame_context_t &frame_context, const SceneConstPtr &scene,
                                         const std::set<std::string> &tags);
 
-    void update_trace_descriptors(frame_context_t &frame_context, const Object3DPtr &cam);
+    void update_trace_descriptors(frame_context_t &frame_context, const vierkant::SceneConstPtr &scene,
+                                  const Object3DPtr &cam);
 
     void path_trace_pass(frame_context_t &frame_context, const vierkant::SceneConstPtr &scene, const Object3DPtr &cam);
 

--- a/include/vierkant/PBRPathTracer.hpp
+++ b/include/vierkant/PBRPathTracer.hpp
@@ -4,6 +4,7 @@
 #pragma once
 
 #include <deque>
+#include <optional>
 #include <vierkant/Bloom.hpp>
 #include <vierkant/Compute.hpp>
 #include <vierkant/DrawContext.hpp>
@@ -13,6 +14,7 @@
 #include <vierkant/SceneRenderer.hpp>
 #include <vierkant/Semaphore.hpp>
 #include <vierkant/culling.hpp>
+#include <vierkant/media.hpp>
 #include <vierkant/mesh_compute.hpp>
 
 
@@ -77,6 +79,10 @@ public:
 
         //! suppress accumulator resets (e.g. caused by scene/camera changes)
         bool suppress_reset = false;
+
+        //! optional global medium the camera is submerged in (fog/underwater/haze).
+        //! when set, seeds the path-tracer's media-stack so rays start inside this medium.
+        std::optional<medium_params_t> camera_medium;
 
         //! max number stored timing-values
         uint32_t timing_history_size = 300;
@@ -241,6 +247,9 @@ private:
 
         //! optionally clamp indirect path-throughput
         float max_path_beta = 0.f;
+
+        //! flag: camera starts inside 'camera_media' (seed media-stack, disable back-face culling)
+        uint32_t camera_inside_media = false;
     };
 
     struct denoise_params_t
@@ -260,14 +269,6 @@ private:
         float aperture = 0.f;
         float focal_distance = 1.f;
         VkBool32 ortho = false;
-    };
-
-    struct alignas(16) media_t
-    {
-        glm::vec3 sigma_s = glm::vec3(0.f);
-        float ior = 1.f;
-        glm::vec3 sigma_a = glm::vec3(0.f);
-        float phase_g = 0.f;
     };
 
     struct sunlight_params_t

--- a/include/vierkant/intersection.hpp
+++ b/include/vierkant/intersection.hpp
@@ -367,11 +367,11 @@ struct OBB
 
     [[nodiscard]] inline bool contains(const glm::vec3 &p) const
     {
-        // point in axis space
-        glm::vec3 p_in_axis_space = axis * (p - center);
-        return std::abs(p_in_axis_space.x) < half_lengths.x && std::abs(p_in_axis_space.y) < half_lengths.y &&
-               std::abs(p_in_axis_space.z) < half_lengths.z;
-    };
+        // project (p - center) onto each box-axis (same convention as intersect(OBB, Ray))
+        const glm::vec3 d = p - center;
+        return std::abs(glm::dot(axis[0], d)) < half_lengths.x && std::abs(glm::dot(axis[1], d)) < half_lengths.y &&
+               std::abs(glm::dot(axis[2], d)) < half_lengths.z;
+    }
 };
 
 //! see https://www.gamedevs.org/uploads/fast-extraction-viewing-frustum-planes-from-world-view-projection-matrix.pdf

--- a/include/vierkant/media.hpp
+++ b/include/vierkant/media.hpp
@@ -1,0 +1,48 @@
+//
+// participating-media description + conversion, shared by host and path-tracer shader.
+//
+
+#pragma once
+
+#include <vierkant/math.hpp>
+
+namespace vierkant
+{
+
+//! participating-medium description (matches the shader-side ray::media_t)
+struct alignas(16) media_t
+{
+    glm::vec3 sigma_s = glm::vec3(0.f);
+    float ior = 1.f;
+    glm::vec3 sigma_a = glm::vec3(0.f);
+    float phase_g = 0.f;
+};
+
+//! material-facing volume parameters (subset of vierkant::Material), the input the user/geometry
+//! provides. converted to a media_t via to_media(). defaults describe a mild absorbing haze.
+struct medium_params_t
+{
+    //! fraction of light transmitted over 'attenuation_distance' (Beer-Lambert), per channel
+    glm::vec3 attenuation_color = glm::vec3(0.7f);
+
+    //! distance over which 'attenuation_color' is applied
+    float attenuation_distance = 1.f;
+
+    //! overall scattering strength [0, 1] (glTF KHR_materials_scatter scatterFactor)
+    float scatter_factor = 0.f;
+
+    //! multi-scatter albedo / scattering tint (glTF multiscatterColorFactor)
+    glm::vec3 scatter_color = glm::vec3(1.f);
+
+    //! phase-function asymmetry (forward- vs. back-scattering) [-1, 1]
+    float phase_asymmetry_g = 0.f;
+
+    //! index of refraction of the medium
+    float ior = 1.f;
+};
+
+//! convert material-facing volume-parameters into a media_t, mirroring the path-tracer shader
+//! (raypipeline.slang). single host-side helper so inside/outside appearance can't drift.
+media_t to_media(const medium_params_t &params);
+
+}// namespace vierkant

--- a/scripts/dispersion_constants.py
+++ b/scripts/dispersion_constants.py
@@ -1,0 +1,59 @@
+#!/usr/bin/env python3
+"""Derive the baked constants for continuous-wavelength dispersion.
+
+Re-run this if the band limits, the CMF fit, or the dispersion->spread relation
+change. The two outputs are pasted into shaders/slang/utils/bsdf.slang:
+  - LAMBDA_RGB_NORM : per-channel white-balance k (uniform-lambda avg -> white)
+  - the Cauchy B factor used by cauchy_ior()
+
+CMF fit: Wyman, Sloan & Shirley, "Simple Analytic Approximations to the CIE XYZ
+Color Matching Functions", JCGT 2013 (multi-lobe Gaussian fit).
+"""
+import math
+
+BAND_LO, BAND_HI = 400.0, 700.0  # nm
+
+def g(x, mu, s1, s2):
+    s = s1 if x < mu else s2
+    t = (x - mu) / s
+    return math.exp(-0.5 * t * t)
+
+def cie_xyz(l):
+    X = 1.056 * g(l, 599.8, 37.9, 31.0) + 0.362 * g(l, 442.0, 16.0, 26.7) - 0.065 * g(l, 501.1, 20.4, 26.2)
+    Y = 0.821 * g(l, 568.8, 46.9, 40.5) + 0.286 * g(l, 530.9, 16.3, 31.1)
+    Z = 1.217 * g(l, 437.0, 11.8, 36.0) + 0.681 * g(l, 459.0, 26.0, 13.8)
+    return (X, Y, Z)
+
+def xyz_to_rec709(X, Y, Z):
+    # same matrix as XYZ_TO_REC709 in utils/bsdf.slang
+    R =  3.2404542 * X - 1.5371385 * Y - 0.4985314 * Z
+    G = -0.9692660 * X + 1.8760108 * Y + 0.0415560 * Z
+    B =  0.0556434 * X - 0.2040259 * Y + 1.0572252 * Z
+    return (R, G, B)
+
+def lambda_to_rgb(l):
+    # clamp out-of-gamut negatives: saturated spectral colors lie outside sRGB, and any negative
+    # throughput gets clipped downstream (accumulation/denoiser), which would bias the average.
+    return tuple(max(c, 0.0) for c in xyz_to_rec709(*cie_xyz(l)))
+
+if __name__ == "__main__":
+    # --- per-channel white balance: (1/band) * integral(k * rgb(l)) == (1,1,1) ---
+    N = 30000
+    acc = [0.0, 0.0, 0.0]
+    for i in range(N):
+        l = BAND_LO + (i + 0.5) * (BAND_HI - BAND_LO) / N
+        rgb = lambda_to_rgb(l)
+        for c in range(3):
+            acc[c] += rgb[c]
+    mean = [a / N for a in acc]
+    k = [1.0 / m for m in mean]
+    print(f"band [{BAND_LO:.0f}, {BAND_HI:.0f}] nm")
+    print(f"mean rgb over band : {mean}")
+    print(f"LAMBDA_RGB_NORM (k): float3({k[0]:.6f}, {k[1]:.6f}, {k[2]:.6f})")
+
+    # --- Cauchy n(l) = A + B/l^2, B fit to glTF dispersion at the F/C lines ---
+    #   n(lF) - n(lC) = 2 * half_spread  =>  B = 2 * half_spread / (1/lF^2 - 1/lC^2)
+    lF, ld, lC = 486.1, 587.6, 656.3  # F (blue), d (yellow ref), C (red) lines
+    factor = 2.0 / (1.0 / lF**2 - 1.0 / lC**2)
+    print(f"\nCauchy: B = {factor:.1f} * half_spread   (half_spread = (ior-1)*0.025*dispersion)")
+    print(f"        A = ior - B / {ld}^2")

--- a/shaders/slang/ray/ray_common.slang
+++ b/shaders/slang/ray/ray_common.slang
@@ -133,7 +133,10 @@ public struct trace_params_t
     //! clamp indirect path-throughput
     public float max_path_beta;
 
-    private int pad0, pad1, pad2;
+    //! camera starts inside 'camera_media' (seed media-stack, disable back-face culling)
+    public bool camera_inside_media;
+
+    private int pad1, pad2;
 };
 
 public struct camera_ubo_t

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -107,7 +107,23 @@ trace_result_t trace(uint2 coord, uint2 size)
 
         uint media_index = 0;
         ray::media_t media[MAX_MEDIA_STACK_SIZE];
-        media[media_index] = trace_data.camera_media;
+
+        // media[0] is always vacuum/air; leaving any medium returns here.
+        ray::media_t vacuum_media;
+        vacuum_media.sigma_s = float3(0);
+        vacuum_media.ior = 1.0;
+        vacuum_media.sigma_a = float3(0);
+        vacuum_media.phase_g = 0.0;
+        media[0] = vacuum_media;
+
+        // when the camera starts submerged, push its medium as the current one. seeding
+        // media_index = 1 also disables back-face culling below, so the surrounding
+        // volume's inner walls are visible and can 'Leave' back into air.
+        if(trace_data.params.camera_inside_media)
+        {
+            media_index = 1;
+            media[media_index] = trace_data.camera_media;
+        }
 
         float3 beta = float3(1);
         float3 path_radiance = float3(0);

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -520,8 +520,13 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
 
     trace_data.camera_params = camera_params;
 
-    // default media: air
+    // default media: air. optionally submerge the camera in a global medium.
     trace_data.camera_media = {};
+    if(frame_context.settings.camera_medium)
+    {
+        trace_data.camera_media = vierkant::to_media(*frame_context.settings.camera_medium);
+        trace_data.trace_params.camera_inside_media = true;
+    }
 
     // optional sunlight
     // trace_data.sunlight_params.color = {1.f, 0.6f, 0.4f};

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -286,8 +286,7 @@ void PBRPathTracer::pre_render(PBRPathTracer::frame_context_t &frame_context)
     timings.total_ms = timings.raybuilder_timings.total_ms;
     if(gpu_start && gpu_end >= gpu_start)
     {
-        timings.total_ms +=
-                timestamp_diff(gpu_start, gpu_end, m_device->properties().core.limits.timestampPeriod);
+        timings.total_ms += timestamp_diff(gpu_start, gpu_end, m_device->properties().core.limits.timestampPeriod);
     }
 
     m_statistics.push_back(frame_context.statistics);
@@ -304,10 +303,10 @@ void PBRPathTracer::pre_render(PBRPathTracer::frame_context_t &frame_context)
     frame_context.cmd_pre_render.submit(m_queue);
 }
 
-void PBRPathTracer::path_trace_pass(frame_context_t &frame_context, const vierkant::SceneConstPtr & /*scene*/,
+void PBRPathTracer::path_trace_pass(frame_context_t &frame_context, const vierkant::SceneConstPtr &scene,
                                     const Object3DPtr &cam)
 {
-    update_trace_descriptors(frame_context, cam);
+    update_trace_descriptors(frame_context, scene, cam);
 
     frame_context.cmd_trace.begin(0);
     vkCmdWriteTimestamp2(frame_context.cmd_trace.handle(), VK_PIPELINE_STAGE_2_TOP_OF_PIPE_BIT,
@@ -460,7 +459,65 @@ void PBRPathTracer::post_fx_pass(frame_context_t &frame_context)
     }
 }
 
-void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, const Object3DPtr &cam)
+//! auto-detect a medium the camera is submerged in: the innermost (smallest world-OBB) volumetric
+//! object containing the camera position. mirrors the shader's 'has_volume' test
+//! (finite attenuation_distance). OBB containment is exact for rotated boxes but still loose for
+//! concave hulls; exactly covers the common 'large box with a volumetric material' case.
+static std::optional<vierkant::medium_params_t> detect_camera_medium(const vierkant::SceneConstPtr &scene,
+                                                                     const vierkant::Object3DPtr &cam)
+{
+    const glm::vec3 cam_pos = cam->global_transform().translation;
+
+    std::optional<vierkant::medium_params_t> result;
+    float best_volume = std::numeric_limits<float>::max();
+
+    vierkant::SelectVisitor<Object3D> visitor;
+    scene->root()->accept(visitor);
+
+    for(const auto *object: visitor.objects)
+    {
+        if(!object->has_component<vierkant::mesh_component_t>()) { continue; }
+
+        // world-space OBB containment test
+        auto world_obb = object->obb().transform(vierkant::mat4_cast(object->global_transform()));
+        if(!world_obb.contains(cam_pos)) { continue; }
+
+        const glm::vec3 &h = world_obb.half_lengths;
+        float volume = 8.f * h.x * h.y * h.z;
+        if(volume >= best_volume) { continue; }
+
+        // find a volumetric material (finite attenuation_distance) among this object's entries
+        const auto &mesh_component = object->get_component<vierkant::mesh_component_t>();
+        const auto &mesh = mesh_component.mesh;
+        if(!mesh) { continue; }
+        const auto &material_ids = mesh_component.material_ids ? *mesh_component.material_ids : mesh->material_ids;
+
+        for(uint32_t i = 0; i < mesh->entries.size(); ++i)
+        {
+            if(mesh_component.entry_indices && !mesh_component.entry_indices->contains(i)) { continue; }
+            const auto material_index = mesh->entries[i].material_index;
+            if(material_index >= material_ids.size()) { continue; }
+
+            const auto *mat = scene->asset_provider()->material(material_ids[material_index]);
+            if(!mat || std::isinf(mat->attenuation_distance)) { continue; }
+
+            vierkant::medium_params_t params;
+            params.attenuation_color = mat->attenuation_color;
+            params.attenuation_distance = mat->attenuation_distance;
+            params.scatter_factor = mat->scatter_factor;
+            params.scatter_color = mat->scatter_color;
+            params.phase_asymmetry_g = mat->phase_asymmetry_g;
+            params.ior = mat->ior;
+            result = params;
+            best_volume = volume;
+            break;
+        }
+    }
+    return result;
+}
+
+void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, const vierkant::SceneConstPtr &scene,
+                                             const Object3DPtr &cam)
 {
     frame_context.tracable.descriptors.clear();
 
@@ -520,11 +577,14 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
 
     trace_data.camera_params = camera_params;
 
-    // default media: air. optionally submerge the camera in a global medium.
+    // default media: air. submerge the camera in a medium if one is set: an explicit global medium
+    // (settings override) wins, otherwise auto-detect the volumetric object the camera is inside.
     trace_data.camera_media = {};
-    if(frame_context.settings.camera_medium)
+    std::optional<vierkant::medium_params_t> camera_medium = frame_context.settings.camera_medium;
+    if(!camera_medium) { camera_medium = detect_camera_medium(scene, cam); }
+    if(camera_medium)
     {
-        trace_data.camera_media = vierkant::to_media(*frame_context.settings.camera_medium);
+        trace_data.camera_media = vierkant::to_media(*camera_medium);
         trace_data.trace_params.camera_inside_media = true;
     }
 

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -464,6 +464,25 @@ void draw_scene_renderer_settings_ui_intern(const PBRPathTracerPtr &path_tracer)
 
     ImGui::Checkbox("depth of field", &path_tracer->settings.depth_of_field);
     ImGui::Checkbox("suppress reset", &path_tracer->settings.suppress_reset);
+
+    // optional global medium the camera is submerged in (fog/underwater/haze).
+    // same material-facing knobs as a volumetric material; converted via vierkant::to_media().
+    bool camera_medium_enabled = path_tracer->settings.camera_medium.has_value();
+    if(ImGui::Checkbox("camera medium", &camera_medium_enabled))
+    {
+        if(camera_medium_enabled) { path_tracer->settings.camera_medium = vierkant::medium_params_t{}; }
+        else { path_tracer->settings.camera_medium.reset(); }
+    }
+    if(path_tracer->settings.camera_medium)
+    {
+        auto &medium = *path_tracer->settings.camera_medium;
+        ImGui::ColorEdit3("attenuation color", &medium.attenuation_color[0]);
+        ImGui::DragFloat("attenuation distance", &medium.attenuation_distance, 0.01f, 0.001f, 1000.f);
+        ImGui::SliderFloat("scatter factor", &medium.scatter_factor, 0.f, 1.f);
+        ImGui::ColorEdit3("scatter color", &medium.scatter_color[0]);
+        ImGui::SliderFloat("phase g", &medium.phase_asymmetry_g, -0.99f, 0.99f);
+        ImGui::SliderFloat("medium ior", &medium.ior, 1.f, 3.f);
+    }
 }
 
 void draw_scene_renderer_statistics_ui_intern(const PBRPathTracerPtr &path_tracer)

--- a/src/media.cpp
+++ b/src/media.cpp
@@ -1,0 +1,24 @@
+#include <vierkant/media.hpp>
+
+namespace vierkant
+{
+
+media_t to_media(const medium_params_t &params)
+{
+    // mirror shaders/slang/raypipeline.slang: attenuation_color/distance give the total extinction
+    // sigma_t; scatter_factor * scatter_color is the multi-scatter albedo (rho_ms), inverted to the
+    // single-scatter albedo (rho_ss) the medium needs via the Kulla-Conty (2017) approximation.
+    glm::vec3 sigma_t = -glm::log(params.attenuation_color) / params.attenuation_distance;
+    glm::vec3 rho_ms = params.scatter_factor * params.scatter_color;
+    glm::vec3 kc = 4.09712f + 4.20863f * rho_ms - glm::sqrt(9.59217f + 41.6808f * rho_ms + 17.7126f * rho_ms * rho_ms);
+    glm::vec3 rho_ss = 1.f - kc * kc;
+
+    media_t media = {};
+    media.sigma_s = rho_ss * sigma_t;
+    media.sigma_a = (1.f - rho_ss) * sigma_t;
+    media.phase_g = params.phase_asymmetry_g;
+    media.ior = params.ior;
+    return media;
+}
+
+}// namespace vierkant


### PR DESCRIPTION
- define an optional global medium for PBRPathtracer
- detect when camera rays start inside a volume and push that material's media_t onto stack
- adds couple required helpers
- corrects OOB::contains routine
- also adds a helper-script used to derive constants used by dispersion shader-logic