### PR TITLE
read gamepads natively: evdev + XInput, with force-feedback

### DIFF
--- a/include/vierkant/Input.hpp
+++ b/include/vierkant/Input.hpp
@@ -1,5 +1,6 @@
 #pragma once
 
+#include <functional>
 #include <string>
 #include <unordered_map>
 #include <vierkant/math.hpp>
@@ -206,6 +207,16 @@ public:
         BUTTON_GUIDE
     };
 
+    /**
+     * @brief   force-feedback hook, provided by the platform-backend.
+     *
+     * @param   strong          low-frequency motor magnitude in [0, 1]
+     * @param   weak            high-frequency motor magnitude in [0, 1]
+     * @param   duration_ms     playback-duration in milliseconds
+     * @return  false if the device is gone or has no force-feedback.
+     */
+    using rumble_fn_t = std::function<bool(float strong, float weak, uint32_t duration_ms)>;
+
     float dead_zone = 0.15f;
 
     /**
@@ -215,12 +226,12 @@ public:
      * @param   buttons             button-states.
      * @param   axis                axis-values.
      * @param   previous_buttons    previous button-states, used for edge-detection.
+     * @param   rumble_fn           optional force-feedback hook for this device.
      *
-     * @note    @p buttons / @p axis are expected in canonical gamepad-order. devices glfw has no
-     *          mapping for are dropped before they get here.
+     * @note    @p buttons / @p axis are expected in canonical gamepad-order.
      */
     Joystick(std::string name, std::vector<uint8_t> buttons, std::vector<float> axis,
-             const std::vector<uint8_t> &previous_buttons = {});
+             const std::vector<uint8_t> &previous_buttons = {}, rumble_fn_t rumble_fn = {});
 
     const std::string &name() const;
 
@@ -240,11 +251,19 @@ public:
 
     const std::unordered_map<Input, Event> &input_events() const;
 
+    /**
+     * @brief   play a rumble-effect on this device, replacing any effect still running.
+     *
+     * @return  false if the device is gone or has no force-feedback.
+     */
+    bool rumble(float strong, float weak, uint32_t duration_ms) const;
+
 private:
     std::string m_name;
     std::vector<uint8_t> m_buttons;
     std::vector<float> m_axis;
     std::unordered_map<Input, Event> m_input_events;
+    rumble_fn_t m_rumble_fn;
 };
 
 std::string to_string(Joystick::Input input);

--- a/src/CMakeLists.txt
+++ b/src/CMakeLists.txt
@@ -29,3 +29,8 @@ include_directories(${CMAKE_CURRENT_SOURCE_DIR})
 add_library(${LIB_NAME} ${LIB_TYPE} ${FOLDER_SOURCES} ${FOLDER_HEADERS} ${VENDORED_SOURCES})
 add_dependencies(${LIB_NAME} shaders slang_shaders)
 target_link_libraries(${LIB_NAME} ${LIBS})
+
+# native gamepad-backend (gamepad_xinput.cpp)
+if (WIN32)
+    target_link_libraries(${LIB_NAME} xinput)
+endif ()

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -59,8 +59,9 @@ static glm::vec2 analog_value(const std::vector<float> &axis, uint32_t index_h, 
 }
 
 Joystick::Joystick(std::string name, std::vector<uint8_t> buttons, std::vector<float> axis,
-                   const std::vector<uint8_t> &previous_buttons)
-    : m_name(std::move(name)), m_buttons(std::move(buttons)), m_axis(std::move(axis))
+                   const std::vector<uint8_t> &previous_buttons, rumble_fn_t rumble_fn)
+    : m_name(std::move(name)), m_buttons(std::move(buttons)), m_axis(std::move(axis)),
+      m_rumble_fn(std::move(rumble_fn))
 {
     if(m_buttons.size() == previous_buttons.size())
     {
@@ -108,5 +109,10 @@ glm::vec2 Joystick::dpad() const
 }
 
 const std::unordered_map<Joystick::Input, Joystick::Event> &Joystick::input_events() const { return m_input_events; }
+
+bool Joystick::rumble(float strong, float weak, uint32_t duration_ms) const
+{
+    return m_rumble_fn && m_rumble_fn(strong, weak, duration_ms);
+}
 
 }// namespace vierkant

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,8 +1,9 @@
-#include <unordered_set>
 #include <vierkant/Window.hpp>
 
 #define GLFW_INCLUDE_NONE
 #include <GLFW/glfw3.h>
+
+#include "gamepad.hpp"
 
 namespace vierkant
 {
@@ -93,40 +94,28 @@ static void get_modifiers(GLFWwindow *window, uint32_t &buttonModifiers, uint32_
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
 
-//! warn once per device that we have no mapping for it and are ignoring it
-static void warn_unmapped_joystick(int joy)
-{
-    static std::unordered_set<std::string> s_warned_guids;
-    const char *guid = glfwGetJoystickGUID(joy);
-    if(!guid || !s_warned_guids.insert(guid).second) { return; }
-    const char *name = glfwGetJoystickName(joy);
-
-    spdlog::warn("no gamepad-mapping for '{}' (guid: {}) - device is ignored", name ? name : "unknown", guid);
-}
-
 std::vector<Joystick> get_joystick_states(const std::vector<Joystick> &previous_joysticks)
 {
+    // gamepads are read directly from the platform (evdev/XInput), which reports named inputs
+    // in canonical order. no mapping-database is involved.
+    auto gamepad_states = gamepad::poll_states();
+
     std::vector<Joystick> ret;
-    for(int i = GLFW_JOYSTICK_1; i <= GLFW_JOYSTICK_LAST; i++)
+    ret.reserve(gamepad_states.size());
+
+    for(uint32_t i = 0; i < gamepad_states.size(); ++i)
     {
-        if(!glfwJoystickPresent(i)) { continue; }
-
-        // glfw resolves any mapped device into a fixed layout, using its bundled SDL-mapping database.
-        // devices it has no mapping for are dropped: raw indices are driver-dependent
-        GLFWgamepadstate gamepad_state;
-        if(!glfwJoystickIsGamepad(i) || !glfwGetGamepadState(i, &gamepad_state))
-        {
-            warn_unmapped_joystick(i);
-            continue;
-        }
-
-        std::vector<float> axis(std::begin(gamepad_state.axes), std::end(gamepad_state.axes));
-        std::vector<uint8_t> buttons(std::begin(gamepad_state.buttons), std::end(gamepad_state.buttons));
-        std::string name = glfwGetGamepadName(i);
+        auto &state = gamepad_states[i];
 
         std::vector<uint8_t> previous_buttons;
-        if(static_cast<uint32_t>(i) < previous_joysticks.size()) { previous_buttons = previous_joysticks[i].buttons(); }
-        ret.emplace_back(std::move(name), std::move(buttons), std::move(axis), previous_buttons);
+        if(i < previous_joysticks.size()) { previous_buttons = previous_joysticks[i].buttons(); }
+
+        const uint64_t device_id = state.id;
+        auto rumble_fn = [device_id](float strong, float weak, uint32_t duration_ms) {
+            return gamepad::rumble(device_id, strong, weak, duration_ms);
+        };
+        ret.emplace_back(std::move(state.name), std::move(state.buttons), std::move(state.axis), previous_buttons,
+                         std::move(rumble_fn));
     }
     return ret;
 }

--- a/src/gamepad.hpp
+++ b/src/gamepad.hpp
@@ -1,0 +1,49 @@
+#pragma once
+
+#include <cstdint>
+#include <string>
+#include <vector>
+
+namespace vierkant::gamepad
+{
+
+/**
+ * @brief   internal, platform-specific gamepad-backend.
+ *
+ * reads gamepads directly from the platform (evdev on linux, XInput on windows), rather than through
+ * glfw's joystick-api. both platforms report *named* inputs, so there is no mapping-database involved.
+ *
+ * @note    not thread-safe, expected to be driven from the thread pumping window-events.
+ */
+
+//! per-device snapshot, in canonical gamepad-order (GLFW_GAMEPAD_BUTTON_* / GLFW_GAMEPAD_AXIS_*)
+struct state_t
+{
+    //! opaque device-handle, stable while the device stays connected. never reused.
+    uint64_t id = 0;
+
+    //! display-name, as reported by the device
+    std::string name;
+
+    //! 15 button-states
+    std::vector<uint8_t> buttons;
+
+    //! 6 axis-values. sticks in [-1, 1], triggers in [-1, 1] (glfw-convention, rescaled by Joystick)
+    std::vector<float> axis;
+};
+
+//! enumerate and poll all connected gamepads. handles hotplug internally.
+std::vector<state_t> poll_states();
+
+/**
+ * @brief   trigger force-feedback on a device.
+ *
+ * @param   device_id       a state_t::id from the most recent poll_states()
+ * @param   strong          low-frequency motor magnitude in [0, 1]
+ * @param   weak            high-frequency motor magnitude in [0, 1]
+ * @param   duration_ms     playback-duration in milliseconds
+ * @return  false if the device is unknown, gone, or has no force-feedback.
+ */
+bool rumble(uint64_t device_id, float strong, float weak, uint32_t duration_ms);
+
+}// namespace vierkant::gamepad

--- a/src/gamepad_evdev.cpp
+++ b/src/gamepad_evdev.cpp
@@ -1,0 +1,333 @@
+#ifdef __linux__
+
+#include <algorithm>
+#include <array>
+#include <cerrno>
+#include <cstring>
+#include <dirent.h>
+#include <fcntl.h>
+#include <optional>
+#include <sys/inotify.h>
+#include <sys/ioctl.h>
+#include <unistd.h>
+
+#include <crocore/crocore.hpp>
+
+// only for the canonical index-constants (GLFW_GAMEPAD_BUTTON_* / GLFW_GAMEPAD_AXIS_*),
+// shared with the interpretation-layer in Input.cpp. no glfw joystick-api is used here.
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+
+#include "gamepad.hpp"
+#include "gamepad_evdev.hpp"
+
+namespace vierkant::gamepad
+{
+
+axis_layout_t detect_axis_layout(const unsigned long *abs_bits)
+{
+    if(test_bit(ABS_GAS, abs_bits) && test_bit(ABS_BRAKE, abs_bits))
+    {
+        return {.right_x = ABS_Z, .right_y = ABS_RZ, .trigger_left = ABS_BRAKE, .trigger_right = ABS_GAS};
+    }
+    return {.right_x = ABS_RX, .right_y = ABS_RY, .trigger_left = ABS_Z, .trigger_right = ABS_RZ};
+}
+
+float normalize_axis(const input_absinfo &abs, bool centered)
+{
+    if(abs.maximum == abs.minimum) { return 0.f; }
+    const float value = std::clamp(static_cast<float>(abs.value), static_cast<float>(abs.minimum),
+                                   static_cast<float>(abs.maximum));
+    const float t = (value - static_cast<float>(abs.minimum)) /
+                    (static_cast<float>(abs.maximum) - static_cast<float>(abs.minimum));
+    return centered ? t * 2.f - 1.f : t;
+}
+
+namespace
+{
+
+//! evdev-codes for the canonical buttons 0..10, the d-pad is handled separately.
+//! @note the kernel aliases BTN_X == BTN_NORTH and BTN_Y == BTN_WEST, which is geometrically odd for
+//!       an xbox-layout. verified against xbox-pads only, other drivers might come out swapped.
+constexpr std::array<int, GLFW_GAMEPAD_BUTTON_RIGHT_THUMB + 1> g_button_codes = {
+        BTN_A,      BTN_B,     BTN_X,    BTN_Y,      BTN_TL,     BTN_TR,
+        BTN_SELECT, BTN_START, BTN_MODE, BTN_THUMBL, BTN_THUMBR};
+
+struct device_t
+{
+    int fd = -1;
+    uint64_t id = 0;
+    std::string node;
+    std::string name;
+    axis_layout_t layout = {};
+    bool dpad_is_hat = false;
+    bool has_rumble = false;
+
+    //! id of a single uploaded FF_RUMBLE-effect, re-uploaded in place. -1 means: none allocated yet.
+    int16_t effect_id = -1;
+};
+
+std::vector<device_t> g_devices;
+uint64_t g_next_device_id = 1;
+int g_inotify_fd = -1;
+bool g_hotplug_disabled = false;
+bool g_scan_pending = true;
+
+void close_device(device_t &device)
+{
+    if(device.effect_id >= 0) { ioctl(device.fd, EVIOCRMFF, device.effect_id); }
+    close(device.fd);
+    device.fd = -1;
+}
+
+std::optional<device_t> open_device(const std::string &node, bool &access_denied)
+{
+    // O_RDWR: force-feedback requires write-access. read-only still yields input, so fall back to it.
+    int fd = open(node.c_str(), O_RDWR | O_NONBLOCK | O_CLOEXEC);
+    const bool read_write = fd >= 0;
+    if(fd < 0) { fd = open(node.c_str(), O_RDONLY | O_NONBLOCK | O_CLOEXEC); }
+    if(fd < 0)
+    {
+        // a node we cannot open cannot be classified either. only reported if no gamepad turns up at all.
+        access_denied = access_denied || errno == EACCES;
+        return {};
+    }
+    unsigned long key_bits[num_longs(KEY_MAX)] = {}, abs_bits[num_longs(ABS_MAX)] = {}, ff_bits[num_longs(FF_MAX)] = {};
+    ioctl(fd, EVIOCGBIT(EV_KEY, sizeof(key_bits)), key_bits);
+    ioctl(fd, EVIOCGBIT(EV_ABS, sizeof(abs_bits)), abs_bits);
+    ioctl(fd, EVIOCGBIT(EV_FF, sizeof(ff_bits)), ff_bits);
+
+    // a gamepad is: two absolute axes plus the kernel's south face-button. no GUID, no database.
+    if(!(test_bit(ABS_X, abs_bits) && test_bit(ABS_Y, abs_bits) && test_bit(BTN_SOUTH, key_bits)))
+    {
+        close(fd);
+        return {};
+    }
+    char name[256] = {};
+    if(ioctl(fd, EVIOCGNAME(sizeof(name) - 1), name) < 0) { strcpy(name, "unknown gamepad"); }
+
+    device_t device = {};
+    device.fd = fd;
+    device.id = g_next_device_id++;
+    device.node = node;
+    device.name = name;
+    device.layout = detect_axis_layout(abs_bits);
+    device.dpad_is_hat = test_bit(ABS_HAT0X, abs_bits);
+    device.has_rumble = read_write && test_bit(FF_RUMBLE, ff_bits);
+
+    if(!read_write && test_bit(FF_RUMBLE, ff_bits))
+    {
+        spdlog::warn("gamepad '{}' ({}) could only be opened read-only - no force-feedback", device.name, device.node);
+    }
+    spdlog::debug("gamepad connected: '{}' ({}, rumble: {})", device.name, device.node,
+                  device.has_rumble ? "yes" : "no");
+    return device;
+}
+
+void scan_devices()
+{
+    DIR *dir = opendir("/dev/input");
+    if(!dir) { return; }
+
+    std::vector<std::string> nodes;
+    while(const dirent *entry = readdir(dir))
+    {
+        if(!strncmp(entry->d_name, "event", 5)) { nodes.push_back(std::string("/dev/input/") + entry->d_name); }
+    }
+    closedir(dir);
+
+    // readdir-order is arbitrary, sorting keeps the exposed device-order stable across scans
+    std::sort(nodes.begin(), nodes.end());
+
+    bool access_denied = false;
+
+    for(const auto &node: nodes)
+    {
+        auto same_node = [&node](const device_t &d) { return d.node == node; };
+        if(std::any_of(g_devices.begin(), g_devices.end(), same_node)) { continue; }
+        if(auto device = open_device(node, access_denied)) { g_devices.push_back(std::move(*device)); }
+    }
+
+    // silence here is what made this expensive to debug in glfw. inaccessible nodes are only worth
+    // reporting when they are the plausible reason for finding nothing at all.
+    static bool s_warned = false;
+    if(g_devices.empty() && access_denied && !s_warned)
+    {
+        spdlog::warn("no gamepad found, but some event-nodes in /dev/input are not accessible. if a pad is "
+                     "connected, its node is missing an ACL because udev did not tag it with ID_INPUT_JOYSTICK");
+        s_warned = true;
+    }
+    s_warned = s_warned && g_devices.empty();
+}
+
+//! watch /dev/input for hotplug. IN_ATTRIB matters as much as IN_CREATE: udev applies the ACL after creation.
+void poll_hotplug()
+{
+    if(g_hotplug_disabled) { return; }
+
+    if(g_inotify_fd < 0)
+    {
+        g_inotify_fd = inotify_init1(IN_NONBLOCK | IN_CLOEXEC);
+
+        if(g_inotify_fd < 0 || inotify_add_watch(g_inotify_fd, "/dev/input", IN_CREATE | IN_ATTRIB | IN_DELETE) < 0)
+        {
+            spdlog::warn("could not watch /dev/input ({}) - gamepad-hotplug is disabled", strerror(errno));
+            if(g_inotify_fd >= 0) { close(g_inotify_fd); }
+            g_inotify_fd = -1;
+            g_hotplug_disabled = true;
+            return;
+        }
+    }
+    alignas(inotify_event) char buf[4096];
+
+    for(ssize_t num_bytes; (num_bytes = read(g_inotify_fd, buf, sizeof(buf))) > 0;)
+    {
+        for(ssize_t i = 0; i < num_bytes;)
+        {
+            const auto *event = reinterpret_cast<const inotify_event *>(buf + i);
+            if(event->len && !strncmp(event->name, "event", 5)) { g_scan_pending = true; }
+            i += static_cast<ssize_t>(sizeof(inotify_event) + event->len);
+        }
+    }
+}
+
+//! drain the device's event-queue. we poll state via ioctl, but an unread queue grows and hides device-loss.
+bool drain_events(const device_t &device)
+{
+    input_event events[32];
+    for(;;)
+    {
+        ssize_t num_bytes = read(device.fd, events, sizeof(events));
+        if(num_bytes < 0) { return errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR; }
+        if(num_bytes < static_cast<ssize_t>(sizeof(events))) { return true; }
+    }
+}
+
+bool read_state(const device_t &device, state_t &out)
+{
+    unsigned long key_bits[num_longs(KEY_MAX)] = {};
+    if(ioctl(device.fd, EVIOCGKEY(sizeof(key_bits)), key_bits) < 0) { return false; }
+
+    auto read_axis = [&device](int code, bool centered) -> float {
+        input_absinfo abs = {};
+        if(ioctl(device.fd, EVIOCGABS(code), &abs) < 0) { return 0.f; }
+        return normalize_axis(abs, centered);
+    };
+
+    out.axis.resize(GLFW_GAMEPAD_AXIS_LAST + 1);
+    out.axis[GLFW_GAMEPAD_AXIS_LEFT_X] = read_axis(ABS_X, true);
+    out.axis[GLFW_GAMEPAD_AXIS_LEFT_Y] = read_axis(ABS_Y, true);
+    out.axis[GLFW_GAMEPAD_AXIS_RIGHT_X] = read_axis(device.layout.right_x, true);
+    out.axis[GLFW_GAMEPAD_AXIS_RIGHT_Y] = read_axis(device.layout.right_y, true);
+
+    // triggers are one-sided, but the canonical layout expects them in [-1, 1]
+    out.axis[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER] = read_axis(device.layout.trigger_left, false) * 2.f - 1.f;
+    out.axis[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER] = read_axis(device.layout.trigger_right, false) * 2.f - 1.f;
+
+    out.buttons.assign(GLFW_GAMEPAD_BUTTON_LAST + 1, 0);
+    for(uint32_t i = 0; i < g_button_codes.size(); ++i)
+    {
+        out.buttons[i] = test_bit(g_button_codes[i], key_bits) ? 1 : 0;
+    }
+
+    // the d-pad is either a hat-axis or four buttons
+    int dpad_x = 0, dpad_y = 0;
+    if(device.dpad_is_hat)
+    {
+        input_absinfo abs = {};
+        if(ioctl(device.fd, EVIOCGABS(ABS_HAT0X), &abs) == 0) { dpad_x = abs.value; }
+        if(ioctl(device.fd, EVIOCGABS(ABS_HAT0Y), &abs) == 0) { dpad_y = abs.value; }
+    }
+    else
+    {
+        auto button = [&key_bits](int code) { return static_cast<int>(test_bit(code, key_bits)); };
+        dpad_x = button(BTN_DPAD_RIGHT) - button(BTN_DPAD_LEFT);
+        dpad_y = button(BTN_DPAD_DOWN) - button(BTN_DPAD_UP);
+    }
+    out.buttons[GLFW_GAMEPAD_BUTTON_DPAD_RIGHT] = dpad_x > 0;
+    out.buttons[GLFW_GAMEPAD_BUTTON_DPAD_LEFT] = dpad_x < 0;
+    out.buttons[GLFW_GAMEPAD_BUTTON_DPAD_DOWN] = dpad_y > 0;
+    out.buttons[GLFW_GAMEPAD_BUTTON_DPAD_UP] = dpad_y < 0;
+
+    out.id = device.id;
+    out.name = device.name;
+    return true;
+}
+
+device_t *find_device(uint64_t id)
+{
+    auto it = std::find_if(g_devices.begin(), g_devices.end(), [id](const device_t &d) { return d.id == id; });
+    return it != g_devices.end() ? &(*it) : nullptr;
+}
+
+}// namespace
+
+std::vector<state_t> poll_states()
+{
+    auto drop_device = [](std::vector<device_t>::iterator it) {
+        spdlog::debug("gamepad disconnected: '{}' ({})", it->name, it->node);
+        close_device(*it);
+        return g_devices.erase(it);
+    };
+
+    // devices vanish mid-session, every ioctl/read must tolerate that. this runs before the scan below,
+    // because a freed node-name can immediately be taken by the next device.
+    for(auto it = g_devices.begin(); it != g_devices.end();) { it = drain_events(*it) ? it + 1 : drop_device(it); }
+
+    poll_hotplug();
+    if(g_scan_pending)
+    {
+        scan_devices();
+        g_scan_pending = false;
+    }
+
+    std::vector<state_t> ret;
+    ret.reserve(g_devices.size());
+
+    for(auto it = g_devices.begin(); it != g_devices.end();)
+    {
+        state_t state;
+        if(!read_state(*it, state))
+        {
+            it = drop_device(it);
+            continue;
+        }
+        ret.push_back(std::move(state));
+        ++it;
+    }
+    return ret;
+}
+
+bool rumble(uint64_t device_id, float strong, float weak, uint32_t duration_ms)
+{
+    device_t *device = find_device(device_id);
+    if(!device || !device->has_rumble) { return false; }
+
+    constexpr float max_magnitude = 0xffff;
+    ff_effect effect = {};
+    effect.type = FF_RUMBLE;
+
+    // re-upload into the same slot rather than allocating an effect per call, -1 allocates the first one
+    effect.id = device->effect_id;
+    effect.u.rumble.strong_magnitude = static_cast<uint16_t>(std::clamp(strong, 0.f, 1.f) * max_magnitude);
+    effect.u.rumble.weak_magnitude = static_cast<uint16_t>(std::clamp(weak, 0.f, 1.f) * max_magnitude);
+    effect.replay.length = static_cast<uint16_t>(std::min<uint32_t>(duration_ms, 0xffff));
+
+    if(ioctl(device->fd, EVIOCSFF, &effect) < 0)
+    {
+        // the slot can be invalidated behind our back, drop it so the next call allocates a fresh one
+        device->effect_id = -1;
+        return false;
+    }
+    device->effect_id = effect.id;
+
+    input_event play = {};
+    play.type = EV_FF;
+    play.code = static_cast<uint16_t>(effect.id);
+    play.value = 1;
+    return write(device->fd, &play, sizeof(play)) == sizeof(play);
+}
+
+}// namespace vierkant::gamepad
+
+#endif// __linux__

--- a/src/gamepad_evdev.hpp
+++ b/src/gamepad_evdev.hpp
@@ -1,0 +1,41 @@
+#pragma once
+
+#ifdef __linux__
+
+#include <cstddef>
+#include <linux/input.h>
+
+namespace vierkant::gamepad
+{
+
+//! bit-array helpers, matching the layout returned by EVIOCGBIT/EVIOCGKEY
+constexpr size_t bits_per_long = 8 * sizeof(unsigned long);
+
+constexpr size_t num_longs(size_t num_bits) { return (num_bits - 1) / bits_per_long + 1; }
+
+constexpr bool test_bit(size_t bit, const unsigned long *bits)
+{
+    return (bits[bit / bits_per_long] >> (bit % bits_per_long)) & 1ul;
+}
+
+//! evdev-codes a pad puts its right-stick and triggers on. two layouts exist in the wild.
+struct axis_layout_t
+{
+    int right_x, right_y, trigger_left, trigger_right;
+};
+
+/**
+ * @brief   determine the axis-layout from a device's EV_ABS capability-bitmap.
+ *
+ * hid-generic (xbox-pads over bluetooth) puts the right-stick on ABS_Z/ABS_RZ and the triggers on
+ * ABS_BRAKE/ABS_GAS, xpad/xpadneo/steam's virtual pad use ABS_RX/ABS_RY and ABS_Z/ABS_RZ.
+ * that is the entire ambiguity, and it is resolved by capability rather than by device-identity.
+ */
+axis_layout_t detect_axis_layout(const unsigned long *abs_bits);
+
+//! map a raw axis-value into [0, 1], or into [-1, 1] if @p centered.
+float normalize_axis(const input_absinfo &abs, bool centered);
+
+}// namespace vierkant::gamepad
+
+#endif// __linux__

--- a/src/gamepad_glfw.cpp
+++ b/src/gamepad_glfw.cpp
@@ -1,0 +1,70 @@
+#if !defined(__linux__) && !defined(_WIN32)
+
+#include <unordered_set>
+
+#include <crocore/crocore.hpp>
+
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+
+#include "gamepad.hpp"
+
+namespace vierkant::gamepad
+{
+
+/**
+ * @brief   fallback-backend for platforms without a native one.
+ *
+ * macos cannot be done the way linux/windows are: IOHIDManager reports face-buttons as
+ * "button 1..N" with no semantics attached, so a mapping-database is unavoidable there.
+ * that database is exactly what glfw provides, so glfw's gamepad-api stays in use.
+ * force-feedback is unavailable, glfw has no api for it.
+ */
+
+namespace
+{
+
+//! warn once per device that we have no mapping for it and are ignoring it
+void warn_unmapped_joystick(int joystick)
+{
+    static std::unordered_set<std::string> s_warned_guids;
+    const char *guid = glfwGetJoystickGUID(joystick);
+    if(!guid || !s_warned_guids.insert(guid).second) { return; }
+    const char *name = glfwGetJoystickName(joystick);
+
+    spdlog::warn("no gamepad-mapping for '{}' (guid: {}) - device is ignored", name ? name : "unknown", guid);
+}
+
+}// namespace
+
+std::vector<state_t> poll_states()
+{
+    std::vector<state_t> ret;
+
+    for(int i = GLFW_JOYSTICK_1; i <= GLFW_JOYSTICK_LAST; ++i)
+    {
+        if(!glfwJoystickPresent(i)) { continue; }
+
+        // glfw resolves any mapped device into a fixed layout, using its bundled SDL-mapping database.
+        // devices it has no mapping for are dropped: raw indices are driver-dependent
+        GLFWgamepadstate gamepad_state;
+        if(!glfwJoystickIsGamepad(i) || !glfwGetGamepadState(i, &gamepad_state))
+        {
+            warn_unmapped_joystick(i);
+            continue;
+        }
+        state_t state;
+        state.id = static_cast<uint64_t>(i) + 1;
+        state.name = glfwGetGamepadName(i);
+        state.axis = {std::begin(gamepad_state.axes), std::end(gamepad_state.axes)};
+        state.buttons = {std::begin(gamepad_state.buttons), std::end(gamepad_state.buttons)};
+        ret.push_back(std::move(state));
+    }
+    return ret;
+}
+
+bool rumble(uint64_t /*device_id*/, float /*strong*/, float /*weak*/, uint32_t /*duration_ms*/) { return false; }
+
+}// namespace vierkant::gamepad
+
+#endif// !__linux__ && !_WIN32

--- a/src/gamepad_xinput.cpp
+++ b/src/gamepad_xinput.cpp
@@ -1,0 +1,115 @@
+#ifdef _WIN32
+
+#include <algorithm>
+#include <array>
+#include <chrono>
+#include <string>
+
+#include <windows.h>
+// clang-format off
+#include <xinput.h>
+// clang-format on
+
+// only for the canonical index-constants (GLFW_GAMEPAD_BUTTON_* / GLFW_GAMEPAD_AXIS_*),
+// shared with the interpretation-layer in Input.cpp. no glfw joystick-api is used here.
+#define GLFW_INCLUDE_NONE
+#include <GLFW/glfw3.h>
+
+#include "gamepad.hpp"
+
+namespace vierkant::gamepad
+{
+
+namespace
+{
+
+//! XINPUT_GAMEPAD_* flags in canonical button-order. XInput has no guide-button, that slot stays unset.
+constexpr std::array<WORD, GLFW_GAMEPAD_BUTTON_LAST + 1> g_button_flags = {
+        XINPUT_GAMEPAD_A,
+        XINPUT_GAMEPAD_B,
+        XINPUT_GAMEPAD_X,
+        XINPUT_GAMEPAD_Y,
+        XINPUT_GAMEPAD_LEFT_SHOULDER,
+        XINPUT_GAMEPAD_RIGHT_SHOULDER,
+        XINPUT_GAMEPAD_BACK,
+        XINPUT_GAMEPAD_START,
+        0,
+        XINPUT_GAMEPAD_LEFT_THUMB,
+        XINPUT_GAMEPAD_RIGHT_THUMB,
+        XINPUT_GAMEPAD_DPAD_UP,
+        XINPUT_GAMEPAD_DPAD_RIGHT,
+        XINPUT_GAMEPAD_DPAD_DOWN,
+        XINPUT_GAMEPAD_DPAD_LEFT};
+
+using rumble_clock_t = std::chrono::steady_clock;
+
+//! XInput vibration runs until it is stopped, so the requested duration is tracked here.
+std::array<rumble_clock_t::time_point, XUSER_MAX_COUNT> g_rumble_end = {};
+
+//! XInput sticks are int16 with a full-scale negative side, triggers are uint8
+float normalize_stick(SHORT value) { return value < 0 ? value / 32768.f : value / 32767.f; }
+
+//! canonical triggers live in [-1, 1]
+float normalize_trigger(BYTE value) { return value / 255.f * 2.f - 1.f; }
+
+}// namespace
+
+std::vector<state_t> poll_states()
+{
+    std::vector<state_t> ret;
+    const auto now = rumble_clock_t::now();
+
+    for(DWORD user_index = 0; user_index < XUSER_MAX_COUNT; ++user_index)
+    {
+        XINPUT_STATE xinput_state = {};
+        if(XInputGetState(user_index, &xinput_state) != ERROR_SUCCESS) { continue; }
+
+        if(g_rumble_end[user_index] != rumble_clock_t::time_point() && now >= g_rumble_end[user_index])
+        {
+            XINPUT_VIBRATION vibration = {};
+            XInputSetState(user_index, &vibration);
+            g_rumble_end[user_index] = {};
+        }
+        const XINPUT_GAMEPAD &pad = xinput_state.Gamepad;
+
+        state_t state;
+        state.id = user_index + 1;
+        state.name = "xinput gamepad " + std::to_string(user_index);
+
+        state.buttons.assign(g_button_flags.size(), 0);
+        for(uint32_t i = 0; i < g_button_flags.size(); ++i)
+        {
+            state.buttons[i] = (pad.wButtons & g_button_flags[i]) ? 1 : 0;
+        }
+        state.axis.resize(GLFW_GAMEPAD_AXIS_LAST + 1);
+        state.axis[GLFW_GAMEPAD_AXIS_LEFT_X] = normalize_stick(pad.sThumbLX);
+
+        // XInput reports sticks with +y up, the canonical layout has +y down
+        state.axis[GLFW_GAMEPAD_AXIS_LEFT_Y] = -normalize_stick(pad.sThumbLY);
+        state.axis[GLFW_GAMEPAD_AXIS_RIGHT_X] = normalize_stick(pad.sThumbRX);
+        state.axis[GLFW_GAMEPAD_AXIS_RIGHT_Y] = -normalize_stick(pad.sThumbRY);
+        state.axis[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER] = normalize_trigger(pad.bLeftTrigger);
+        state.axis[GLFW_GAMEPAD_AXIS_RIGHT_TRIGGER] = normalize_trigger(pad.bRightTrigger);
+        ret.push_back(std::move(state));
+    }
+    return ret;
+}
+
+bool rumble(uint64_t device_id, float strong, float weak, uint32_t duration_ms)
+{
+    if(device_id == 0 || device_id > XUSER_MAX_COUNT) { return false; }
+    const auto user_index = static_cast<DWORD>(device_id - 1);
+
+    constexpr float max_magnitude = 0xffff;
+    XINPUT_VIBRATION vibration = {};
+    vibration.wLeftMotorSpeed = static_cast<WORD>(std::clamp(strong, 0.f, 1.f) * max_magnitude);
+    vibration.wRightMotorSpeed = static_cast<WORD>(std::clamp(weak, 0.f, 1.f) * max_magnitude);
+
+    if(XInputSetState(user_index, &vibration) != ERROR_SUCCESS) { return false; }
+    g_rumble_end[user_index] = rumble_clock_t::now() + std::chrono::milliseconds(duration_ms);
+    return true;
+}
+
+}// namespace vierkant::gamepad
+
+#endif// _WIN32

--- a/tests/CMakeLists.txt
+++ b/tests/CMakeLists.txt
@@ -1,4 +1,7 @@
 include_directories(${vierkant_INCLUDE_DIRS})
+
+# internal headers, e.g. the platform gamepad-backends
+include_directories(${PROJECT_SOURCE_DIR}/src)
 set(LIBS ${vierkant_LIBRARIES} GTest::gtest_main)
 if (CMAKE_CXX_COMPILER_ID STREQUAL "GNU")
     # gcc requires additional linking against libatomic, msvc/clang do not provide it.


### PR DESCRIPTION
glfw has no force-feedback api, and its gamepad-mapping database needs a matching entry per device. evdev and XINPUT_GAMEPAD both report named inputs, so reading the platform directly drops the mapping entirely. glfw keeps windowing and the vulkan surface.

- Window::get_joystick_states() calls the new backend, Joystick's public surface is unchanged
- gamepad_evdev.cpp: discovery by capability, axis-layout from EV_ABS caps, ranges normalized from EVIOCGABS, inotify hotplug
- gamepad_xinput.cpp: same interface over XInput, untested
- gamepad_glfw.cpp: fallback for macos, hid has no button-semantics there
- Joystick::rumble(strong, weak, ms), one re-uploaded FF_RUMBLE slot per device
- tests: TestGamepadEvdev