### PR TITLE
punctual lights in PBRDeferred: culling, dirty-tracking, shader layout

### DIFF
--- a/include/vierkant/Object3D.hpp
+++ b/include/vierkant/Object3D.hpp
@@ -141,12 +141,13 @@ struct flag_component_t
         DIRTY_TRANSFORM = 0x01,
         DIRTY_MATERIAL = 0x02,
         DIRTY_MESH = 0x04,
+        DIRTY_LIGHT = 0x08,
         MAX_ENUM
     };
     uint32_t flags = 0;
     uint64_t timestamps[msb(MAX_ENUM) + 1] = {};
 
-    inline uint64_t timestamp(FlagEnum flag) const { return timestamps[msb(flag)]; }
+    [[nodiscard]] uint64_t timestamp(FlagEnum flag) const { return timestamps[msb(flag)]; }
 };
 
 uint64_t last_inherited_flag_update(const vierkant::Object3D *object, flag_component_t::FlagEnum flag);

--- a/include/vierkant/PBRDeferred.hpp
+++ b/include/vierkant/PBRDeferred.hpp
@@ -269,6 +269,9 @@ private:
         size_t scene_hash = 0;
         bool recycle_commands = false;
 
+        //! lightsources changed, refresh cull_result.lights without a re-cull
+        bool lights_dirty = false;
+
         uint64_t current_semaphore_value = 0;
         SemaphoreValue semaphore_value_done = SemaphoreValue::INVALID;
         Rasterizer::indirect_draw_bundle_t indirect_draw_params_main = {}, indirect_draw_params_post = {};

--- a/include/vierkant/culling.hpp
+++ b/include/vierkant/culling.hpp
@@ -62,4 +62,17 @@ struct cull_params_t
  */
 cull_result_t cull(const cull_params_t &cull_params);
 
+/**
+ * @brief   Collects the punctual lightsources in a scene, in world-space.
+ *
+ * Split out of the culling-operation so renderers can refresh their lights without a full re-cull.
+ *
+ * @param   scene   a provided scene.
+ * @param   tags    optional tag-whitelist, empty accepts everything.
+ *
+ * @return  an array of light_t, ready for upload.
+ */
+std::vector<vierkant::light_t> gather_lights(const vierkant::SceneConstPtr &scene,
+                                             const std::set<std::string> &tags = {});
+
 }

--- a/include/vierkant/punctual_light.hpp
+++ b/include/vierkant/punctual_light.hpp
@@ -33,6 +33,12 @@ enum class LightType : uint32_t
     Disk
 };
 
+//! true for the punctual light-types every renderer can shade (Omni/Spot/Directional)
+static inline bool is_punctual(LightType type)
+{
+    return type == LightType::Omni || type == LightType::Spot || type == LightType::Directional;
+}
+
 //! lightsource-asset, owned by an AssetProvider and referenced by LightId
 struct lightsource_t
 {

--- a/shaders/slang/renderer/point_light.slang
+++ b/shaders/slang/renderer/point_light.slang
@@ -10,6 +10,7 @@ static const uint LIGHT_TYPE_POINT = 0;
 static const uint LIGHT_TYPE_SPOT = 1;
 static const uint LIGHT_TYPE_DIRECTIONAL = 2;
 
+//! matches host-side vierkant::light_t (80 bytes), same layout as ray_common's light_t
 public struct lightsource_t
 {
     public float3 position;
@@ -20,6 +21,18 @@ public struct lightsource_t
     public float range;
     public float spot_angle_scale;
     public float spot_angle_offset;
+
+    //! >0 on directional lights indicates a sun-style disc-light (apex angle in radians)
+    public float angular_size;
+
+    //! area-light extent: half-height (Rect) / half-length (Tube)
+    public float size_y;
+
+    //! area-light in-plane x-axis (Rect)
+    public float3 tangent;
+
+    //! area-light extent: radius (Sphere/Disk/Tube) / half-width (Rect)
+    public float size_x;
 };
 
 float GeometrySchlickGGX(float NdotV, float roughness)

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -306,10 +306,11 @@ PBRDeferredPtr PBRDeferred::create(const DevicePtr &device, const create_info_t 
 
 void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr &cam, frame_context_t &frame_context)
 {
-    uint64_t frame_thresh = scene->current_frame();
+    const uint64_t frame_thresh = scene->current_frame();
     bool need_culling = false;
     frame_context.cull_result.camera = cam;
     frame_context.recycle_commands = true;
+    frame_context.lights_dirty = false;
     frame_context.dirty_drawable_indices.clear();
 
     size_t scene_hash = 0;
@@ -322,11 +323,23 @@ void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr
     {
         vierkant::hash_combine(scene_hash, object);
 
-        auto *mesh_component = object->get_component_ptr<mesh_component_t>();
-        if(!mesh_component || !mesh_component->mesh) { continue; }
-
         flag_component_t flag_cmp = {};
-        if(auto *fc = object->get_component_ptr<flag_component_t>()) { flag_cmp = *fc; }
+        if(const auto *fc = object->get_component_ptr<flag_component_t>()) { flag_cmp = *fc; }
+
+        // a light-change only needs cull_result.lights refreshed, not a re-cull (see render_scene).
+        // this also runs for removed light-components, those need to drop out of the array.
+        const bool light_dirty =
+                flag_cmp.timestamp(flag_component_t::DIRTY_LIGHT) + m_frame_contexts.size() >= frame_thresh;
+        if(light_dirty || object->has_component<vierkant::lightsource_component_t>())
+        {
+            frame_context.lights_dirty = frame_context.lights_dirty || light_dirty ||
+                                         last_inherited_flag_update(object, flag_component_t::DIRTY_TRANSFORM) +
+                                                         m_frame_contexts.size() >=
+                                                 frame_thresh;
+        }
+
+        const auto *mesh_component = object->get_component_ptr<mesh_component_t>();
+        if(!mesh_component || !mesh_component->mesh) { continue; }
 
         vierkant::hash_combine(scene_hash, flag_cmp.timestamp(flag_component_t::DIRTY_MESH) + m_frame_contexts.size() >=
                                                    frame_thresh);
@@ -334,8 +347,8 @@ void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr
                 flag_cmp.timestamp(flag_component_t::DIRTY_MATERIAL) + m_frame_contexts.size() >= frame_thresh;
         if(material_update) { flag_cmp.flags |= flag_component_t::DIRTY_MATERIAL; }
 
-        auto mesh = mesh_component->mesh.get();
-        bool transform_update =
+        const auto *mesh = mesh_component->mesh.get();
+        const bool transform_update =
                 last_inherited_flag_update(object, flag_component_t::DIRTY_TRANSFORM) + m_frame_contexts.size() >=
                 frame_thresh;
         if(transform_update) { flag_cmp.flags |= flag_component_t::DIRTY_TRANSFORM; }
@@ -362,9 +375,8 @@ void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr
                 // entry disabled
                 if(mesh_component->entry_indices && !mesh_component->entry_indices->contains(i)) { continue; }
                 const auto &entry = mesh->entries[i];
-                id_entry_t key = {object->id(), i};
 
-                if(frame_context.cull_result.index_map.contains(key))
+                if(id_entry_t key = {.id = object->id(), .entry = i}; frame_context.cull_result.index_map.contains(key))
                 {
                     auto transform = object->global_transform();
 
@@ -441,6 +453,11 @@ SceneRenderer::render_result_t PBRDeferred::render_scene(Rasterizer &renderer, c
         cull_params.check_intersection = false;
         cull_params.world_space = true;
         frame_context.cull_result = vierkant::cull(cull_params);
+    }
+    else if(frame_context.lights_dirty)
+    {
+        // lights_ubo is re-uploaded every frame anyway, so only the array needs to be current here
+        frame_context.cull_result.lights = vierkant::gather_lights(scene, tags);
     }
 
     // timeline semaphore

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -26,7 +26,7 @@ public:
         if(object.enabled && check_tags(m_tags, object.tags))
         {
             // cached global, no accumulation during traversal required
-            auto model_view = m_base_transform * object.global_transform();
+            const auto model_view = m_base_transform * object.global_transform();
 
             if(m_check_intersection)
             {
@@ -47,7 +47,7 @@ public:
 
                 if(object.has_component<animation_component_t>())
                 {
-                    auto &animation_state = object.get_component<animation_component_t>();
+                    const auto &animation_state = object.get_component<animation_component_t>();
                     drawable_params.animation_index = animation_state.index;
                     drawable_params.animation_time = static_cast<float>(animation_state.current_time);
                 }
@@ -56,7 +56,7 @@ public:
                 for(uint32_t i = 0; i < mesh_drawables.size(); ++i)
                 {
                     auto &drawable = mesh_drawables[i];
-                    m_cull_result.entity_map[drawable.id] = {object.id(), i};
+                    m_cull_result.entity_map[drawable.id] = {.id = object.id(), .entry = i};
                     drawable.matrices.projection = camera::projection_matrix(m_camera.get());
 
                     id_entry_t key = {object.id(), drawable.entry_index};
@@ -68,13 +68,8 @@ public:
                     m_cull_result.drawables.push_back(std::move(drawable));
                 }
             }
-            //            if(object.has_component<vierkant::model::lightsource_t>())
-            //            {
-            //                const auto &lightsource = object.get_component<vierkant::model::lightsource_t>();
-            //                m_cull_result.lights.push_back(vierkant::convert_light(lightsource));
-            //            }
 
-            for(Object3DPtr &child: object.children) { child->accept(*this); }
+            for(const Object3DPtr &child: object.children) { child->accept(*this); }
         }
     }
 
@@ -101,7 +96,31 @@ cull_result_t cull(const cull_params_t &cull_params)
     cull_params.scene->root()->accept(cull_visitor);
     cull_visitor.m_cull_result.scene = cull_params.scene;
     cull_visitor.m_cull_result.camera = cull_params.camera;
+    cull_visitor.m_cull_result.lights = gather_lights(cull_params.scene, cull_params.tags);
     return std::move(cull_visitor.m_cull_result);
+}
+
+std::vector<vierkant::light_t> gather_lights(const vierkant::SceneConstPtr &scene, const std::set<std::string> &tags)
+{
+    std::vector<vierkant::light_t> ret;
+
+    vierkant::LambdaVisitor visitor;
+    visitor.traverse(*scene->root(), [&ret, &scene, &tags](const Object3D &object) -> bool {
+        if(!object.enabled || !check_tags(tags, object.tags)) { return false; }
+
+        if(const auto *light_cmp = object.get_component_ptr<vierkant::lightsource_component_t>())
+        {
+            const auto *light_src = scene->asset_provider()->light(light_cmp->light_id);
+
+            // rasterizers shade punctual lights only, area-lights remain path-tracer exclusive
+            if(light_src && light_src->intensity > 0.f && is_punctual(light_src->type))
+            {
+                ret.push_back(vierkant::convert_light(*light_src, object.global_transform()));
+            }
+        }
+        return true;
+    });
+    return ret;
 }
 
 }// namespace vierkant

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -122,7 +122,7 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
 
 bool draw_material_ui(const vierkant::ScenePtr &scene, const MaterialId &material_id);
 
-void draw_light_ui(vierkant::lightsource_t &light);
+bool draw_light_ui(vierkant::lightsource_t &light);
 
 void draw_application_ui(const crocore::ApplicationPtr &app, const vierkant::WindowPtr &window)
 {
@@ -1191,8 +1191,10 @@ bool draw_material_ui(const vierkant::ScenePtr &scene, const MaterialId &materia
     return material && draw_material_ui(*material, draw_texture);
 }
 
-void draw_light_ui(vierkant::lightsource_t &light)
+bool draw_light_ui(vierkant::lightsource_t &light)
 {
+    bool changed = false;
+
     constexpr size_t buf_size = 4096;
     char text_buf[buf_size];
 
@@ -1222,26 +1224,28 @@ void draw_light_ui(vierkant::lightsource_t &light)
     if(ImGui::Combo("type", &light_type_index, light_type_strings, IM_ARRAYSIZE(light_type_strings)))
     {
         light.type = light_types[light_type_index];
+        changed = true;
     }
-    ImGui::ColorEdit3("color", glm::value_ptr(light.color));
-    ImGui::InputFloat("intensity", &light.intensity);
-    ImGui::InputFloat("range", &light.range);
+    changed |= ImGui::ColorEdit3("color", glm::value_ptr(light.color));
+    changed |= ImGui::InputFloat("intensity", &light.intensity);
+    changed |= ImGui::InputFloat("range", &light.range);
 
     if(light.type == LightType::Spot)
     {
-        ImGui::SliderAngle("inner_cone_angle", &light.inner_cone_angle, 0.f, 89.f);
-        ImGui::SliderAngle("outer_cone_angle", &light.outer_cone_angle, 0.f, 89.f);
+        changed |= ImGui::SliderAngle("inner_cone_angle", &light.inner_cone_angle, 0.f, 89.f);
+        changed |= ImGui::SliderAngle("outer_cone_angle", &light.outer_cone_angle, 0.f, 89.f);
     }
-    else if(light.type == LightType::Rect) { ImGui::InputFloat2("half_extents", glm::value_ptr(light.size)); }
+    else if(light.type == LightType::Rect) { changed |= ImGui::InputFloat2("half_extents", glm::value_ptr(light.size)); }
     else if(light.type == LightType::Sphere || light.type == LightType::Disk)
     {
-        ImGui::InputFloat("radius", &light.size.x);
+        changed |= ImGui::InputFloat("radius", &light.size.x);
     }
     else if(light.type == LightType::Tube)
     {
-        ImGui::InputFloat("radius", &light.size.x);
-        ImGui::InputFloat("half_length", &light.size.y);
+        changed |= ImGui::InputFloat("radius", &light.size.x);
+        changed |= ImGui::InputFloat("half_length", &light.size.y);
     }
+    return changed;
 }
 
 void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &object,
@@ -1562,6 +1566,7 @@ void draw_object_ui(const vierkant::ScenePtr &scene, const Object3DPtr &object)
     }
 
     // lightsource-component: references a lightsource-asset by id
+    bool light_changed = false;
     bool has_light = object->has_component<vierkant::lightsource_component_t>();
     if(ImGui::Checkbox("lightsource", &has_light))
     {
@@ -1570,26 +1575,41 @@ void draw_object_ui(const vierkant::ScenePtr &scene, const Object3DPtr &object)
         {
             object->remove_component<vierkant::lightsource_component_t>();
         }
+        light_changed = true;
     }
     if(has_light)
     {
         auto &light_cmp = object->get_component<vierkant::lightsource_component_t>();
 
-        draw_id_combo("light", light_cmp.light_id, scene->asset_provider()->lights());
+        light_changed |= draw_id_combo("light", light_cmp.light_id, scene->asset_provider()->lights());
 
         strcpy(text_buf, light_cmp.light_id.str().c_str());
         if(ImGui::InputText("light-id", text_buf, sizeof(text_buf), ImGuiInputTextFlags_EnterReturnsTrue))
         {
             light_cmp.light_id = vierkant::LightId::from_string(text_buf);
+            light_changed = true;
         }
 
         if(auto *light_asset = scene->asset_provider()->light(light_cmp.light_id))
         {
             if(ImGui::TreeNode(light_asset, "%s", light_asset->name.empty() ? "<unnamed>" : light_asset->name.c_str()))
             {
-                draw_light_ui(*light_asset);
+                light_changed |= draw_light_ui(*light_asset);
                 ImGui::TreePop();
             }
+        }
+    }
+
+    if(light_changed)
+    {
+        if(auto *flag_cmp_ptr = object->get_component_ptr<flag_component_t>())
+        {
+            flag_cmp_ptr->flags |= flag_component_t::DIRTY_LIGHT;
+        }
+        else
+        {
+            auto &flag_cmp = object->add_component<vierkant::flag_component_t>();
+            flag_cmp.flags |= flag_component_t::DIRTY_LIGHT;
         }
     }
 


### PR DESCRIPTION
- culling.cpp: gather_lights(scene, tags) collects punctual lightsources with intensity > 0, split out of CullVisitor so renderers can refresh lights without a re-cull; cull() calls it too
- point_light.slang: lightsource_t grown to 80 bytes to match light_t, every light past index 0 previously read at the wrong offset
- flag_component_t::DIRTY_LIGHT, latched by the object-inspector on component add/remove, light-id re-point and any lightsource_t edit
- draw_light_ui returns bool, mirroring draw_material_ui
- PBRDeferred::update_recycling: light-dirt ahead of the mesh early-out, transform-dirt via last_inherited_flag_update so lights under a moving parent follow; sets frame_context.lights_dirty, which refreshes cull_result.lights with command-recycling left intact
- is_punctual(LightType) helper