### PR TITLE
Analytic area lights (Rect/Sphere/Tube/Disk) + NEE/BSDF MIS

### DIFF
--- a/include/vierkant/PBRPathTracer.hpp
+++ b/include/vierkant/PBRPathTracer.hpp
@@ -60,6 +60,9 @@ public:
         //! disable colors from textures, material, positions
         bool disable_material = false;
 
+        //! debug: force a single direct-light estimator (0: MIS, 1: NEE-only, 2: BSDF-only)
+        uint32_t mis_mode = 0;
+
         //! draw the skybox, if any
         bool draw_skybox = true;
 
@@ -263,6 +266,9 @@ private:
 
         //! flag: camera starts inside 'camera_media' (seed media-stack, disable back-face culling)
         uint32_t camera_inside_media = false;
+
+        //! debug: force a single direct-light estimator (0: MIS, 1: NEE-only, 2: BSDF-only)
+        uint32_t mis_mode = 0;
     };
 
     struct denoise_params_t

--- a/shaders/slang/ray/bsdf_disney.slang
+++ b/shaders/slang/ray/bsdf_disney.slang
@@ -372,9 +372,12 @@ public float3 eval_disney(material_t material, float3 L, float3 N, float3 V, flo
     pdf = lerp(brdfPdf, bsdfPdf, trans_weight);
     float3 F = lerp(brdf, bsdf, trans_weight);
 
-    // invariant: F is zero whenever pdf is zero or invalid.
-    // covers asymmetric lobe corners (e.g. diffuse-transmission with zero pdf-weight) and NaN-pdfs (grazing clearcoat)
-    return pdf > 0.0 ? F : float3(0.0);
+    // invariant: F is zero whenever pdf is zero or invalid, and the returned pdf is never NaN/negative.
+    // covers asymmetric lobe corners (e.g. diffuse-transmission with zero pdf-weight) and NaN-pdfs (grazing
+    // clearcoat), which would otherwise poison MIS weights
+    bool valid = pdf > 0.0;
+    pdf = valid ? pdf : 0.0;
+    return valid ? F : float3(0.0);
 }
 
 }// namespace ray

--- a/shaders/slang/ray/direct_lighting.slang
+++ b/shaders/slang/ray/direct_lighting.slang
@@ -143,8 +143,24 @@ public float power_heuristic(float p_a, float p_b)
     return 1.0 / (1.0 + r * r);
 }
 
-//! whether bsdf/phase-sampled rays can hit this light (M2 adds the sun-disc, M3 analytic light bodies)
-public bool bsdf_reachable(light_t l) { return false; }
+//! whether bsdf/phase-sampled rays can hit this light (M2: sun-discs via miss shaders; M3 adds analytic light bodies)
+public bool bsdf_reachable(light_t l) { return l.type == LightType::Directional && l.angular_size > 0.0; }
+
+//! NEE-side MIS weight against a bsdf/phase competitor-pdf, respecting a forced estimator-mode
+public float mis_weight_nee(MisMode mode, float p_nee, float p_bsdf)
+{
+    if(mode == MisMode::NeeOnly) { return 1.0; }
+    if(mode == MisMode::BsdfOnly) { return 0.0; }
+    return power_heuristic(p_nee, p_bsdf);
+}
+
+//! hit-side MIS weight for a bsdf/phase ray that reached a light (prev_bsdf_pdf <= 0: no NEE competitor -> full)
+public float mis_weight_hit(MisMode mode, float prev_bsdf_pdf, float p_nee)
+{
+    if(mode == MisMode::NeeOnly) { return 0.0; }
+    if(mode == MisMode::BsdfOnly || prev_bsdf_pdf <= 0.0) { return 1.0; }
+    return power_heuristic(prev_bsdf_pdf, p_nee);
+}
 
 //! solid-angle pdf of sample_light() generating direction `dir` from P — the hit-side density for MIS.
 //! must mirror the sampling strategies in sample_light() exactly
@@ -249,7 +265,9 @@ public float3 nee_surface(material_t material, trace_data_t trace_data, Raytraci
         float3 F = eval_disney(material, ls.direction, N, V, eta, bsdf_pdf);
 
         // MIS vs. bsdf-sampling for lights that bsdf-rays can hit (weight == 1 for all others)
-        float weight = bsdf_reachable(trace_data.lights[index]) ? power_heuristic(ls.pdf / num_lights, bsdf_pdf) : 1.0;
+        float weight = bsdf_reachable(trace_data.lights[index])
+                               ? mis_weight_nee(trace_data.params.mis_mode, ls.pdf / num_lights, bsdf_pdf)
+                               : 1.0;
 
         // divide by pick-pdf (1/num_lights) and solid-angle pdf
         radiance = weight * float(num_lights) * ls.radiance * F * cos_theta / ls.pdf;
@@ -285,7 +303,9 @@ public float3 nee_volume(Ray ray, trace_data_t trace_data, RaytracingAcceleratio
     float phase = utils::phase_hg(dot(ray.direction, ls.direction), phase_g);
 
     // MIS vs. phase-sampling for lights that phase-rays can hit (weight == 1 for all others)
-    float weight = bsdf_reachable(trace_data.lights[index]) ? power_heuristic(ls.pdf / num_lights, phase) : 1.0;
+    float weight = bsdf_reachable(trace_data.lights[index])
+                           ? mis_weight_nee(trace_data.params.mis_mode, ls.pdf / num_lights, phase)
+                           : 1.0;
 
     // divide by pick-pdf (1/num_lights) and solid-angle pdf
     return weight * float(num_lights) * ls.radiance * phase / ls.pdf;

--- a/shaders/slang/ray/direct_lighting.slang
+++ b/shaders/slang/ray/direct_lighting.slang
@@ -136,16 +136,101 @@ public light_sample_t sample_light(light_t l, float3 P, float2 Xi)
     return ret;
 }
 
+//! overflow-safe power-heuristic weight (beta = 2): p_a^2 / (p_a^2 + p_b^2)
+public float power_heuristic(float p_a, float p_b)
+{
+    float r = p_b / p_a;
+    return 1.0 / (1.0 + r * r);
+}
+
+//! whether bsdf/phase-sampled rays can hit this light (M2 adds the sun-disc, M3 analytic light bodies)
+public bool bsdf_reachable(light_t l) { return false; }
+
+//! solid-angle pdf of sample_light() generating direction `dir` from P — the hit-side density for MIS.
+//! must mirror the sampling strategies in sample_light() exactly
+public float light_pdf(light_t l, float3 P, float3 dir)
+{
+    switch(l.type)
+    {
+        case LightType::Directional:
+        {
+            // sun-disc: constant over the cone; delta lights (angular_size == 0) are never bsdf-reachable
+            if(l.angular_size <= 0.0) { return 0.0; }
+            float cos_sigma = cos(l.angular_size);
+            return dot(dir, -l.direction) < cos_sigma ? 0.0 : 1.0 / (2.0 * utils::PI * (1.0 - cos_sigma));
+        }
+        case LightType::Sphere:
+        {
+            // constant over the subtended cone
+            float3 to_center = l.position - P;
+            float d2 = dot(to_center, to_center);
+            float r2 = l.size_x * l.size_x;
+            if(d2 <= r2) { return 0.0; }
+            float sin2_sigma = r2 / d2;
+            float cos_sigma = sqrt(1.0 - sin2_sigma);
+            return dot(dir, to_center * rsqrt(d2)) < cos_sigma ? 0.0
+                                                               : (1.0 + cos_sigma) / (2.0 * utils::PI * sin2_sigma);
+        }
+        case LightType::Rect:
+        case LightType::Disk:
+        {
+            // intersect the light plane, check the shape's extent, convert the area-pdf at the hit
+            float cos_light = dot(l.direction, -dir);
+            if(cos_light <= 0.0) { return 0.0; }
+            float t = dot(l.position - P, l.direction) / -cos_light;
+            if(t <= 0.0) { return 0.0; }
+
+            float3 q = P + t * dir - l.position;
+            float pdf_area;
+            if(l.type == LightType::Rect)
+            {
+                float3 bitangent = cross(l.direction, l.tangent);
+                if(abs(dot(q, l.tangent)) > l.size_x || abs(dot(q, bitangent)) > l.size_y) { return 0.0; }
+                pdf_area = 1.0 / (4.0 * l.size_x * l.size_y);
+            }
+            else
+            {
+                if(dot(q, q) > l.size_x * l.size_x) { return 0.0; }
+                pdf_area = 1.0 / (utils::PI * l.size_x * l.size_x);
+            }
+            return pdf_area * t * t / cos_light;
+        }
+        case LightType::Tube:
+        {
+            // nearest mantle intersection (quadratic in the plane perpendicular to the axis)
+            float3 o = P - l.position;
+            float3 d_perp = dir - l.direction * dot(dir, l.direction);
+            float3 o_perp = o - l.direction * dot(o, l.direction);
+            float A = dot(d_perp, d_perp);
+            float B = dot(o_perp, d_perp);
+            float C = dot(o_perp, o_perp) - l.size_x * l.size_x;
+            float disc = B * B - A * C;
+
+            // parallel to the axis, miss, or P inside the mantle radius (backfacing hit)
+            if(A <= EPS || disc <= 0.0 || C <= 0.0) { return 0.0; }
+            float t = (-B - sqrt(disc)) / A;
+            if(t <= 0.0 || abs(dot(o + t * dir, l.direction)) > l.size_y) { return 0.0; }
+
+            // radial unit-normal at the hit
+            float3 n = (o_perp + t * d_perp) / l.size_x;
+            float cos_light = dot(n, -dir);
+            if(cos_light <= 0.0) { return 0.0; }
+            return t * t / (4.0 * utils::PI * l.size_x * l.size_y * cos_light);
+        }
+        default: return 0.0;// punctual delta lights: never bsdf-reachable
+    }
+}
+
 //! next-event estimation at a surface: uniformly pick one light, sample it, trace a visibility ray.
-//! requires num_lights > 0
-public float3 nee_surface(material_t material, Ptr<light_t, Access.Read> lights, uint num_lights,
-                          RaytracingAccelerationStructure as, float3 pos, float3 N, float3 V, float eta,
-                          inout uint rng_state)
+//! requires trace_data.num_lights > 0
+public float3 nee_surface(material_t material, trace_data_t trace_data, RaytracingAccelerationStructure as,
+                          Sampler2D textures[], float3 pos, float3 N, float3 V, float eta, inout uint rng_state)
 {
     // uniform 1/N light-pick (single light: keep rng-stream untouched)
+    uint num_lights = trace_data.num_lights;
     uint index = num_lights > 1 ? min(uint(utils::rnd(rng_state) * num_lights), num_lights - 1) : 0;
     float2 Xi = float2(utils::rnd(rng_state), utils::rnd(rng_state));
-    light_sample_t ls = sample_light(lights[index], pos, Xi);
+    light_sample_t ls = sample_light(trace_data.lights[index], pos, Xi);
 
     // skip the shadow ray for black samples (beyond range, inside a sphere-light)
     if(!any(ls.radiance > 0.0)) { return float3(0); }
@@ -157,50 +242,53 @@ public float3 nee_surface(material_t material, Ptr<light_t, Access.Read> lights,
     r.tmax = ls.dist;
 
     float3 radiance = float3(0);
-    if(visibility_test(r, as))
+    if(visibility_test(r, as, 0, trace_data, textures, rng_state))
     {
-        // bsdf-pdf is unused until MIS enters the picture (area/env lights)
         float bsdf_pdf = 0.0;
         float cos_theta = max(dot(N, ls.direction), 0.0);
         float3 F = eval_disney(material, ls.direction, N, V, eta, bsdf_pdf);
 
+        // MIS vs. bsdf-sampling for lights that bsdf-rays can hit (weight == 1 for all others)
+        float weight = bsdf_reachable(trace_data.lights[index]) ? power_heuristic(ls.pdf / num_lights, bsdf_pdf) : 1.0;
+
         // divide by pick-pdf (1/num_lights) and solid-angle pdf
-        radiance = float(num_lights) * ls.radiance * F * cos_theta / ls.pdf;
+        radiance = weight * float(num_lights) * ls.radiance * F * cos_theta / ls.pdf;
     }
     return radiance;
 }
 
 //! next-event estimation at a volume-scattering event, using the phase function.
-//! requires num_lights > 0
-public float3 nee_volume(Ray ray, Ptr<light_t, Access.Read> lights, uint num_lights,
-                         RaytracingAccelerationStructure as, float phase_g, inout uint rng_state)
+//! requires trace_data.num_lights > 0
+public float3 nee_volume(Ray ray, trace_data_t trace_data, RaytracingAccelerationStructure as, Sampler2D textures[],
+                         float phase_g, inout uint rng_state)
 {
     // uniform 1/N light-pick (single light: keep rng-stream untouched)
+    uint num_lights = trace_data.num_lights;
     uint index = num_lights > 1 ? min(uint(utils::rnd(rng_state) * num_lights), num_lights - 1) : 0;
     float2 Xi = float2(utils::rnd(rng_state), utils::rnd(rng_state));
-    light_sample_t ls = sample_light(lights[index], ray.origin, Xi);
+    light_sample_t ls = sample_light(trace_data.lights[index], ray.origin, Xi);
 
     // skip the shadow ray for black samples (beyond range, inside a sphere-light)
     if(!any(ls.radiance > 0.0)) { return float3(0); }
 
     // shadow ray from inside volume: cull back faces from enclosing mesh
-    RayDesc shadow_desc;
-    shadow_desc.Origin = ray.origin;
-    shadow_desc.Direction = ls.direction;
-    shadow_desc.TMin = EPS;
-    shadow_desc.TMax = ls.dist;
-
-    RayQuery<RAY_FLAG_FORCE_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER |
-             RAY_FLAG_CULL_BACK_FACING_TRIANGLES> shadow_query;
-    shadow_query.TraceRayInline(as, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_CULL_BACK_FACING_TRIANGLES,
-                                0xFF, shadow_desc);
-    shadow_query.Proceed();
-    if(shadow_query.CommittedStatus() != COMMITTED_NOTHING) { return float3(0); }
+    Ray r;
+    r.origin = ray.origin;
+    r.direction = ls.direction;
+    r.tmin = EPS;
+    r.tmax = ls.dist;
+    if(!visibility_test(r, as, RAY_FLAG_CULL_BACK_FACING_TRIANGLES, trace_data, textures, rng_state))
+    {
+        return float3(0);
+    }
 
     float phase = utils::phase_hg(dot(ray.direction, ls.direction), phase_g);
 
+    // MIS vs. phase-sampling for lights that phase-rays can hit (weight == 1 for all others)
+    float weight = bsdf_reachable(trace_data.lights[index]) ? power_heuristic(ls.pdf / num_lights, phase) : 1.0;
+
     // divide by pick-pdf (1/num_lights) and solid-angle pdf
-    return float(num_lights) * ls.radiance * phase / ls.pdf;
+    return weight * float(num_lights) * ls.radiance * phase / ls.pdf;
 }
 
 }// namespace ray

--- a/shaders/slang/ray/direct_lighting.slang
+++ b/shaders/slang/ray/direct_lighting.slang
@@ -143,8 +143,97 @@ public float power_heuristic(float p_a, float p_b)
     return 1.0 / (1.0 + r * r);
 }
 
-//! whether bsdf/phase-sampled rays can hit this light (M2: sun-discs via miss shaders; M3 adds analytic light bodies)
-public bool bsdf_reachable(light_t l) { return l.type == LightType::Directional && l.angular_size > 0.0; }
+//! whether bsdf/phase-sampled rays can hit this light: sun-discs via the miss shaders,
+//! analytic light bodies via the raygen ghost-light pass
+public bool bsdf_reachable(light_t l)
+{
+    return (l.type == LightType::Directional && l.angular_size > 0.0) || l.type == LightType::Rect ||
+           l.type == LightType::Sphere || l.type == LightType::Tube || l.type == LightType::Disk;
+}
+
+//! closed-form ray-intersection with an analytic light body
+public struct light_hit_t
+{
+    //! hit distance, <= 0 marks a miss
+    public float t;
+
+    //! cosine at the light surface (facing the ray origin)
+    public float cos_light;
+};
+
+//! intersect a ray with an analytic light body. front-facing surfaces only: back sides are
+//! transparent, consistent with the one-sided black NEE samples. non-area types never hit
+public light_hit_t intersect_light(light_t l, float3 P, float3 dir)
+{
+    light_hit_t ret;
+    ret.t = 0.0;
+    ret.cos_light = 0.0;
+
+    switch(l.type)
+    {
+        case LightType::Sphere:
+        {
+            float3 to_center = l.position - P;
+            float d2 = dot(to_center, to_center);
+            float r2 = l.size_x * l.size_x;
+
+            // inside the sphere: no hit (matches the black NEE sample)
+            if(d2 <= r2) { break; }
+            float b = dot(dir, to_center);
+            float disc = b * b - d2 + r2;
+            if(disc <= 0.0) { break; }
+            float t = b - sqrt(disc);
+            if(t <= 0.0) { break; }
+            ret.t = t;
+            ret.cos_light = dot((P + t * dir - l.position) / l.size_x, -dir);
+            break;
+        }
+        case LightType::Rect:
+        case LightType::Disk:
+        {
+            float cos_light = dot(l.direction, -dir);
+            if(cos_light <= 0.0) { break; }
+            float t = dot(l.position - P, l.direction) / -cos_light;
+            if(t <= 0.0) { break; }
+
+            float3 q = P + t * dir - l.position;
+            if(l.type == LightType::Rect)
+            {
+                float3 bitangent = cross(l.direction, l.tangent);
+                if(abs(dot(q, l.tangent)) > l.size_x || abs(dot(q, bitangent)) > l.size_y) { break; }
+            }
+            else if(dot(q, q) > l.size_x * l.size_x) { break; }
+            ret.t = t;
+            ret.cos_light = cos_light;
+            break;
+        }
+        case LightType::Tube:
+        {
+            // nearest mantle intersection (quadratic in the plane perpendicular to the axis)
+            float3 o = P - l.position;
+            float3 d_perp = dir - l.direction * dot(dir, l.direction);
+            float3 o_perp = o - l.direction * dot(o, l.direction);
+            float A = dot(d_perp, d_perp);
+            float B = dot(o_perp, d_perp);
+            float C = dot(o_perp, o_perp) - l.size_x * l.size_x;
+            float disc = B * B - A * C;
+
+            // parallel to the axis, miss, or P inside the mantle radius (backfacing hit)
+            if(A <= EPS || disc <= 0.0 || C <= 0.0) { break; }
+            float t = (-B - sqrt(disc)) / A;
+            if(t <= 0.0 || abs(dot(o + t * dir, l.direction)) > l.size_y) { break; }
+
+            // radial unit-normal at the hit
+            float cos_light = dot((o_perp + t * d_perp) / l.size_x, -dir);
+            if(cos_light <= 0.0) { break; }
+            ret.t = t;
+            ret.cos_light = cos_light;
+            break;
+        }
+        default: break;
+    }
+    return ret;
+}
 
 //! NEE-side MIS weight against a bsdf/phase competitor-pdf, respecting a forced estimator-mode
 public float mis_weight_nee(MisMode mode, float p_nee, float p_bsdf)
@@ -189,49 +278,15 @@ public float light_pdf(light_t l, float3 P, float3 dir)
         }
         case LightType::Rect:
         case LightType::Disk:
-        {
-            // intersect the light plane, check the shape's extent, convert the area-pdf at the hit
-            float cos_light = dot(l.direction, -dir);
-            if(cos_light <= 0.0) { return 0.0; }
-            float t = dot(l.position - P, l.direction) / -cos_light;
-            if(t <= 0.0) { return 0.0; }
-
-            float3 q = P + t * dir - l.position;
-            float pdf_area;
-            if(l.type == LightType::Rect)
-            {
-                float3 bitangent = cross(l.direction, l.tangent);
-                if(abs(dot(q, l.tangent)) > l.size_x || abs(dot(q, bitangent)) > l.size_y) { return 0.0; }
-                pdf_area = 1.0 / (4.0 * l.size_x * l.size_y);
-            }
-            else
-            {
-                if(dot(q, q) > l.size_x * l.size_x) { return 0.0; }
-                pdf_area = 1.0 / (utils::PI * l.size_x * l.size_x);
-            }
-            return pdf_area * t * t / cos_light;
-        }
         case LightType::Tube:
         {
-            // nearest mantle intersection (quadratic in the plane perpendicular to the axis)
-            float3 o = P - l.position;
-            float3 d_perp = dir - l.direction * dot(dir, l.direction);
-            float3 o_perp = o - l.direction * dot(o, l.direction);
-            float A = dot(d_perp, d_perp);
-            float B = dot(o_perp, d_perp);
-            float C = dot(o_perp, o_perp) - l.size_x * l.size_x;
-            float disc = B * B - A * C;
-
-            // parallel to the axis, miss, or P inside the mantle radius (backfacing hit)
-            if(A <= EPS || disc <= 0.0 || C <= 0.0) { return 0.0; }
-            float t = (-B - sqrt(disc)) / A;
-            if(t <= 0.0 || abs(dot(o + t * dir, l.direction)) > l.size_y) { return 0.0; }
-
-            // radial unit-normal at the hit
-            float3 n = (o_perp + t * d_perp) / l.size_x;
-            float cos_light = dot(n, -dir);
-            if(cos_light <= 0.0) { return 0.0; }
-            return t * t / (4.0 * utils::PI * l.size_x * l.size_y * cos_light);
+            // uniform-area strategies: convert the area-pdf at the front-facing hit
+            light_hit_t hit = intersect_light(l, P, dir);
+            if(hit.t <= 0.0) { return 0.0; }
+            float area = l.type == LightType::Rect   ? 4.0 * l.size_x * l.size_y
+                         : l.type == LightType::Disk ? utils::PI * l.size_x * l.size_x
+                                                     : 4.0 * utils::PI * l.size_x * l.size_y;
+            return hit.t * hit.t / (area * hit.cos_light);
         }
         default: return 0.0;// punctual delta lights: never bsdf-reachable
     }

--- a/shaders/slang/ray/ray_common.slang
+++ b/shaders/slang/ray/ray_common.slang
@@ -138,6 +138,9 @@ public struct payload_t
     //! object/entity
     public uint entity_index;
 
+    //! solid-angle pdf of the bsdf/phase sample that spawned this ray; <= 0: no MIS competitor (camera ray, NEE off)
+    public float prev_bsdf_pdf;
+
     public media_t media;
 };
 

--- a/shaders/slang/ray/ray_common.slang
+++ b/shaders/slang/ray/ray_common.slang
@@ -144,6 +144,14 @@ public struct payload_t
     public media_t media;
 };
 
+//! debug: force a single direct-light estimator (verification: all modes must converge to the same image)
+public enum MisMode : uint
+{
+    Full = 0,
+    NeeOnly = 1,
+    BsdfOnly = 2,
+};
+
 public struct trace_params_t
 {
     //! current time since start in seconds
@@ -176,7 +184,10 @@ public struct trace_params_t
     //! camera starts inside 'camera_media' (seed media-stack, disable back-face culling)
     public bool camera_inside_media;
 
-    private int pad1, pad2;
+    //! debug: force a single direct-light estimator
+    public MisMode mis_mode;
+
+    private int pad1;
 };
 
 public struct camera_ubo_t

--- a/shaders/slang/ray/visibility_test.slang
+++ b/shaders/slang/ray/visibility_test.slang
@@ -1,6 +1,9 @@
 module visibility_test;
 
 import ray_common;
+import types;
+import "../utils/packed_vertex.slang";
+import "../utils/random.slang";
 
 namespace ray
 {
@@ -37,12 +40,49 @@ public RayHit ray_cast(Ray ray, RaytracingAccelerationStructure as)
     return ret;
 }
 
-public bool visibility_test(Ray ray, RaytracingAccelerationStructure as)
+//! binary shadow-ray visibility. non-opaque candidates get the same alpha-cutout/blend treatment as any_hit(),
+//! so alpha-masked geometry no longer casts solid shadows
+public bool visibility_test(Ray ray, RaytracingAccelerationStructure as, uint extra_ray_flags,
+                            trace_data_t trace_data, Sampler2D textures[], inout uint rng_state)
 {
-    RayQuery<RAY_FLAG_FORCE_OPAQUE | RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER> query;
-    query.TraceRayInline(as, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH, 0xFF,
+    RayQuery<RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | RAY_FLAG_SKIP_CLOSEST_HIT_SHADER> query;
+    query.TraceRayInline(as, RAY_FLAG_ACCEPT_FIRST_HIT_AND_END_SEARCH | extra_ray_flags, 0xFF,
                          RayDesc(ray.origin, ray.tmin, ray.direction, ray.tmax));
-    query.Proceed();
+
+    while(query.Proceed())
+    {
+        if(query.CandidateType() != CANDIDATE_NON_OPAQUE_TRIANGLE) { continue; }
+
+        let entry = trace_data.entries + query.CandidateInstanceIndex();
+        material_t material = trace_data.materials[entry->material_index];
+
+        bool blocks = true;
+        if(!material.null_surface &&
+           (material.blend_mode == BlendMode::Mask || material.blend_mode == BlendMode::Blend))
+        {
+            if((material.texture_type_flags & uint(TextureTypeBits::Color)) != 0)
+            {
+                uint base = entry->base_index + 3 * query.CandidatePrimitiveIndex();
+                int3 ind = int3(trace_data.index_buffers[entry->buffer_index][base + 0],
+                                trace_data.index_buffers[entry->buffer_index][base + 1],
+                                trace_data.index_buffers[entry->buffer_index][base + 2]);
+
+                float2 bary = query.CandidateTriangleBarycentrics();
+                float3 barycentric = float3(1.0 - bary.x - bary.y, bary.x, bary.y);
+                float2 tex_coord =
+                        utils::unpack(trace_data.vertex_buffers[entry->buffer_index][entry->vertex_offset + ind.x])
+                                        .tex_coord * barycentric.x +
+                        utils::unpack(trace_data.vertex_buffers[entry->buffer_index][entry->vertex_offset + ind.y])
+                                        .tex_coord * barycentric.y +
+                        utils::unpack(trace_data.vertex_buffers[entry->buffer_index][entry->vertex_offset + ind.z])
+                                        .tex_coord * barycentric.z;
+                material.color *= textures[NonUniformResourceIndex(material.albedo_index)].SampleLevel(tex_coord, 0);
+            }
+            if(material.blend_mode == BlendMode::Mask && material.color.a < material.alpha_cutoff) { blocks = false; }
+            if(material.blend_mode == BlendMode::Blend && material.color.a < utils::rnd(rng_state)) { blocks = false; }
+        }
+        if(blocks) { query.CommitNonOpaqueTriangleHit(); }
+    }
     return query.CommittedStatus() == COMMITTED_NOTHING;
 }
 

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -564,7 +564,8 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
                                                                 payload.position, payload.normal, V, eta, rng_state);
         }
 
-        if(bsdf_sample.pdf <= 0.0)
+        // negated form also stops NaN-pdfs, which would poison beta and MIS weights
+        if(!(bsdf_sample.pdf > 0.0))
         {
             payload.stop = true;
             return;
@@ -662,6 +663,26 @@ void any_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttributes
 // miss shaders
 //-----------------------------------------------------------------------------
 
+//! sun-style directional disc-lights are visible on miss, MIS-weighted against their NEE strategy.
+//! local analytic light bodies terminate rays elsewhere and never show up here (M3)
+float3 eval_distant_lights(float3 dir, float prev_bsdf_pdf)
+{
+    float3 radiance = float3(0);
+    for(uint i = 0; i < trace_data.num_lights; ++i)
+    {
+        ray::light_t l = trace_data.lights[i];
+        if(l.type != ray::LightType::Directional) { continue; }
+
+        // constant disc-radiance inside the cone; delta suns (angular_size == 0) yield pdf 0
+        float pdf = ray::light_pdf(l, float3(0), dir);
+        if(pdf <= 0.0) { continue; }
+
+        float w = ray::mis_weight_hit(trace_data.params.mis_mode, prev_bsdf_pdf, pdf / trace_data.num_lights);
+        radiance += w * l.color * l.intensity;
+    }
+    return radiance;
+}
+
 [shader("miss")]
 void miss_default(inout ray::payload_t payload)
 {
@@ -671,6 +692,7 @@ void miss_default(inout ray::payload_t payload)
 
     float3 col = utils::environment_white(payload.ray.direction);
     payload.radiance += trace_data.params.environment * payload.beta * col;
+    payload.radiance += payload.beta * eval_distant_lights(payload.ray.direction, payload.prev_bsdf_pdf);
 }
 
 [shader("miss")]
@@ -685,4 +707,5 @@ void miss_environment(inout ray::payload_t payload)
 
     payload.radiance +=
             trace_data.params.environment * payload.beta * u_sampler_cube.SampleLevel(WorldRayDirection(), lod).rgb;
+    payload.radiance += payload.beta * eval_distant_lights(payload.ray.direction, payload.prev_bsdf_pdf);
 }

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -159,6 +159,11 @@ trace_result_t trace(uint2 coord, uint2 size)
             ray_desc.Direction = next_ray.direction;
             ray_desc.TMax = next_ray.tmax;
 
+            // segment state for the ghost-light pass below (closest_hit updates beta/prev_bsdf_pdf/ray)
+            ray::Ray seg_ray = next_ray;
+            float3 seg_beta = beta;
+            float seg_prev_pdf = payload.prev_bsdf_pdf;
+
             //let hit = HitObject.TraceRay(topLevelAS, ray_flags, 0xff, 0, 0, ray::MISS_INDEX_DEFAULT, ray_desc, payload);
             //ReorderThread(hit);
             //HitObject.Invoke(topLevelAS, hit, payload);
@@ -175,6 +180,31 @@ trace_result_t trace(uint2 coord, uint2 size)
                 media[media_index] = payload.media;
             }
             else if(payload.media_op == ray::MediaOp::Leave) { media_index = media_index > 0u ? media_index - 1u : 0u; }
+
+            // ghost-light pass: analytic light bodies are additive, non-terminating emitters.
+            // front-facing intersections within the traced segment add MIS-weighted emission; the segment
+            // itself (media integration, scatter, surface shading) is untouched. media-transmittance toward
+            // the light is deliberately omitted until NEE shadow rays get it too (keeps both strategies
+            // estimating the same integral, so the estimator-toggle A/B stays valid)
+            {
+                // segment endpoint: where the path continued (surface hit, scatter point or
+                // null-surface boundary alike), or the traced tmax on a miss
+                bool seg_miss = payload.entity_index == utils::MAX_UINT16;
+                float t_end = seg_miss ? seg_ray.tmax : length(payload.ray.origin - seg_ray.origin);
+
+                for(uint li = 0; li < trace_data.num_lights; ++li)
+                {
+                    ray::light_t l = trace_data.lights[li];
+
+                    // non-area types never intersect
+                    ray::light_hit_t hit = ray::intersect_light(l, seg_ray.origin, seg_ray.direction);
+                    if(hit.t <= seg_ray.tmin || hit.t >= t_end) { continue; }
+
+                    float p_nee = ray::light_pdf(l, seg_ray.origin, seg_ray.direction) / trace_data.num_lights;
+                    float w = ray::mis_weight_hit(trace_data.params.mis_mode, seg_prev_pdf, p_nee);
+                    payload.radiance += seg_beta * w * l.color * l.intensity;
+                }
+            }
 
             path_radiance = payload.radiance;
 

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -131,6 +131,7 @@ trace_result_t trace(uint2 coord, uint2 size)
         float disp_lambda = -1.0;
 
         ray::payload_t payload;
+        payload.prev_bsdf_pdf = 0.0;
         bool ray_miss = false;
 
         for(uint i = 0; i < trace_data.params.max_trace_depth; i++)
@@ -413,13 +414,16 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
 
             if(use_direct_lighting)
             {
-                payload.radiance += payload.beta * ray::nee_volume(payload.ray, trace_data.lights,
-                                                                   trace_data.num_lights, topLevelAS, g, rng_state);
+                payload.radiance +=
+                        payload.beta * ray::nee_volume(payload.ray, trace_data, topLevelAS, u_textures, g, rng_state);
             }
 
             float phase_pdf;
             payload.ray.direction =
                     mul(utils::sample_phase_hg(Xi, g, phase_pdf), utils::local_frame(payload.ray.direction));
+
+            // solid-angle pdf of this bounce for MIS at the next vertex (<= 0: no NEE competitor here)
+            payload.prev_bsdf_pdf = use_direct_lighting ? phase_pdf : 0.0;
         }
     }
 
@@ -556,9 +560,8 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
 
         if(use_direct_lighting)
         {
-            payload.radiance +=
-                    payload.beta * ray::nee_surface(material, trace_data.lights, trace_data.num_lights, topLevelAS,
-                                                    payload.position, payload.normal, V, eta, rng_state);
+            payload.radiance += payload.beta * ray::nee_surface(material, trace_data, topLevelAS, u_textures,
+                                                                payload.position, payload.normal, V, eta, rng_state);
         }
 
         if(bsdf_sample.pdf <= 0.0)
@@ -568,6 +571,10 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
         }
 
         payload.ray.direction = bsdf_sample.direction;
+
+        // solid-angle pdf of this bounce for MIS at the next vertex (<= 0: no NEE competitor here)
+        payload.prev_bsdf_pdf = use_direct_lighting ? bsdf_sample.pdf : 0.0;
+
         float cos_theta = abs(dot(payload.normal, bsdf_sample.direction));
 
         float3 path_throughput = bsdf_sample.F * cos_theta / max(bsdf_sample.pdf, ray::PDF_EPS);

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -581,6 +581,7 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
     trace_data.trace_params.max_trace_depth = frame_context.settings.max_trace_depth;
     trace_data.trace_params.max_path_beta = frame_context.settings.max_path_beta;
     trace_data.trace_params.disable_material = frame_context.settings.disable_material;
+    trace_data.trace_params.mis_mode = frame_context.settings.mis_mode;
     trace_data.trace_params.draw_skybox = frame_context.settings.draw_skybox;
     trace_data.trace_params.environment = frame_context.settings.environment_factor;
     trace_data.trace_params.random_seed = m_random_engine();

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -452,6 +452,14 @@ void draw_scene_renderer_settings_ui_intern(const PBRPathTracerPtr &path_tracer)
     ImGui::Checkbox("skybox", &path_tracer->settings.draw_skybox);
     ImGui::Checkbox("suspend_trace_when_done", &path_tracer->settings.suspend_trace_when_done);
     ImGui::Checkbox("disable material", &path_tracer->settings.disable_material);
+
+    // debug: force a single direct-light estimator (all modes must converge to the same image)
+    constexpr const char *mis_mode_items[] = {"MIS", "NEE only", "BSDF only"};
+    int mis_mode = static_cast<int>(path_tracer->settings.mis_mode);
+    if(ImGui::Combo("direct-light estimator", &mis_mode, mis_mode_items, IM_ARRAYSIZE(mis_mode_items)))
+    {
+        path_tracer->settings.mis_mode = static_cast<uint32_t>(mis_mode);
+    }
     ImGui::Checkbox("denoiser", &path_tracer->settings.denoising);
     ImGui::Checkbox("tonemap", &path_tracer->settings.tonemap);
     ImGui::Checkbox("bloom", &path_tracer->settings.bloom);


### PR DESCRIPTION
<img width="2880" height="1782" alt="image" src="https://github.com/user-attachments/assets/dccea8e3-1160-48c0-abb1-21934ac91d00" />

## MIS (NEE ↔ BSDF sampling)
  - power heuristic (overflow-safe), per-type `light_pdf()`, `prev_bsdf_pdf` through the
    payload; punctual delta lights keep the plain NEE estimator
  - sun disc visible in miss shaders and in specular reflections, MIS-weighted against
    the existing cone-NEE (settles the missing mirror-sun)
  - light bodies visible via an additive, non-terminating ghost-light pass in raygen
    (closed-form intersections, front-facing only, transparent back sides) — no payload/
    miss/host changes, strategy-symmetric with shadow rays
  - `direct-light estimator` debug toggle (MIS / NEE-only / BSDF-only): all modes
    converge to the same image; NEE-only reproduces the pre-MIS renderer bit-identically

  ## Fixes along the way
  - alpha-cutout/blend materials no longer cast solid NEE shadows (shadow rays run the
    any-hit alpha logic in the inline query)
  - NaN bsdf-pdfs from grazing clearcoat eval no longer poison MIS weights
    (`eval_disney` sanitizes the out-pdf; NaN-safe bounce guard)
