### PR TITLE
cache global transforms in a transform_component_t

### DIFF
--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -92,6 +92,27 @@ constexpr inline uint32_t msb(uint32_t v)
     return ret;
 }
 
+/**
+ * @brief   transform_component_t groups an object's local transformation with a cached global one.
+ *
+ * presence of this component means "this object has a transformation", absence means identity.
+ * 'global' is a memoized 'local' composed with all ancestors, valid only while 'dirty' is false.
+ * it is deliberately a transform_t and not a glm::mat4, that is the GPU wire-format.
+ */
+struct transform_component_t
+{
+    VIERKANT_ENABLE_AS_COMPONENT();
+
+    //! local transformation, relative to the parent
+    vierkant::transform_t local = {};
+
+    //! cached global transformation, only valid while !dirty
+    mutable vierkant::transform_t global = {};
+
+    //! marks 'global' as stale. set for this object and all descendants on any change affecting them.
+    mutable bool dirty = true;
+};
+
 struct flag_component_t
 {
     VIERKANT_ENABLE_AS_COMPONENT();
@@ -125,6 +146,26 @@ public:
     void remove_child(const Object3DPtr &child, bool recursive = false);
 
     void set_parent(const Object3DPtr &parent);
+
+    /**
+     * @return  a pointer to this object's local transformation, nullptr if it has none.
+     *          only valid until the next add/remove of a transform_component_t, do not store it.
+     */
+    const vierkant::transform_t *transform() const;
+
+    /**
+     * @brief   set this object's local transformation.
+     *          invalidates the cached global transformation of this object and all descendants.
+     *
+     * @param   t   a transformation
+     */
+    void set_transform(const vierkant::transform_t &t);
+
+    /**
+     * @brief   remove this object's local transformation, it will inherit its parent's.
+     *          invalidates the cached global transformation of this object and all descendants.
+     */
+    void remove_transform();
 
     vierkant::transform_t global_transform() const;
 
@@ -256,9 +297,6 @@ public:
     //! enabled hint, can be used by Visitors
     bool enabled = true;
 
-    //! local transformation of this object
-    std::optional<vierkant::transform_t> transform = {};
-
     //! a list of child-objects
     std::vector<Object3DPtr> children;
 
@@ -268,7 +306,12 @@ protected:
     explicit Object3D(entt::registry *registry, std::string name = "");
 
 private:
+    friend class ObjectStoreImpl;
     friend class crocore::fixed_size_free_list<vierkant::Object3D>;
+
+    //! mark this object's and all descendants' cached global transformation as stale
+    void invalidate_global_transform();
+
     Object3D *m_parent = nullptr;
 
     entt::registry *m_registry = nullptr;

--- a/include/vierkant/transform.hpp
+++ b/include/vierkant/transform.hpp
@@ -66,6 +66,19 @@ inline constexpr bool is_scale_uniform(const transform_t_<T> &t)
 }
 
 /**
+ * @brief   is_identity can be used to check if a transform is the identity-transform.
+ *
+ * @param   t   a provided vierkant::transform_t
+ * @return  true if t is the identity-transform.
+ */
+template<typename T>
+inline constexpr bool is_identity(const transform_t_<T> &t)
+{
+    return t.translation == glm::vec<3, T>(0) && t.rotation == glm::qua<T>(1, 0, 0, 0) &&
+           t.scale == glm::vec<3, T>(1);
+}
+
+/**
  * @brief   operator to apply a vierkant::transform_t to a 3d-vector.
  *
  * @param   t   a provided vierkant::transform_t
@@ -91,6 +104,9 @@ inline constexpr transform_t_<T> operator*(const transform_t_<T> &lhs, const tra
     // fallback to matrix-multiplication to support non-uniform scaling + rotation (sheer)
     if(!is_scale_uniform(lhs) || !is_scale_uniform(rhs))
     {
+        // an identity-operand composes exactly, skip the matrix-roundtrip and its glm::decompose
+        if(is_identity(lhs)) { return rhs; }
+        if(is_identity(rhs)) { return lhs; }
         return transform_cast<T>(mat4_cast<T>(lhs) * mat4_cast<T>(rhs));
     }
     transform_t_<T> ret = lhs;

--- a/include/vierkant/transform.hpp
+++ b/include/vierkant/transform.hpp
@@ -40,6 +40,12 @@ inline constexpr glm::mat<4, 4, T1> mat4_cast(const transform_t_<T2> &t)
 /**
  * @brief   transform_cast can be used to return a vierkant::transform_t for a provided mat4
  *
+ * NOTE: transform_t cannot represent shear (non-uniform scale + rotation), skew/perspective are
+ * discarded here. not a bug: the engine assumes no shear anywhere. two consequences:
+ * - the discarded part is a QR upper-triangle, so this and the composition in operator* cancel
+ *   exactly. a global -> local -> global roundtrip is lossless.
+ * - the projection is not associative, so composition order is observable on a sheared chain.
+ *
  * @param   t   a provided mat4
  * @return  a vierkant::transform_t.
  */
@@ -101,7 +107,8 @@ inline constexpr glm::vec<3, T2> operator*(const transform_t_<T1> &t, const glm:
 template<typename T>
 inline constexpr transform_t_<T> operator*(const transform_t_<T> &lhs, const transform_t_<T> &rhs)
 {
-    // fallback to matrix-multiplication to support non-uniform scaling + rotation (sheer)
+    // fallback to matrix-multiplication to support non-uniform scaling + rotation (sheer).
+    // this projects shear away, see transform_cast.
     if(!is_scale_uniform(lhs) || !is_scale_uniform(rhs))
     {
         // an identity-operand composes exactly, skip the matrix-roundtrip and its glm::decompose

--- a/samples/empty_sample/empty_sample.cpp
+++ b/samples/empty_sample/empty_sample.cpp
@@ -82,8 +82,7 @@ void HelloTriangleApplication::create_context_and_window()
     m_camera->add_component<vierkant::camera_component_t>({params});
     m_camera->name = "default";
 
-    m_camera->transform.emplace();
-    m_camera->transform->translation = {0.f, 0.f, 3.f};
+    m_camera->set_transform({.translation = {0.f, 0.f, 3.f}});
 }
 
 void HelloTriangleApplication::create_graphics_pipeline()

--- a/src/Object3D.cpp
+++ b/src/Object3D.cpp
@@ -194,7 +194,9 @@ vierkant::transform_t Object3D::global_transform() const
 
 void Object3D::set_global_transform(const vierkant::transform_t &t)
 {
-    set_transform(parent() ? transform_cast(glm::inverse(get_global_mat4(parent())) * mat4_cast(t)) : t);
+    // the parent's global is cached, and transform_t::inverse has a uniform-scale fast-path,
+    // so this avoids a mat4-inverse + glm::decompose unless the parent-chain scales non-uniformly
+    set_transform(parent() ? vierkant::inverse(parent()->global_transform()) * t : t);
 
     if(auto *flag_cmp_ptr = get_component_ptr<flag_component_t>())
     {

--- a/src/Object3D.cpp
+++ b/src/Object3D.cpp
@@ -41,9 +41,8 @@ public:
             dst_obj->remove_component<Object3D *>();
             dst_obj->enabled = src_obj->enabled;
             dst_obj->tags = src_obj->tags;
-            dst_obj->transform = src_obj->transform;
 
-            // copy entt-components
+            // copy entt-components, this includes a potential transform_component_t
             for(auto [id, storage]: m_registry->storage())
             {
                 if(storage.contains(static_cast<entt::entity>(src_obj->id())))
@@ -53,6 +52,9 @@ public:
                 }
             }
             dst_obj->add_component(dst_obj.get());
+
+            // the copied cache belongs to the source's position in the hierarchy
+            dst_obj->invalidate_global_transform();
 
             // clone children iteratively
             for(const auto &child: src_obj->children)
@@ -106,11 +108,11 @@ bool has_inherited_flag(const vierkant::Object3D *object, uint32_t flag_bits)
 
 glm::mat4 get_global_mat4(const vierkant::Object3D *obj)
 {
-    glm::mat4 ret = obj->transform ? mat4_cast(*obj->transform) : glm::mat4(1);
+    glm::mat4 ret = obj->transform() ? mat4_cast(*obj->transform()) : glm::mat4(1);
     auto ancestor = obj->parent();
     while(ancestor)
     {
-        if(ancestor->transform) { ret = mat4_cast(*ancestor->transform) * ret; }
+        if(ancestor->transform()) { ret = mat4_cast(*ancestor->transform()) * ret; }
         ancestor = ancestor->parent();
     }
     return ret;
@@ -130,27 +132,70 @@ Object3D::~Object3D() noexcept
 {
     for(const auto &child: children)
     {
-        if(child) { child->m_parent = nullptr; }
+        if(child)
+        {
+            // orphaned children lose an ancestor, their cached globals are stale now
+            child->m_parent = nullptr;
+            child->invalidate_global_transform();
+        }
     }
 
     if(m_registry) { m_registry->destroy(m_entity); }
 }
 
+const vierkant::transform_t *Object3D::transform() const
+{
+    auto *transform_cmp = get_component_ptr<transform_component_t>();
+    return transform_cmp ? &transform_cmp->local : nullptr;
+}
+
+void Object3D::set_transform(const vierkant::transform_t &t)
+{
+    add_component<transform_component_t>({.local = t});
+    invalidate_global_transform();
+}
+
+void Object3D::remove_transform()
+{
+    remove_component<transform_component_t>();
+    invalidate_global_transform();
+}
+
+void Object3D::invalidate_global_transform()
+{
+    // a dirty object may still have clean descendants, so the whole sub-tree has to be visited
+    std::stack<Object3D *> stack;
+    stack.push(this);
+
+    while(!stack.empty())
+    {
+        auto *object = stack.top();
+        stack.pop();
+
+        if(auto *transform_cmp = object->get_component_ptr<transform_component_t>()) { transform_cmp->dirty = true; }
+        for(const auto &child: object->children) { stack.push(child.get()); }
+    }
+}
+
 vierkant::transform_t Object3D::global_transform() const
 {
-    vierkant::transform_t ret = transform ? *transform : vierkant::transform_t{};
-    const Object3D *ancestor = parent();
-    while(ancestor)
+    auto *transform_cmp = get_component_ptr<transform_component_t>();
+
+    // no transform of our own, we are wherever our parent is
+    if(!transform_cmp) { return parent() ? parent()->global_transform() : vierkant::transform_t{}; }
+
+    if(transform_cmp->dirty)
     {
-        if(ancestor->transform) { ret = *ancestor->transform * ret; }
-        ancestor = ancestor->parent();
+        transform_cmp->global = parent() ? parent()->global_transform() * transform_cmp->local : transform_cmp->local;
+        transform_cmp->dirty = false;
     }
-    return ret;
+    return transform_cmp->global;
 }
 
 void Object3D::set_global_transform(const vierkant::transform_t &t)
 {
-    transform = parent() ? transform_cast(glm::inverse(get_global_mat4(parent())) * mat4_cast(t)) : t;
+    set_transform(parent() ? transform_cast(glm::inverse(get_global_mat4(parent())) * mat4_cast(t)) : t);
+
     if(auto *flag_cmp_ptr = get_component_ptr<flag_component_t>())
     {
         flag_cmp_ptr->flags |= flag_component_t::DIRTY_TRANSFORM;
@@ -183,7 +228,11 @@ void Object3D::set_parent(const Object3DPtr &parent_object)
         parent_object->add_child(shared_from_this());
         m_registry = parent_object->m_registry;
     }
-    else { m_parent = nullptr; }
+    else
+    {
+        m_parent = nullptr;
+        invalidate_global_transform();
+    }
 }
 
 void Object3D::add_child(const Object3DPtr &child)
@@ -202,6 +251,9 @@ void Object3D::add_child(const Object3DPtr &child)
         child->set_parent(Object3DPtr());
         child->m_parent = this;
 
+        // the child gained an ancestor-chain
+        child->invalidate_global_transform();
+
         // prevent multiple insertions
         if(std::ranges::find(children, child) == children.end()) { children.push_back(child); }
     }
@@ -212,7 +264,13 @@ void Object3D::remove_child(const Object3DPtr &child, bool recursive)
     if(const auto it = std::ranges::find(children, child); it != children.end())
     {
         children.erase(it);
-        if(child) { child->set_parent(nullptr); }
+        if(child)
+        {
+            child->set_parent(nullptr);
+
+            // the child lost its ancestor-chain
+            child->invalidate_global_transform();
+        }
     }
     else if(recursive)
     {
@@ -232,7 +290,7 @@ AABB Object3D::aabb() const
     for(const auto &child: children)
     {
         auto child_aabb = child->aabb();
-        if(child->transform) { child_aabb = child_aabb.transform(*child->transform); }
+        if(const auto *child_transform = child->transform()) { child_aabb = child_aabb.transform(*child_transform); }
         ret += child_aabb;
     }
     return ret;

--- a/src/Object3D.cpp
+++ b/src/Object3D.cpp
@@ -106,18 +106,6 @@ bool has_inherited_flag(const vierkant::Object3D *object, uint32_t flag_bits)
     return false;
 }
 
-glm::mat4 get_global_mat4(const vierkant::Object3D *obj)
-{
-    glm::mat4 ret = obj->transform() ? mat4_cast(*obj->transform()) : glm::mat4(1);
-    auto ancestor = obj->parent();
-    while(ancestor)
-    {
-        if(ancestor->transform()) { ret = mat4_cast(*ancestor->transform()) * ret; }
-        ancestor = ancestor->parent();
-    }
-    return ret;
-}
-
 Object3D::Object3D(entt::registry *registry, std::string name_) : name(std::move(name_)), m_registry(registry)
 {
     if(registry)

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -20,7 +20,7 @@ vierkant::Object3DPtr Scene::create_mesh_object(const mesh_component_t &mesh_com
     auto object = create_object();
 
     // add a transform
-    object->transform.emplace();
+    object->set_transform({});
 
     object->add_component(mesh_component);
     if(!mesh_component.mesh->node_animations.empty()) { object->add_component<vierkant::animation_component_t>(); }

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -37,9 +37,17 @@ public:
 
     void visit(vierkant::Object3D &object) override
     {
-        if(should_visit(object))
+        if(object.enabled && check_tags(m_tags, object.tags))
         {
+            // compose once, reused for the frustum-check, the drawables and the child-stack
             auto model_view = object.transform ? m_transform_stack.top() * *object.transform : m_transform_stack.top();
+
+            if(m_check_intersection)
+            {
+                // check intersection of aabb in eye-coords with view-frustum
+                auto aabb = object.aabb().transform(model_view);
+                if(!vierkant::intersect(m_frustum, aabb)) { return; }
+            }
 
             // keep track of meshes
             if(const auto *mesh_component = object.get_component_ptr<vierkant::mesh_component_t>())
@@ -80,27 +88,9 @@ public:
             //                m_cull_result.lights.push_back(vierkant::convert_light(lightsource));
             //            }
 
-            auto transform = object.transform ? m_transform_stack.top() * *object.transform : m_transform_stack.top();
-            scoped_stack_push scoped_stack_push(m_transform_stack, transform);
+            scoped_stack_push scoped_stack_push(m_transform_stack, model_view);
             for(Object3DPtr &child: object.children) { child->accept(*this); }
         }
-    }
-
-    bool should_visit(vierkant::Object3D &object) const override
-    {
-        if(object.enabled && check_tags(m_tags, object.tags))
-        {
-            if(m_check_intersection)
-            {
-                // check intersection of aabb in eye-coords with view-frustum
-                auto transform =
-                        object.transform ? m_transform_stack.top() * *object.transform : m_transform_stack.top();
-                auto aabb = object.aabb().transform(transform);
-                return vierkant::intersect(m_frustum, aabb);
-            }
-            return true;
-        }
-        return false;
     }
 
     std::set<std::string> m_tags;

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -11,16 +11,6 @@
 namespace vierkant
 {
 
-struct scoped_stack_push
-{
-    std::stack<vierkant::transform_t> &stack;
-
-    scoped_stack_push(std::stack<vierkant::transform_t> &stack_, const vierkant::transform_t &t) : stack(stack_)
-    { stack.push(t); }
-
-    ~scoped_stack_push() { stack.pop(); }
-};
-
 class CullVisitor : public vierkant::Visitor
 {
 public:
@@ -28,19 +18,15 @@ public:
         : m_frustum(camera::frustum(cam.get())), m_camera(std::move(cam)), m_scene(std::move(scene)),
           m_check_intersection(check_intersection)
     {
-        if(!world_space) { m_transform_stack.push(camera::view_transform(m_camera.get())); }
-        else
-        {
-            m_transform_stack.push({});
-        }
+        if(!world_space) { m_base_transform = camera::view_transform(m_camera.get()); }
     };
 
     void visit(vierkant::Object3D &object) override
     {
         if(object.enabled && check_tags(m_tags, object.tags))
         {
-            // compose once, reused for the frustum-check, the drawables and the child-stack
-            auto model_view = object.transform ? m_transform_stack.top() * *object.transform : m_transform_stack.top();
+            // cached global, no accumulation during traversal required
+            auto model_view = m_base_transform * object.global_transform();
 
             if(m_check_intersection)
             {
@@ -88,7 +74,6 @@ public:
             //                m_cull_result.lights.push_back(vierkant::convert_light(lightsource));
             //            }
 
-            scoped_stack_push scoped_stack_push(m_transform_stack, model_view);
             for(Object3DPtr &child: object.children) { child->accept(*this); }
         }
     }
@@ -103,7 +88,8 @@ public:
 
     bool m_check_intersection;
 
-    std::stack<vierkant::transform_t> m_transform_stack;
+    //! view-transform for eye-space culling, identity when culling in world-space
+    vierkant::transform_t m_base_transform = {};
 
     cull_result_t m_cull_result;
 };

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -1519,25 +1519,35 @@ void draw_object_ui(const vierkant::ScenePtr &scene, const Object3DPtr &object)
         bool change = ImGui::InputFloat("width", &w);
         change |= ImGui::InputFloat("height", &h);
         change |= ImGui::InputFloat("depth", &d);
-        if(change && object->transform)
+        if(change && object->transform())
         {
-            object->transform->scale *= glm::vec3(w / aabb.width(), h / aabb.height(), d / aabb.depth());
+            auto local = *object->transform();
+            local.scale *= glm::vec3(w / aabb.width(), h / aabb.height(), d / aabb.depth());
+            object->set_transform(local);
         }
         ImGui::TreePop();
     }
 
     // transform
-    if(object->transform && draw_transform(*object->transform))
+    if(object->transform())
     {
-        if(auto *flag_cmp_ptr = object->get_component_ptr<flag_component_t>())
-        {
-            flag_cmp_ptr->flags |= flag_component_t::DIRTY_TRANSFORM;
-        }
-        else
-        {
+        // draw_transform edits in place, so operate on a copy and write it back through the setter
+        auto local = *object->transform();
 
-            auto &flag_cmp = object->add_component<flag_component_t>();
-            flag_cmp.flags |= flag_component_t::DIRTY_TRANSFORM;
+        if(draw_transform(local))
+        {
+            object->set_transform(local);
+
+            if(auto *flag_cmp_ptr = object->get_component_ptr<flag_component_t>())
+            {
+                flag_cmp_ptr->flags |= flag_component_t::DIRTY_TRANSFORM;
+            }
+            else
+            {
+
+                auto &flag_cmp = object->add_component<flag_component_t>();
+                flag_cmp.flags |= flag_component_t::DIRTY_TRANSFORM;
+            }
         }
     }
 

--- a/tests/TestObject3D.cpp
+++ b/tests/TestObject3D.cpp
@@ -51,6 +51,29 @@ TEST(Object3D, hierarchy)
     EXPECT_TRUE(glm::vec3(b->global_transform().translation) == glm::vec3(1, 2, 3));
 }
 
+TEST(Object3D, identity_grouping_node)
+{
+    auto object_store = vierkant::create_object_store();
+    Object3DPtr root(object_store->create_object()), group(object_store->create_object()),
+            child(object_store->create_object());
+
+    root->add_child(group);
+    group->add_child(child);
+
+    child->transform =
+            transform_t{.translation = {0.1f, -0.03f, 7.25f},
+                        .rotation = glm::angleAxis(glm::radians(123.456f), glm::normalize(glm::vec3(4, -7, 6))),
+                        .scale = {0.37f, 1.23f, 2.91f}};
+
+    // a present identity-transform must not perturb the accumulated transform ...
+    group->transform = transform_t{};
+    EXPECT_TRUE(child->global_transform() == *child->transform);
+
+    // ... and needs to match the absent-transform case exactly
+    group->transform = {};
+    EXPECT_TRUE(child->global_transform() == *child->transform);
+}
+
 TEST(Object3D, outliving_parent)
 {
     auto object_store = vierkant::create_object_store();

--- a/tests/TestObject3D.cpp
+++ b/tests/TestObject3D.cpp
@@ -161,6 +161,47 @@ TEST(Object3D, global_transform_cache_invalidation)
     EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 0.1f, 0.f));
 }
 
+//! set_global_transform(t) followed by global_transform() has to reproduce t, whatever the parent is
+TEST(Object3D, set_global_transform_roundtrip)
+{
+    auto object_store = vierkant::create_object_store();
+
+    const transform_t targets[] = {
+            {.translation = {1.f, 2.f, 3.f}},
+            {.translation = {-4.f, 0.5f, 9.f},
+             .rotation = glm::angleAxis(glm::radians(73.f), glm::normalize(glm::vec3(1, -2, 4))),
+             .scale = glm::vec3(2.f)},
+            {.translation = {0.3f, -1.f, 0.f},
+             .rotation = glm::angleAxis(glm::radians(31.f), glm::normalize(glm::vec3(0, 1, 1))),
+             .scale = {0.4f, 1.7f, 2.2f}},
+    };
+
+    const transform_t parents[] = {
+            {},
+            {.translation = {5.f, 0.f, -2.f}},
+            {.translation = {5.f, 0.f, -2.f},
+             .rotation = glm::angleAxis(glm::radians(30.f), glm::vec3(0, 1, 0)),
+             .scale = glm::vec3(3.f)},
+            // non-uniform scale + rotation, i.e. a sheared parent-chain
+            {.translation = {1.f, 2.f, 3.f},
+             .rotation = glm::angleAxis(glm::radians(30.f), glm::vec3(0, 1, 0)),
+             .scale = {1.f, 3.f, 1.f}},
+    };
+
+    for(const auto &parent_transform: parents)
+    {
+        for(const auto &target: targets)
+        {
+            Object3DPtr parent(object_store->create_object()), child(object_store->create_object());
+            parent->set_transform(parent_transform);
+            parent->add_child(child);
+
+            child->set_global_transform(target);
+            EXPECT_TRUE(epsilon_equal(child->global_transform(), target, 1.e-5f));
+        }
+    }
+}
+
 TEST(Object3D, global_transform_cache_clone)
 {
     auto object_store = vierkant::create_object_store();

--- a/tests/TestObject3D.cpp
+++ b/tests/TestObject3D.cpp
@@ -1,5 +1,7 @@
 #include "vierkant/Object3D.hpp"
 #include <gtest/gtest.h>
+#include <random>
+#include <ranges>
 
 using namespace vierkant;
 //____________________________________________________________________________//
@@ -39,8 +41,8 @@ TEST(Object3D, hierarchy)
     EXPECT_TRUE(c->parent() == b.get());
     EXPECT_TRUE(b->parent() == a.get());
 
-    a->transform = transform_t{.translation = {0, 100, 0}};
-    b->transform = transform_t{.translation{0, 50, 0}};
+    a->set_transform({.translation = {0, 100, 0}});
+    b->set_transform({.translation{0, 50, 0}});
     EXPECT_TRUE(glm::vec3(b->global_transform().translation) == glm::vec3(0, 150, 0));
 
     vierkant::transform_t t = {};
@@ -60,29 +62,213 @@ TEST(Object3D, identity_grouping_node)
     root->add_child(group);
     group->add_child(child);
 
-    child->transform =
+    child->set_transform(
             transform_t{.translation = {0.1f, -0.03f, 7.25f},
                         .rotation = glm::angleAxis(glm::radians(123.456f), glm::normalize(glm::vec3(4, -7, 6))),
-                        .scale = {0.37f, 1.23f, 2.91f}};
+                        .scale = {0.37f, 1.23f, 2.91f}});
 
     // a present identity-transform must not perturb the accumulated transform ...
-    group->transform = transform_t{};
-    EXPECT_TRUE(child->global_transform() == *child->transform);
+    group->set_transform({});
+    EXPECT_TRUE(child->global_transform() == *child->transform());
 
     // ... and needs to match the absent-transform case exactly
-    group->transform = {};
-    EXPECT_TRUE(child->global_transform() == *child->transform);
+    group->remove_transform();
+    EXPECT_TRUE(child->global_transform() == *child->transform());
+}
+
+//! reference: the bottom-up ancestor-walk that global_transform() used to be. right-associated.
+transform_t reference_global_bottom_up(const Object3D *object)
+{
+    transform_t ret = object->transform() ? *object->transform() : transform_t{};
+    const Object3D *ancestor = object->parent();
+    while(ancestor)
+    {
+        if(ancestor->transform()) { ret = *ancestor->transform() * ret; }
+        ancestor = ancestor->parent();
+    }
+    return ret;
+}
+
+//! reference: root-first accumulation, as CullVisitor's transform-stack did it. left-associated.
+transform_t reference_global_top_down(const Object3D *object)
+{
+    std::vector<const Object3D *> chain;
+    for(const Object3D *o = object; o; o = o->parent()) { chain.push_back(o); }
+
+    transform_t ret = {};
+    for(const auto *o: std::ranges::reverse_view(chain))
+    {
+        if(o->transform()) { ret = ret * *o->transform(); }
+    }
+    return ret;
+}
+
+TEST(Object3D, global_transform_cache_same_frame_write)
+{
+    auto object_store = vierkant::create_object_store();
+    Object3DPtr parent(object_store->create_object()), child(object_store->create_object());
+    parent->add_child(child);
+
+    parent->set_transform({.translation = {0.f, 10.f, 0.f}});
+    child->set_transform({.translation = {0.f, 1.f, 0.f}});
+
+    // prime both caches
+    EXPECT_EQ(glm::vec3(child->global_transform().translation), glm::vec3(0.f, 11.f, 0.f));
+
+    // a write to the parent must be visible to the child immediately, not only after a frame-boundary.
+    // this is the physics_context.cpp:1770-1774 case: parents are written before children are read.
+    parent->set_transform({.translation = {0.f, 20.f, 0.f}});
+    EXPECT_EQ(glm::vec3(child->global_transform().translation), glm::vec3(0.f, 21.f, 0.f));
+
+    // same via set_global_transform, which physics actually uses
+    parent->set_global_transform(transform_t{.translation = {0.f, 30.f, 0.f}});
+    EXPECT_EQ(glm::vec3(child->global_transform().translation), glm::vec3(0.f, 31.f, 0.f));
+}
+
+TEST(Object3D, global_transform_cache_invalidation)
+{
+    auto object_store = vierkant::create_object_store();
+    Object3DPtr parent(object_store->create_object()), child(object_store->create_object()),
+            grand_child(object_store->create_object());
+
+    parent->set_transform({.translation = {0.f, 10.f, 0.f}});
+    child->set_transform({.translation = {0.f, 1.f, 0.f}});
+    grand_child->set_transform({.translation = {0.f, 0.1f, 0.f}});
+
+    // invalidation has to reach descendants, not just direct children
+    parent->add_child(child);
+    child->add_child(grand_child);
+    EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 11.1f, 0.f));
+
+    parent->set_transform({.translation = {0.f, 20.f, 0.f}});
+    EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 21.1f, 0.f));
+
+    // remove_child drops an ancestor-chain
+    parent->remove_child(child);
+    EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 1.1f, 0.f));
+
+    // set_parent re-attaches it
+    child->set_parent(parent);
+    EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 21.1f, 0.f));
+
+    // set_parent(nullptr) detaches
+    child->set_parent(Object3DPtr());
+    EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 1.1f, 0.f));
+
+    // removing the transform entirely
+    child->remove_transform();
+    EXPECT_TRUE(!child->transform());
+    EXPECT_EQ(glm::vec3(grand_child->global_transform().translation), glm::vec3(0.f, 0.1f, 0.f));
+}
+
+TEST(Object3D, global_transform_cache_clone)
+{
+    auto object_store = vierkant::create_object_store();
+    Object3DPtr parent(object_store->create_object()), child(object_store->create_object());
+    parent->set_transform({.translation = {0.f, 10.f, 0.f}});
+    child->set_transform({.translation = {0.f, 1.f, 0.f}});
+    parent->add_child(child);
+
+    // prime the caches, so a clone would inherit stale values
+    EXPECT_EQ(glm::vec3(child->global_transform().translation), glm::vec3(0.f, 11.f, 0.f));
+
+    // the clone has no parent, so its global must equal its local
+    auto clone = object_store->clone(child.get());
+    EXPECT_TRUE(!clone->parent());
+    EXPECT_EQ(glm::vec3(clone->global_transform().translation), glm::vec3(0.f, 1.f, 0.f));
+}
+
+//! chain of 'num_objects', every 3rd without a transform. scales are uniform, see the shear-note below.
+std::vector<Object3DPtr> build_chain(vierkant::ObjectStore &object_store, uint32_t num_objects, bool uniform_scale)
+{
+    std::vector<Object3DPtr> objects;
+    for(uint32_t i = 0; i < num_objects; ++i)
+    {
+        auto object = object_store.create_object();
+        if(i % 3 != 0)
+        {
+            object->set_transform({.translation = {float(i), 2.f * float(i), -float(i)},
+                                              .rotation = glm::angleAxis(glm::radians(17.f * float(i)),
+                                                                         glm::normalize(glm::vec3(1, 2, 3))),
+                                              .scale = uniform_scale
+                                                               ? glm::vec3(0.5f + 0.1f * float(i))
+                                                               : glm::vec3(1.f, 0.5f + 0.1f * float(i), 1.3f)});
+        }
+        if(i) { objects[i - 1]->add_child(object); }
+        objects.push_back(object);
+    }
+    return objects;
+}
+
+TEST(Object3D, global_transform_cache_equivalence)
+{
+    auto object_store = vierkant::create_object_store();
+    auto objects = build_chain(*object_store, 6, true);
+
+    auto check_all = [&objects]() {
+        for(const auto &object: objects)
+        {
+            EXPECT_TRUE(epsilon_equal(object->global_transform(), reference_global_bottom_up(object.get()), 1.e-5f));
+        }
+    };
+    check_all();
+
+    // a deterministic sequence of mutations, comparing against the reference-walk after each
+    std::mt19937 rng(42);
+    for(uint32_t i = 0; i < 64; ++i)
+    {
+        auto &object = objects[rng() % objects.size()];
+
+        switch(rng() % 3)
+        {
+            case 0:
+                object->set_transform({.translation = glm::vec3(float(rng() % 10), 1.f, 2.f),
+                                                  .scale = glm::vec3(1.f + float(rng() % 3))});
+                break;
+            case 1: object->remove_transform(); break;
+            case 2:
+                if(object->parent()) { object->set_global_transform(transform_t{.translation = {1.f, 2.f, 3.f}}); }
+                break;
+            default: break;
+        }
+        check_all();
+    }
+}
+
+/**
+ * a cached global is 'parent_global * local', which accumulates root-first (left-associated).
+ * the old bottom-up walk accumulated leaf-first (right-associated). those agree exactly in
+ * exact arithmetic, but operator* projects shear away for non-uniform scale (transform.hpp:104),
+ * and that projection is not associative - the two disagree by a lot on a sheared chain.
+ *
+ * this is not a regression: CullVisitor's transform-stack already accumulated root-first, so the
+ * cached value matches what the renderer has always used, and global_transform() now agrees with it.
+ */
+TEST(Object3D, global_transform_cache_matches_top_down_accumulation)
+{
+    auto object_store = vierkant::create_object_store();
+    auto objects = build_chain(*object_store, 6, false);
+
+    for(const auto &object: objects)
+    {
+        EXPECT_TRUE(epsilon_equal(object->global_transform(), reference_global_top_down(object.get()), 1.e-5f));
+    }
+
+    // ... and the sheared chain really does disagree with the old bottom-up walk, i.e. the test above
+    // would fail here. guards against someone "fixing" the shear-projection and silently changing poses.
+    const auto &leaf = objects.back();
+    EXPECT_FALSE(epsilon_equal(leaf->global_transform(), reference_global_bottom_up(leaf.get()), 1.e-5f));
 }
 
 TEST(Object3D, outliving_parent)
 {
     auto object_store = vierkant::create_object_store();
     Object3DPtr child = object_store->create_object();
-    child->transform = transform_t{.translation = {1.f, 2.f, 3.f}};
+    child->set_transform({.translation = {1.f, 2.f, 3.f}});
 
     {
         Object3DPtr parent = object_store->create_object();
-        parent->transform = transform_t{.translation = {0.f, 50.f, 0.f}};
+        parent->set_transform({.translation = {0.f, 50.f, 0.f}});
         parent->add_child(child);
         ASSERT_TRUE(child->parent() == parent.get());
         EXPECT_EQ(glm::vec3(child->global_transform().translation), glm::vec3(1.f, 52.f, 3.f));

--- a/tests/TestPhysicsContext.cpp
+++ b/tests/TestPhysicsContext.cpp
@@ -29,7 +29,7 @@ void create_ground(const std::shared_ptr<vierkant::ObjectStore> &object_store,
                    const std::shared_ptr<vierkant::PhysicsScene> &scene, const glm::vec3 &half_extents)
 {
     auto ground = object_store->create_object();
-    ground->transform = transform_t{.translation = {0.f, -half_extents.y, 0.f}};
+    ground->set_transform({.translation = {0.f, -half_extents.y, 0.f}});
     vierkant::physics_component_t cmp = {};
     cmp.shape = collision::box_t{.half_extents = half_extents};
     cmp.mass = 0.f;
@@ -43,7 +43,7 @@ void create_ramp(const std::shared_ptr<vierkant::ObjectStore> &object_store,
 {
     auto ramp = object_store->create_object();
     glm::quat rotation = glm::angleAxis(glm::radians(angle_deg), glm::vec3(1.f, 0.f, 0.f));
-    ramp->transform = transform_t{.translation = rotation * glm::vec3(0.f, -.5f, 0.f), .rotation = rotation};
+    ramp->set_transform({.translation = rotation * glm::vec3(0.f, -.5f, 0.f), .rotation = rotation});
     vierkant::physics_component_t cmp = {};
     cmp.shape = collision::box_t{.half_extents = {50.f, .5f, 50.f}};
     cmp.mass = 0.f;
@@ -58,7 +58,7 @@ vierkant::Object3DPtr create_character(const std::shared_ptr<vierkant::ObjectSto
 {
     constexpr float radius = .3f, cylinder_height = 1.2f;
     auto player = object_store->create_object();
-    player->transform = transform_t{.translation = position};
+    player->set_transform({.translation = position});
     vierkant::physics_component_t cmp = {};
     cmp.shape = collision::capsule_t{.radius = radius, .height = cylinder_height};
     cmp.shape_transform = transform_t{.translation = {0.f, .5f * cylinder_height + radius, 0.f}};
@@ -94,7 +94,7 @@ TEST(PhysicsContext, add_remove_object)
 
     // create object / init transform
     auto a = object_store->create_object();
-    a->transform.emplace();
+    a->set_transform({});
 
     // a does not (yet) have a vierkant::physics_component, so adding has no effect
     scene->add_object(a);
@@ -104,7 +104,7 @@ TEST(PhysicsContext, add_remove_object)
     // now add required component
     vierkant::object_component auto &cmp = a->add_component<vierkant::physics_component_t>();
     cmp.shape = collision::box_t{glm::vec3(0.5f)};
-    scene->physics_context().add_object(a->id(), *a->transform, cmp);
+    scene->physics_context().add_object(a->id(), *a->transform(), cmp);
 
     EXPECT_TRUE(context.contains(a->id()));
     EXPECT_EQ(context.body_interface().velocity(a->id()), glm::vec3(0));
@@ -130,7 +130,7 @@ TEST(PhysicsContext, character)
     // static, concave triangle-mesh as ground, top-surface at y == 0.5
     constexpr float ground_height = .5f;
     auto ground = object_store->create_object();
-    ground->transform.emplace();
+    ground->set_transform({});
     vierkant::physics_component_t ground_cmp = {};
     ground_cmp.shape = create_collision_shape(context, Geometry::Box(), false);
     ground_cmp.mass = 0.f;
@@ -140,7 +140,7 @@ TEST(PhysicsContext, character)
     // 1.8m character: 0.3 radius + 1.2 cylinder, shape_transform puts the origin at the feet
     constexpr float radius = .3f, cylinder_height = 1.2f, start_height = 3.f;
     auto player = object_store->create_object();
-    player->transform = transform_t{.translation = {0.f, start_height, 0.f}};
+    player->set_transform({.translation = {0.f, start_height, 0.f}});
     vierkant::physics_component_t player_cmp = {};
     player_cmp.shape = collision::capsule_t{.radius = radius, .height = cylinder_height};
     player_cmp.shape_transform = transform_t{.translation = {0.f, .5f * cylinder_height + radius, 0.f}};
@@ -165,14 +165,14 @@ TEST(PhysicsContext, character)
     for(uint32_t i = 0; i < 200; ++i) { scene->update(1.f / 60.f); }
 
     // the character fell, its object-transform tracked the body via the existing readback
-    EXPECT_LT(player->transform->translation.y, start_height);
+    EXPECT_LT(player->transform()->translation.y, start_height);
 
     // ... and came to rest with its feet on the ground
-    EXPECT_NEAR(player->transform->translation.y, ground_height, .05f);
+    EXPECT_NEAR(player->transform()->translation.y, ground_height, .05f);
     EXPECT_EQ(character.ground_state, vierkant::GroundState::OnGround);
 
     // rotation is locked -> the capsule stayed upright
-    EXPECT_NEAR(std::abs(player->transform->rotation.w), 1.f, 1.e-5f);
+    EXPECT_NEAR(std::abs(player->transform()->rotation.w), 1.f, 1.e-5f);
 
     context.remove_object(player->id(), player_cmp);
     EXPECT_FALSE(context.contains(player->id()));
@@ -191,7 +191,7 @@ TEST(PhysicsContext, character_slope)
     // 1.8m character standing on the ramp, slope-limit below the ramp's angle
     constexpr float radius = .3f, cylinder_height = 1.2f;
     auto player = object_store->create_object();
-    player->transform = transform_t{.translation = {0.f, .1f, 0.f}};
+    player->set_transform({.translation = {0.f, .1f, 0.f}});
     vierkant::physics_component_t player_cmp = {};
     player_cmp.shape = collision::capsule_t{.radius = radius, .height = cylinder_height};
     player_cmp.shape_transform = transform_t{.translation = {0.f, .5f * cylinder_height + radius, 0.f}};
@@ -224,7 +224,7 @@ TEST(PhysicsContext, player_move)
 
     // static box as ground, top-surface at y == 0
     auto ground = object_store->create_object();
-    ground->transform = transform_t{.translation = {0.f, -.5f, 0.f}};
+    ground->set_transform({.translation = {0.f, -.5f, 0.f}});
     vierkant::physics_component_t ground_cmp = {};
     ground_cmp.shape = collision::box_t{.half_extents = {50.f, .5f, 50.f}};
     ground_cmp.mass = 0.f;
@@ -234,7 +234,7 @@ TEST(PhysicsContext, player_move)
     // 1.8m character: 0.3 radius + 1.2 cylinder, shape_transform puts the origin at the feet
     constexpr float radius = .3f, cylinder_height = 1.2f;
     auto player = object_store->create_object();
-    player->transform = transform_t{.translation = {0.f, .1f, 0.f}};
+    player->set_transform({.translation = {0.f, .1f, 0.f}});
     vierkant::physics_component_t player_cmp = {};
     player_cmp.shape = collision::capsule_t{.radius = radius, .height = cylinder_height};
     player_cmp.shape_transform = transform_t{.translation = {0.f, .5f * cylinder_height + radius, 0.f}};
@@ -249,11 +249,11 @@ TEST(PhysicsContext, player_move)
     // let the capsule settle on the ground
     for(uint32_t i = 0; i < 60; ++i) { scene->update(dt); }
     ASSERT_EQ(input.ground_state, vierkant::GroundState::OnGround);
-    const glm::vec3 rest_position = player->transform->translation;
+    const glm::vec3 rest_position = player->transform()->translation;
 
     // no input -> the tracker holds the position
     for(uint32_t i = 0; i < 60; ++i) { scene->update(dt); }
-    EXPECT_NEAR(glm::length(player->transform->translation - rest_position), 0.f, .01f);
+    EXPECT_NEAR(glm::length(player->transform()->translation - rest_position), 0.f, .01f);
 
     // the character-body has no contact-friction, so the tracker settles right at max_speed
     constexpr float speed_eps = .02f;
@@ -264,7 +264,7 @@ TEST(PhysicsContext, player_move)
     glm::vec3 velocity = context.body_interface().velocity(player->id());
     EXPECT_NEAR(velocity.z, -input.max_speed, speed_eps);
     EXPECT_NEAR(velocity.x, 0.f, .01f);
-    EXPECT_LT(player->transform->translation.z, rest_position.z - 1.f);
+    EXPECT_LT(player->transform()->translation.z, rest_position.z - 1.f);
 
     // ... yaw rotates the movement-basis, 90 degrees puts 'forward' onto -x
     input.yaw = glm::half_pi<float>();
@@ -298,7 +298,7 @@ TEST(PhysicsContext, character_jump)
     constexpr float dt = 1.f / 60.f;
     for(uint32_t i = 0; i < 60; ++i) { scene->update(dt); }
     ASSERT_EQ(input.ground_state, vierkant::GroundState::OnGround);
-    const float rest_height = player->transform->translation.y;
+    const float rest_height = player->transform()->translation.y;
 
     // a jump from standing reaches jump_height and lands again
     input.jump = true;
@@ -306,10 +306,10 @@ TEST(PhysicsContext, character_jump)
     for(uint32_t i = 0; i < 120; ++i)
     {
         scene->update(dt);
-        apex = std::max(apex, player->transform->translation.y);
+        apex = std::max(apex, player->transform()->translation.y);
     }
     EXPECT_NEAR(apex - rest_height, input.jump_height, .1f);
-    EXPECT_NEAR(player->transform->translation.y, rest_height, .05f);
+    EXPECT_NEAR(player->transform()->translation.y, rest_height, .05f);
     EXPECT_EQ(input.ground_state, vierkant::GroundState::OnGround);
 
     // jump again, then press mid-air, well past the coyote-window
@@ -378,9 +378,9 @@ TEST(PhysicsContext, character_stands_on_slope)
     EXPECT_NEAR(glm::degrees(std::acos(glm::dot(input.ground_normal, glm::vec3(0.f, 1.f, 0.f)))), 30.f, 1.f);
 
     // the body has no friction, so only the gravity-compensation keeps it from sliding off
-    const glm::vec3 rest_position = player->transform->translation;
+    const glm::vec3 rest_position = player->transform()->translation;
     for(uint32_t i = 0; i < 120; ++i) { scene->update(dt); }
-    EXPECT_NEAR(glm::length(player->transform->translation - rest_position), 0.f, .02f);
+    EXPECT_NEAR(glm::length(player->transform()->translation - rest_position), 0.f, .02f);
 }
 
 TEST(PhysicsContext, character_cannot_climb_steep_slope)
@@ -404,16 +404,16 @@ TEST(PhysicsContext, character_cannot_climb_steep_slope)
 
         for(uint32_t i = 0; i < 30; ++i) { scene->update(dt); }
         EXPECT_EQ(input.ground_state, vierkant::GroundState::OnSteepGround);
-        const glm::vec3 start_position = player->transform->translation;
+        const glm::vec3 start_position = player->transform()->translation;
 
         // -z is uphill
         if(uphill_input) { input.move = {0.f, 1.f}; }
         for(uint32_t i = 0; i < 120; ++i) { scene->update(dt); }
 
         // gravity is in charge: the character keeps sliding downhill
-        EXPECT_LT(player->transform->translation.y, start_position.y);
-        EXPECT_GT(player->transform->translation.z, start_position.z);
-        return glm::length(player->transform->translation - start_position);
+        EXPECT_LT(player->transform()->translation.y, start_position.y);
+        EXPECT_GT(player->transform()->translation.z, start_position.z);
+        return glm::length(player->transform()->translation - start_position);
     };
 
     // ... and the tracker stays silent, so the input makes no difference at all
@@ -434,7 +434,7 @@ TEST(PhysicsContext, character_does_not_stick_to_walls)
         if(with_wall)
         {
             auto wall = object_store->create_object();
-            wall->transform = transform_t{.translation = {.8f, 0.f, 0.f}};
+            wall->set_transform({.translation = {.8f, 0.f, 0.f}});
             vierkant::physics_component_t cmp = {};
             cmp.shape = collision::box_t{.half_extents = {.5f, 10.f, 10.f}};
             cmp.mass = 0.f;
@@ -447,9 +447,9 @@ TEST(PhysicsContext, character_does_not_stick_to_walls)
         // full input towards +x, i.e. into the wall
         input.move = {1.f, 0.f};
         scene->update(dt);
-        const float start_height = player->transform->translation.y;
+        const float start_height = player->transform()->translation.y;
         for(uint32_t i = 0; i < 60; ++i) { scene->update(dt); }
-        return start_height - player->transform->translation.y;
+        return start_height - player->transform()->translation.y;
     };
 
     // pressed against a wall the character still falls freely - no friction to hang on
@@ -503,8 +503,7 @@ TEST(PhysicsContext, simulation)
     float i = 0;
     for(const auto &obj: objects)
     {
-        obj->transform.emplace();
-        obj->transform->translation.y = i++ * 5.f;
+        obj->set_transform({.translation = {0.f, i++ * 5.f, 0.f}});
         scene->add_object(obj);
         scene->physics_context().set_callbacks(obj->id(), callbacks);
 
@@ -523,7 +522,7 @@ TEST(PhysicsContext, simulation)
 
     auto sensor = object_store->create_object();
     sensor->name = "sensor";
-    sensor->transform = transform_t{.translation = {0.f, 3.f, 0.f}};
+    sensor->set_transform({.translation = {0.f, 3.f, 0.f}});
     phys_cmp.sensor = true;
     phys_cmp.kinematic = true;
     phys_cmp.shape = collision::box_t{glm::vec3(4.f, 0.5f, 4.f)};
@@ -531,10 +530,10 @@ TEST(PhysicsContext, simulation)
     scene->add_object(sensor);
     scene->physics_context().set_callbacks(sensor->id(), callbacks);
 
-    auto tground = ground->transform;
-    auto ta = a->transform;
-    auto tb = b->transform;
-    auto tc = c->transform;
+    auto tground = ground->transform() ? *ground->transform() : vierkant::transform_t{};
+    auto ta = a->transform() ? *a->transform() : vierkant::transform_t{};
+    auto tb = b->transform() ? *b->transform() : vierkant::transform_t{};
+    auto tc = c->transform() ? *c->transform() : vierkant::transform_t{};
 
     // run simulation a bit
     for(uint32_t l = 0; l < 50; ++l) { scene->update(1.f / 60.f); }
@@ -542,17 +541,17 @@ TEST(PhysicsContext, simulation)
     EXPECT_NE(body_interface.velocity(a->id()), glm::vec3(0));
 
     // bodies should be pulled down some way
-    EXPECT_NE(ta, a->transform);
-    EXPECT_NE(tb, b->transform);
+    EXPECT_NE(ta, *a->transform());
+    EXPECT_NE(tb, *b->transform());
 
     // ground and c were static and did not move
-    EXPECT_EQ(tc, c->transform);
-    EXPECT_EQ(tground, ground->transform);
+    EXPECT_EQ(tc, *c->transform());
+    EXPECT_EQ(tground, *ground->transform());
 
     // remove object, again keep track of transforms
     scene->remove_object(b);
-    ta = a->transform;
-    tb = b->transform;
+    ta = a->transform() ? *a->transform() : vierkant::transform_t{};
+    tb = b->transform() ? *b->transform() : vierkant::transform_t{};
 
     // again, run simulation a bit
     for(uint32_t l = 0; l < 50; ++l)
@@ -562,8 +561,8 @@ TEST(PhysicsContext, simulation)
     }
 
     // b was removed, transform should still be the same
-    EXPECT_NE(ta, a->transform);
-    EXPECT_EQ(tb, b->transform);
+    EXPECT_NE(ta, *a->transform());
+    EXPECT_EQ(tb, *b->transform());
 
     // check if a and ground have contacts
     EXPECT_TRUE(contact_map[a->id()]);

--- a/tests/TestTransform.cpp
+++ b/tests/TestTransform.cpp
@@ -48,6 +48,20 @@ void check_transform(T epsilon)
     scale.scale = scale_val;
     EXPECT_TRUE(glm::all(glm::epsilonEqual(scale * p1, scale_val * p1, epsilon)));
 
+    // identity-check
+    EXPECT_TRUE(is_identity(identity));
+    EXPECT_TRUE(!is_identity(scale));
+
+    // composing with identity needs to be exact, also on the non-uniform matrix-fallback path.
+    // a decompose-roundtrip is not, it can even flip the quaternion's sign.
+    transform_t_<T> nonuniform = {};
+    nonuniform.translation = {0.1, -0.03, 7.25};
+    nonuniform.rotation = glm::angleAxis(glm::radians(T(123.456)), glm::normalize(glm::vec<3, T>(4, -7, 6)));
+    nonuniform.scale = {0.37, 1.23, 2.91};
+    EXPECT_TRUE(!is_scale_uniform(nonuniform));
+    EXPECT_TRUE(identity * nonuniform == nonuniform);
+    EXPECT_TRUE(nonuniform * identity == nonuniform);
+
     vierkant::transform_t_<T> combo = scale * translate * rotate;
     auto combo_mat = mat4_cast<T>(scale) * mat4_cast<T>(translate) * mat4_cast<T>(rotate);
 


### PR DESCRIPTION
  Object3D::transform moves from a public member into a registry-component holding
  local + cached global + dirty. global_transform() becomes an amortized O(1) read
  instead of an O(depth) ancestor-walk.

  - transform_component_t{local, global, dirty}, presence replaces the std::optional
  - accessors transform() / set_transform() / remove_transform() replace the member

  - caching re-associates the compose: parent_global * local is left-associated, the
    old ancestor-walk was right-associated. operator*'s shear-projection is not
    associative, so poses differ on non-uniform-scale + rotation chains. this is the
    value CullVisitor already accumulated, so the renderer is unchanged and
    global_transform() now agrees with it.
  - the decompose-roundtrip was never representation-stable: it can return the
    negated quaternion, so an unchanged pose compared unequal and hashed differently.
    the identity short-circuit removes that for identity levels.
  - flag_component_t::DIRTY_TRANSFORM is untouched. it is a per-frame render-hint,
    cleared in Scene::update, and is not usable as cache-validity.

  tests (120 -> 126)

  - same-frame parent-write visibility, i.e. a write to a parent is observed by a
    child immediately, not only after a frame boundary
  - invalidation coverage per mutation-point, incl. the ~Object3D orphan case
  - clone does not inherit a stale cache
  - equivalence vs. both accumulation orders: bottom-up under uniform scale,
    top-down on a sheared chain
  - set_global_transform roundtrip over 4 parent chains x 3 targets
  - identity-compose exactness, float and double