### PR TITLE
packed tangent-frame: merge normal+tangent into a single dword

### DIFF
--- a/include/vierkant/Geometry.hpp
+++ b/include/vierkant/Geometry.hpp
@@ -74,7 +74,9 @@ public:
     std::vector<glm::vec4> colors;
     std::vector<glm::vec2> tex_coords;
     std::vector<glm::vec3> normals;
-    std::vector<glm::vec3> tangents;
+
+    //! glTF convention: tangent-direction in xyz, bitangent-handedness in w (bitangent = cross(n, t.xyz) * t.w)
+    std::vector<glm::vec4> tangents;
 
     //! each vertex can reference up to 4 bones
     std::vector<glm::vec<4, uint16_t>> bone_indices;

--- a/include/vierkant/octahedral_map.hpp
+++ b/include/vierkant/octahedral_map.hpp
@@ -6,6 +6,8 @@
 
 #include <vierkant/math.hpp>
 
+#include <cmath>
+
 namespace vierkant
 {
 
@@ -21,10 +23,10 @@ inline glm::vec2 normalized_vector_to_octahedral_mapping(const glm::vec3 &n)
     glm::vec2 p = glm::vec2(n.x, n.y) * (1.f / (std::abs(n.x) + std::abs(n.y) + std::abs(n.z)));
 
     // reflect folds of lower hemisphere over the diagonals.
-    if(n.z < 0.0)
+    if(n.z < 0.f)
     {
-        p = glm::vec2((1.0 - std::abs(p.y)) * (p.x >= 0.0 ? 1.0 : -1.0),
-                      (1.0 - std::abs(p.x)) * (p.y >= 0.0 ? 1.0 : -1.0));
+        p = glm::vec2((1.f - std::abs(p.y)) * (p.x >= 0.f ? 1.f : -1.f),
+                      (1.f - std::abs(p.x)) * (p.y >= 0.f ? 1.f : -1.f));
     }
     return p;
 }
@@ -37,13 +39,17 @@ inline glm::vec2 normalized_vector_to_octahedral_mapping(const glm::vec3 &n)
  */
 inline glm::vec3 octahedral_mapping_to_normalized_vector(const glm::vec2 &p)
 {
-    glm::vec3 n = glm::vec3(p.x, p.y, 1.0 - std::abs(p.x) - std::abs(p.y));
+    glm::vec3 n = glm::vec3(p.x, p.y, 1.f - std::abs(p.x) - std::abs(p.y));
 
     // Reflect the folds of the lower hemisphere over the diagonals.
-    if(n.z < 0.0)
+    // NOTE: glm's swizzle is a by-value function under GLM_FORCE_XYZW_ONLY, so 'n.xy() = ...'
+    // silently assigns to a temporary - both components must be written explicitly.
+    if(n.z < 0.f)
     {
-        n.xy() = glm::vec2((1.0 - std::abs(n.y)) * (n.x >= 0.0 ? 1.0 : -1.0),
-                           (1.0 - std::abs(n.x)) * (n.y >= 0.0 ? 1.0 : -1.0));
+        float x = (1.f - std::abs(n.y)) * (n.x >= 0.f ? 1.f : -1.f);
+        float y = (1.f - std::abs(n.x)) * (n.y >= 0.f ? 1.f : -1.f);
+        n.x = x;
+        n.y = y;
     }
     return normalize(n);
 }
@@ -73,6 +79,109 @@ inline uint32_t pack_snorm_2x16(glm::vec2 v)
     auto iv = glm::ivec2(glm::round(v * 32767.f));
     uint32_t packed = (iv.x & 0x0000ffff) | (iv.y << 16);
     return packed;
+}
+
+/**
+ * @brief   unpack two 12-bit snorm values from the low 24 bits of a dword.
+ *
+ * @param   packed  two 12-bit snorm in bits [11:0] and [23:12].
+ * @return  two float values in [-1,1].
+ */
+inline glm::vec2 unpack_snorm_2x12(uint32_t packed)
+{
+    glm::ivec2 bits = glm::ivec2(packed << 20, packed << 8) >> 20;
+    return glm::max(glm::vec2(bits) / 2047.f, glm::vec2(-1.f));
+}
+
+/**
+ * @brief   pack two floats into 12-bit snorm values in the low 24 bits of a dword.
+ *
+ * @param   v   two provided floats
+ * @return  two 12-bit snorm in bits [11:0] and [23:12].
+ */
+inline uint32_t pack_snorm_2x12(glm::vec2 v)
+{
+    v = any(isnan(v)) ? glm::vec2(0) : glm::clamp(v, glm::vec2(-1.f), glm::vec2(1.f));
+    auto iv = glm::ivec2(glm::round(v * 2047.f));
+    return (iv.x & 0xfff) | ((iv.y & 0xfff) << 12);
+}
+
+/**
+ * @brief   construct a deterministic orthonormal basis for a direction.
+ *          Duff et al., "Building an Orthonormal Basis, Revisited" (JCGT 2017).
+ *
+ * @attention   must stay bit-identical to the shader-side implementation in octahedral_map.slang,
+ *              otherwise packed tangent-angles decode against a different reference frame.
+ *              Note the basis flips discontinuously across n.z == 0 - safe here because both sides
+ *              evaluate 'n' from the same quantized bits and 1 - |p.x| - |p.y| contains no multiply
+ *              (no fma-contraction can change the sign).
+ *
+ * @param   n   a normalized direction.
+ * @param   b1  output: first basis-vector, orthogonal to n.
+ * @param   b2  output: second basis-vector, orthogonal to n and b1.
+ */
+inline void reference_basis(const glm::vec3 &n, glm::vec3 &b1, glm::vec3 &b2)
+{
+    float s = n.z >= 0.f ? 1.f : -1.f;
+    float a = -1.f / (s + n.z);
+    float b = n.x * n.y * a;
+    b1 = glm::vec3(1.f + s * n.x * n.x * a, s * b, -s * n.x);
+    b2 = glm::vec3(b, s + n.y * n.y * a, -n.y);
+}
+
+//! bit-layout of a packed tangent-frame: octahedral normal | tangent-angle | handedness
+constexpr uint32_t tangent_frame_oct_bits = 24;
+constexpr uint32_t tangent_frame_angle_bits = 7;
+constexpr uint32_t tangent_frame_angle_steps = 1u << tangent_frame_angle_bits;
+constexpr uint32_t tangent_frame_angle_mask = tangent_frame_angle_steps - 1;
+constexpr uint32_t tangent_frame_sign_bit = 1u << 31;
+
+/**
+ * @brief   pack an orthonormal tangent-frame into a single dword.
+ *
+ *          The normal is stored as a 12:12 octahedral mapping, the tangent as its rotation around
+ *          that normal relative to reference_basis(), plus one bit of bitangent-handedness.
+ *          The angle is measured against the *quantized* normal, so the two quantization-errors
+ *          do not compound.
+ *
+ * @param   n   a normalized normal.
+ * @param   t   a tangent, not required to be orthogonal to n (the projection is implicit).
+ * @param   w   bitangent handedness, glTF convention: bitangent = cross(n, t) * w.
+ * @return  the packed tangent-frame.
+ */
+inline uint32_t pack_tangent_frame(const glm::vec3 &n, const glm::vec3 &t, float w)
+{
+    uint32_t oct = pack_snorm_2x12(normalized_vector_to_octahedral_mapping(n));
+
+    // re-derive the basis from the quantized normal, exactly as the unpack-side will
+    glm::vec3 quantized_normal = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(oct));
+    glm::vec3 b1, b2;
+    reference_basis(quantized_normal, b1, b2);
+
+    // a tangent parallel to n projects to (0,0) -> atan2(0,0) == 0, an arbitrary but valid frame
+    float angle = std::atan2(glm::dot(t, b2), glm::dot(t, b1));
+    auto steps = static_cast<uint32_t>(std::lround(angle * (tangent_frame_angle_steps / glm::two_pi<float>())));
+    return oct | ((steps & tangent_frame_angle_mask) << tangent_frame_oct_bits) | (w < 0.f ? tangent_frame_sign_bit : 0);
+}
+
+/**
+ * @brief   unpack a tangent-frame packed by pack_tangent_frame.
+ *
+ * @param   packed  a packed tangent-frame.
+ * @param   n       output: the normal.
+ * @param   t       output: the tangent, orthogonal to n.
+ * @param   w       output: bitangent handedness, bitangent = cross(n, t) * w.
+ */
+inline void unpack_tangent_frame(uint32_t packed, glm::vec3 &n, glm::vec3 &t, float &w)
+{
+    n = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(packed));
+    glm::vec3 b1, b2;
+    reference_basis(n, b1, b2);
+
+    float angle = static_cast<float>((packed >> tangent_frame_oct_bits) & tangent_frame_angle_mask) *
+                  (glm::two_pi<float>() / tangent_frame_angle_steps);
+    t = std::cos(angle) * b1 + std::sin(angle) * b2;
+    w = (packed & tangent_frame_sign_bit) ? -1.f : 1.f;
 }
 
 }// namespace vierkant

--- a/include/vierkant/vertex_splicer.hpp
+++ b/include/vierkant/vertex_splicer.hpp
@@ -17,17 +17,20 @@ struct vertex_t
     glm::vec3 position;
     glm::vec2 tex_coord;
     glm::vec3 normal;
-    glm::vec3 tangent;
+    glm::vec4 tangent;
 };
 
 //! layout for a quantized and packed vertex
 struct packed_vertex_t
 {
     float pos_x, pos_y, pos_z;
-    uint32_t normal;
-    uint32_t tangent;
+
+    //! octahedral normal, tangent-angle and bitangent-handedness, see vierkant::pack_tangent_frame
+    uint32_t tangent_frame;
+
     uint16_t texcoord_x, texcoord_y;
 };
+static_assert(sizeof(packed_vertex_t) == 20, "unexpected packed_vertex_t size");
 
 //! layout for a quantized and packed bone-vertex
 struct bone_vertex_data_t

--- a/shaders/slang/mesh_compute.slang
+++ b/shaders/slang/mesh_compute.slang
@@ -44,12 +44,14 @@ void skin_compute(uint3 dispatchThreadID: SV_DispatchThreadID,
     {
         new_pos += utils::apply_transform(params.bones_in[bone_ids[i]], v.position) * bone_weights[i];
         new_normal += utils::apply_rotation(params.bones_in[bone_ids[i]], v.normal) * bone_weights[i];
-        new_tangent += utils::apply_rotation(params.bones_in[bone_ids[i]], v.tangent) * bone_weights[i];
+        new_tangent += utils::apply_rotation(params.bones_in[bone_ids[i]], v.tangent.xyz) * bone_weights[i];
     }
 
     v.position = new_pos;
     v.normal = normalize(new_normal);
-    v.tangent = normalize(new_tangent);
+
+    // handedness is invariant under the bone-rotations -> passthrough
+    v.tangent.xyz = normalize(new_tangent);
 
     // write transformed+packed vertex
     params.vertex_out[gid] = utils::pack(v);
@@ -76,10 +78,12 @@ void morph_compute(uint3 dispatchThreadID: SV_DispatchThreadID,
 
         v.position += morph_vertex.position * params.weights[i];
         new_normal += utils::slerp(v.normal, v.normal + morph_vertex.normal, params.weights[i]);
-        new_tangent += utils::slerp(v.tangent, v.tangent + morph_vertex.tangent, params.weights[i]);
+        new_tangent += utils::slerp(v.tangent.xyz, v.tangent.xyz + morph_vertex.tangent.xyz, params.weights[i]);
     }
     v.normal = normalize(new_normal);
-    v.tangent = normalize(new_tangent);
+
+    // handedness is not affected by morph-targets -> passthrough
+    v.tangent.xyz = normalize(new_tangent);
 
     // write transformed+packed vertex
     params.vertex_out[gid] = utils::pack(v);

--- a/shaders/slang/pbr/g_buffer_mesh.slang
+++ b/shaders/slang/pbr/g_buffer_mesh.slang
@@ -118,7 +118,8 @@ void mesh_main(uint ti: SV_GroupThreadID, uint wg_id: SV_GroupID, in payload ren
         out_vertices[i].g_buffer_data.last_position = last_pos;
         out_vertices[i].g_buffer_data.tex_coord = mul(m.texture, float4(v.tex_coord, 0, 1)).xy;
         out_vertices[i].g_buffer_data.normal = utils::apply_rotation(m.transform, v.normal);
-        out_vertices[i].g_buffer_data.tangent = utils::apply_rotation(m.transform, v.tangent);
+        out_vertices[i].g_buffer_data.tangent =
+                float4(utils::apply_rotation(m.transform, v.tangent.xyz), v.tangent.w);
 
 #if CULLING
         vertex_clip[i] = float3((jittered_position.xy / jittered_position.w * 0.5 + float2(0.5)) * context.size,

--- a/shaders/slang/pbr/g_buffer_tangent.slang
+++ b/shaders/slang/pbr/g_buffer_tangent.slang
@@ -52,7 +52,7 @@ renderer::g_buffer_vertex_data_t vertex_main(uint vertex_id: SV_VertexID, uint b
 
     vertex_out.tex_coord = mul(m.texture, float4(v.tex_coord, 0, 1)).xy;
     vertex_out.normal = utils::apply_rotation(m.transform, v.normal);
-    vertex_out.tangent = utils::apply_rotation(m.transform, v.tangent);
+    vertex_out.tangent = float4(utils::apply_rotation(m.transform, v.tangent.xyz), v.tangent.w);
 
     return vertex_out;
 }

--- a/shaders/slang/pbr/g_buffer_uber.slang
+++ b/shaders/slang/pbr/g_buffer_uber.slang
@@ -119,9 +119,9 @@ FragOutput fragment_main(nointerpolation in renderer::index_bundle_t indices,
                            float2(0.5));
         normal.z = sqrt(1.0 - normal.x * normal.x - normal.y * normal.y);
 
-        float3 t = normalize(vertex_in.tangent);
+        float3 t = normalize(vertex_in.tangent.xyz);
         float3 n = normalize(vertex_in.normal);
-        float3 b = normalize(cross(n, t));
+        float3 b = normalize(cross(n, t)) * vertex_in.tangent.w;
         // mul(v, M) with row-major M(t,b,n) is equivalent to GLSL mat3(t,b,n) * v (column-major)
         normal = mul(normal, float3x3(t, b, n));
         result.normal = float4(normalize(normal), 1);

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -388,8 +388,10 @@ utils::Vertex interpolate_vertex(Ptr<ray::entry_t, Access::Read> entry, ray::Tri
             t.v0.tex_coord * barycentric.x + t.v1.tex_coord * barycentric.y + t.v2.tex_coord * barycentric.z;
     out_vert.normal =
             normalize(t.v0.normal * barycentric.x + t.v1.normal * barycentric.y + t.v2.normal * barycentric.z);
-    out_vert.tangent =
-            normalize(t.v0.tangent * barycentric.x + t.v1.tangent * barycentric.y + t.v2.tangent * barycentric.z);
+    // all three vertices of a triangle share the same handedness -> interpolate the direction only
+    out_vert.tangent = float4(normalize(t.v0.tangent.xyz * barycentric.x + t.v1.tangent.xyz * barycentric.y +
+                                        t.v2.tangent.xyz * barycentric.z),
+                              t.v0.tangent.w);
 
     out_vert.position = utils::apply_transform(entry->transform, position);
     out_vert.tex_coord = mul(entry->texture_matrix, float4(out_vert.tex_coord, 0.0, 1.0)).xy;
@@ -398,7 +400,7 @@ utils::Vertex interpolate_vertex(Ptr<ray::entry_t, Access::Read> entry, ray::Tri
                          entry->transform.rotation_w);
     out_vert.normal = utils::rotate_quat(quat, out_vert.normal);
     out_vert.normal = (HitKind() == HIT_KIND_BACK_FACE) ? -out_vert.normal : out_vert.normal;
-    out_vert.tangent = utils::rotate_quat(quat, out_vert.tangent);
+    out_vert.tangent.xyz = utils::rotate_quat(quat, out_vert.tangent.xyz);
     return out_vert;
 }
 
@@ -590,8 +592,8 @@ void closest_hit(inout ray::payload_t payload, BuiltInTriangleIntersectionAttrib
 
             // v.normal potentially flipped for backfaces, but v.tangent is not.
             // -> adjust bitangent handedness for backfaces
-            float3 b = normalize(cross(v.normal, v.tangent));
-            normal = normalize(mul(normal, float3x3(v.tangent, backface ? -b : b, v.normal)));
+            float3 b = normalize(cross(v.normal, v.tangent.xyz)) * v.tangent.w;
+            normal = normalize(mul(normal, float3x3(v.tangent.xyz, backface ? -b : b, v.normal)));
 
             // hemisphere clamp
             shading_normal = normalize(normal + max(0, -dot(normal, v.normal) + 1e-3) * v.normal);

--- a/shaders/slang/renderer/types.slang
+++ b/shaders/slang/renderer/types.slang
@@ -65,7 +65,9 @@ public struct g_buffer_vertex_data_t
 {
     public float2 tex_coord;
     public float3 normal;
-    public float3 tangent;
+
+    //! tangent-direction in xyz, bitangent-handedness in w
+    public float4 tangent;
     public float4 current_position;
     public float4 last_position;
 };

--- a/shaders/slang/utils/octahedral_map.slang
+++ b/shaders/slang/utils/octahedral_map.slang
@@ -54,4 +54,93 @@ public uint pack_snorm_2x16(float2 v)
     return packed;
 }
 
+// Unpack two 12-bit snorm values from the low 24 bits of a dword.
+//  - packed: Two 12-bit snorm in bits [11:0] and [23:12].
+//  - returns: Two float values in [-1,1].
+public float2 unpack_snorm_2x12(uint packed)
+{
+    int2 bits = int2(packed << 20, packed << 8) >> 20;
+    return max(float2(bits) / 2047.0, -1.0);
+}
+
+// Pack two floats into 12-bit snorm values in the low 24 bits of a dword.
+//  - returns: Two 12-bit snorm in bits [11:0] and [23:12].
+public uint pack_snorm_2x12(float2 v)
+{
+    v = any(isnan(v)) ? float2(0, 0) : clamp(v, -1.0, 1.0);
+    int2 iv = int2(round(v * 2047.0));
+    return (iv.x & 0xfff) | ((iv.y & 0xfff) << 12);
+}
+
+// Construct a deterministic orthonormal basis for a direction.
+// Duff et al., "Building an Orthonormal Basis, Revisited" (JCGT 2017).
+//
+// ATTENTION: must stay bit-identical to the host-side implementation in octahedral_map.hpp,
+// otherwise packed tangent-angles decode against a different reference frame. The basis flips
+// discontinuously across n.z == 0 - safe because both sides evaluate 'n' from the same quantized
+// bits and 1 - |p.x| - |p.y| contains no multiply (no fma-contraction can change the sign).
+public void reference_basis(float3 n, out float3 b1, out float3 b2)
+{
+    float s = n.z >= 0.0 ? 1.0 : -1.0;
+    float a = -1.0 / (s + n.z);
+    float b = n.x * n.y * a;
+    b1 = float3(1.0 + s * n.x * n.x * a, s * b, -s * n.x);
+    b2 = float3(b, s + n.y * n.y * a, -n.y);
+}
+
+// bit-layout of a packed tangent-frame: octahedral normal | tangent-angle | handedness
+public static const uint tangent_frame_oct_bits = 24;
+public static const uint tangent_frame_angle_bits = 7;
+public static const uint tangent_frame_angle_steps = 1u << tangent_frame_angle_bits;
+public static const uint tangent_frame_angle_mask = tangent_frame_angle_steps - 1;
+public static const uint tangent_frame_sign_bit = 1u << 31;
+
+static const float TWO_PI = 6.28318530717958647692;
+
+// Pack an orthonormal tangent-frame into a single dword.
+// The normal is stored as a 12:12 octahedral mapping, the tangent as its rotation around that
+// normal relative to reference_basis(), plus one bit of bitangent-handedness. The angle is measured
+// against the *quantized* normal, so the two quantization-errors do not compound.
+//  - n: normalized normal.
+//  - t: tangent, not required to be orthogonal to n (the projection is implicit).
+//  - w: bitangent handedness, glTF convention: bitangent = cross(n, t) * w.
+public uint pack_tangent_frame(float3 n, float3 t, float w)
+{
+    uint oct = pack_snorm_2x12(normalized_vector_to_octahedral_mapping(n));
+
+    // re-derive the basis from the quantized normal, exactly as the unpack-side will
+    float3 quantized_normal = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(oct));
+    float3 b1, b2;
+    reference_basis(quantized_normal, b1, b2);
+
+    // a tangent parallel to n projects to (0,0) -> atan2(0,0) == 0, an arbitrary but valid frame
+    float angle = atan2(dot(t, b2), dot(t, b1));
+    int steps = int(round(angle * (float(tangent_frame_angle_steps) / TWO_PI)));
+    return oct | ((uint(steps) & tangent_frame_angle_mask) << tangent_frame_oct_bits) |
+           (w < 0.0 ? tangent_frame_sign_bit : 0u);
+}
+
+// Unpack a tangent-frame packed by pack_tangent_frame.
+//  - n: output normal.
+//  - t: output tangent, orthogonal to n.
+//  - w: output bitangent handedness, bitangent = cross(n, t) * w.
+public void unpack_tangent_frame(uint packed, out float3 n, out float3 t, out float w)
+{
+    n = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(packed));
+    float3 b1, b2;
+    reference_basis(n, b1, b2);
+
+    float angle = float((packed >> tangent_frame_oct_bits) & tangent_frame_angle_mask) *
+                  (TWO_PI / float(tangent_frame_angle_steps));
+    t = cos(angle) * b1 + sin(angle) * b2;
+    w = (packed & tangent_frame_sign_bit) != 0u ? -1.0 : 1.0;
+}
+
+// Unpack only the normal of a packed tangent-frame - skips the basis-construction and sincos.
+// Prefer this in paths that never sample a normal-map (shadow-rays, alpha-test any-hit).
+public float3 unpack_tangent_frame_normal(uint packed)
+{
+    return octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(packed));
+}
+
 }

--- a/shaders/slang/utils/packed_vertex.slang
+++ b/shaders/slang/utils/packed_vertex.slang
@@ -11,14 +11,18 @@ public struct Vertex
     public float3 position;
     public float2 tex_coord;
     public float3 normal;
-    public float3 tangent;
+
+    //! glTF convention: tangent-direction in xyz, bitangent-handedness in w
+    public float4 tangent;
 };
 
 public struct packed_vertex_t
 {
     float pos_x, pos_y, pos_z;
-    uint normal;
-    uint tangent;
+
+    //! octahedral normal, tangent-angle and bitangent-handedness, see utils::pack_tangent_frame
+    uint tangent_frame;
+
     float16_t texcoord_x, texcoord_y;
 };
 
@@ -35,8 +39,22 @@ public Vertex unpack(packed_vertex_t v)
     Vertex ret;
     ret.position = float3(v.pos_x, v.pos_y, v.pos_z);
     ret.tex_coord = float2(v.texcoord_x, v.texcoord_y);
-    ret.normal = utils::octahedral_mapping_to_normalized_vector(utils::unpack_snorm_2x16(v.normal));
-    ret.tangent = utils::octahedral_mapping_to_normalized_vector(utils::unpack_snorm_2x16(v.tangent));
+
+    float3 tangent;
+    float handedness;
+    utils::unpack_tangent_frame(v.tangent_frame, ret.normal, tangent, handedness);
+    ret.tangent = float4(tangent, handedness);
+    return ret;
+}
+
+//! unpack only position/tex_coord/normal - skips the tangent-frame's basis-construction and sincos
+public Vertex unpack_no_tangent(packed_vertex_t v)
+{
+    Vertex ret;
+    ret.position = float3(v.pos_x, v.pos_y, v.pos_z);
+    ret.tex_coord = float2(v.texcoord_x, v.texcoord_y);
+    ret.normal = utils::unpack_tangent_frame_normal(v.tangent_frame);
+    ret.tangent = float4(0, 0, 0, 1);
     return ret;
 }
 
@@ -47,8 +65,7 @@ public packed_vertex_t pack(Vertex v)
     ret.pos_y = v.position.y;
     ret.pos_z = v.position.z;
 
-    ret.normal = utils::pack_snorm_2x16(utils::normalized_vector_to_octahedral_mapping(v.normal));
-    ret.tangent = utils::pack_snorm_2x16(utils::normalized_vector_to_octahedral_mapping(v.tangent));
+    ret.tangent_frame = utils::pack_tangent_frame(v.normal, v.tangent.xyz, v.tangent.w);
 
     ret.texcoord_x = float16_t(v.tex_coord.x);
     ret.texcoord_y = float16_t(v.tex_coord.y);

--- a/src/Geometry.cpp
+++ b/src/Geometry.cpp
@@ -203,7 +203,7 @@ void Geometry::compute_tangents()
     if(tangents.size() != positions.size())
     {
         tangents.clear();
-        tangents.resize(positions.size(), glm::vec3(0));
+        tangents.resize(positions.size(), glm::vec4(0));
     }
     tangents_tmp.resize(positions.size(), glm::vec3(0));
     bitangents_tmp.resize(positions.size(), glm::vec3(0));
@@ -246,10 +246,14 @@ void Geometry::compute_tangents()
         const glm::vec3 &b = bitangents_tmp[a];
 
         // Gram-Schmidt orthogonalize
-        tangents[a] = glm::normalize(t - n * glm::dot(n, t));
+        glm::vec3 tangent = glm::normalize(t - n * glm::dot(n, t));
 
         // correct handedness
-        tangents[a] *= (glm::dot(glm::cross(n, t), b) < 0.f) ? 1.f : -1.f;
+        tangent *= (glm::dot(glm::cross(n, t), b) < 0.f) ? 1.f : -1.f;
+
+        // NOTE: handedness is baked into the tangent-direction here rather than carried in w.
+        // w == 1 keeps 'bitangent = cross(n, t) * w' identical to the previous reconstruction.
+        tangents[a] = glm::vec4(tangent, 1.f);
     }
 }
 

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -305,7 +305,7 @@ vierkant::GeometryPtr create_geometry(const tinygltf::Primitive &primitive, cons
     // last resort is to fill with zeros here
     geometry->tex_coords.resize(geometry->positions.size(), glm::vec2(0.f));
     geometry->normals.resize(geometry->positions.size(), glm::vec3(0.f));
-    geometry->tangents.resize(geometry->positions.size(), glm::vec3(0.f));
+    geometry->tangents.resize(geometry->positions.size(), glm::vec4(0.f, 0.f, 0.f, 1.f));
 
     return geometry;
 }

--- a/src/vertex_splicer.cpp
+++ b/src/vertex_splicer.cpp
@@ -76,7 +76,7 @@ bool vertex_splicer::insert(const vierkant::GeometryConstPtr &geometry)
             {
                 const glm::vec3 &pos = geom->positions[i];
                 const glm::vec3 &normal = geom->normals[i];
-                const glm::vec3 &tangent = geom->tangents[i];
+                const glm::vec4 &tangent = geom->tangents[i];
                 const glm::vec2 &texcoord = geom->tex_coords[i];
 
                 packed_vertex_t *v = (packed_vertex_t *) ret.data() + offset_bundle.base_vertex + i;
@@ -84,9 +84,8 @@ bool vertex_splicer::insert(const vierkant::GeometryConstPtr &geometry)
                 v->pos_y = meshopt_quantizeFloat(pos.y, num_mantissa_bits);
                 v->pos_z = meshopt_quantizeFloat(pos.z, num_mantissa_bits);
 
-                // store directions in packed octahedral mapping
-                v->normal = vierkant::pack_snorm_2x16(vierkant::normalized_vector_to_octahedral_mapping(normal));
-                v->tangent = vierkant::pack_snorm_2x16(vierkant::normalized_vector_to_octahedral_mapping(tangent));
+                // store the orthonormal tangent-frame in a single dword
+                v->tangent_frame = vierkant::pack_tangent_frame(normal, glm::vec3(tangent), tangent.w);
 
                 v->texcoord_x = meshopt_quantizeHalf(texcoord.x);
                 v->texcoord_y = meshopt_quantizeHalf(texcoord.y);
@@ -122,20 +121,16 @@ bool vertex_splicer::insert(const vierkant::GeometryConstPtr &geometry)
         pos_attrib.offset = offsetof(packed_vertex_t, pos_x);
         pos_attrib.stride = sizeof(packed_vertex_t);
 
+        // normal and tangent share a single packed dword, exposed at the normal-location
         auto &normal_attrib = ret[Mesh::AttribLocation::ATTRIB_NORMAL];
-        normal_attrib.format = VK_FORMAT_R8G8B8A8_UINT;
-        normal_attrib.offset = offsetof(packed_vertex_t, normal);
+        normal_attrib.format = VK_FORMAT_R32_UINT;
+        normal_attrib.offset = offsetof(packed_vertex_t, tangent_frame);
         normal_attrib.stride = sizeof(packed_vertex_t);
 
         auto &texcoord_attrib = ret[Mesh::AttribLocation::ATTRIB_TEX_COORD];
         texcoord_attrib.format = VK_FORMAT_R16G16_SFLOAT;
         texcoord_attrib.offset = offsetof(packed_vertex_t, texcoord_x);
         texcoord_attrib.stride = sizeof(packed_vertex_t);
-
-        auto &tangent_attrib = ret[Mesh::AttribLocation::ATTRIB_TANGENT];
-        tangent_attrib.format = VK_FORMAT_R8G8B8A8_UINT;
-        tangent_attrib.offset = offsetof(packed_vertex_t, tangent);
-        tangent_attrib.stride = sizeof(packed_vertex_t);
     }
     return ret;
 }

--- a/tests/TestOctahedralMap.cpp
+++ b/tests/TestOctahedralMap.cpp
@@ -1,0 +1,186 @@
+#include <gtest/gtest.h>
+#include <random>
+#include <spdlog/spdlog.h>
+#include <vierkant/octahedral_map.hpp>
+
+using namespace vierkant;
+//____________________________________________________________________________//
+
+namespace
+{
+
+//! deterministic unit-directions
+std::vector<glm::vec3> random_directions(size_t num, uint32_t seed = 0x5eed)
+{
+    std::mt19937 rng(seed);
+    std::uniform_real_distribution<float> dist(-1.f, 1.f);
+    std::vector<glm::vec3> ret;
+    ret.reserve(num);
+
+    while(ret.size() < num)
+    {
+        glm::vec3 v(dist(rng), dist(rng), dist(rng));
+        float len2 = glm::length2(v);
+        if(len2 > 1e-4f && len2 <= 1.f) { ret.push_back(v / std::sqrt(len2)); }
+    }
+    return ret;
+}
+
+//! axis-aligned + diagonal directions - n.z == 0 exercises the reference_basis discontinuity
+const std::vector<glm::vec3> g_degenerate_directions = {
+        {1, 0, 0},  {-1, 0, 0}, {0, 1, 0},
+        {0, -1, 0}, {0, 0, 1},  {0, 0, -1},
+        glm::normalize(glm::vec3(1, 1, 0)),
+        glm::normalize(glm::vec3(-1, 1, 0)),
+        glm::normalize(glm::vec3(1, -1, 0)),
+        glm::normalize(glm::vec3(1, 1, 1)),
+        glm::normalize(glm::vec3(-1, -1, -1)),
+};
+
+float angle_between(const glm::vec3 &a, const glm::vec3 &b)
+{
+    return glm::degrees(std::acos(glm::clamp(glm::dot(a, b), -1.f, 1.f)));
+}
+
+//! an arbitrary tangent orthogonal to n, rotated by 'angle' within the tangent-plane
+glm::vec3 tangent_for(const glm::vec3 &n, float angle)
+{
+    glm::vec3 b1, b2;
+    reference_basis(n, b1, b2);
+    return std::cos(angle) * b1 + std::sin(angle) * b2;
+}
+
+}// namespace
+
+TEST(OctahedralMap, snorm_2x12_roundtrip)
+{
+    // 12-bit snorm: 1/2047 quantum, so worst-case error is half of that
+    constexpr float max_error = 0.5f / 2047.f + 1e-6f;
+
+    for(int i = -2047; i <= 2047; ++i)
+    {
+        glm::vec2 v(static_cast<float>(i) / 2047.f, static_cast<float>(-i) / 2047.f);
+        glm::vec2 rt = unpack_snorm_2x12(pack_snorm_2x12(v));
+        EXPECT_NEAR(v.x, rt.x, max_error);
+        EXPECT_NEAR(v.y, rt.y, max_error);
+    }
+
+    // the two components must not bleed into each other
+    EXPECT_EQ(pack_snorm_2x12({1.f, 0.f}) >> 12, 0u);
+    EXPECT_EQ(pack_snorm_2x12({0.f, 1.f}) & 0xfff, 0u);
+
+    // nothing may escape the low 24 bits
+    for(const auto &d: random_directions(4096))
+    {
+        EXPECT_EQ(pack_snorm_2x12(normalized_vector_to_octahedral_mapping(d)) & 0xff000000u, 0u);
+    }
+}
+
+TEST(OctahedralMap, reference_basis_orthonormal)
+{
+    auto directions = random_directions(65536);
+    directions.insert(directions.end(), g_degenerate_directions.begin(), g_degenerate_directions.end());
+
+    for(const auto &n: directions)
+    {
+        glm::vec3 b1, b2;
+        reference_basis(n, b1, b2);
+
+        EXPECT_NEAR(glm::length(b1), 1.f, 1e-5f);
+        EXPECT_NEAR(glm::length(b2), 1.f, 1e-5f);
+        EXPECT_NEAR(glm::dot(b1, b2), 0.f, 1e-5f);
+        EXPECT_NEAR(glm::dot(b1, n), 0.f, 1e-5f);
+        EXPECT_NEAR(glm::dot(b2, n), 0.f, 1e-5f);
+
+        // right-handed: cross(b1, b2) == n. compared component-wise - acos is ill-conditioned here
+        glm::vec3 c = glm::cross(b1, b2);
+        EXPECT_NEAR(c.x, n.x, 1e-5f);
+        EXPECT_NEAR(c.y, n.y, 1e-5f);
+        EXPECT_NEAR(c.z, n.z, 1e-5f);
+    }
+}
+
+TEST(OctahedralMap, tangent_frame_roundtrip)
+{
+    // 12:12 octahedral - measured worst case is ~0.056 degrees (at the octahedral cell-corners)
+    constexpr float max_normal_error = 0.1f;
+
+    // 7-bit angle -> 360/128 == 2.8125 degree steps, worst case half a step
+    constexpr float max_tangent_error = 0.5f * 360.f / 128.f + 0.05f;
+
+    std::mt19937 rng(0xc0ffee);
+    std::uniform_real_distribution<float> angle_dist(-glm::pi<float>(), glm::pi<float>());
+
+    auto directions = random_directions(65536);
+    directions.insert(directions.end(), g_degenerate_directions.begin(), g_degenerate_directions.end());
+
+    float worst_normal = 0.f, worst_tangent = 0.f;
+
+    for(const auto &n: directions)
+    {
+        for(float w: {1.f, -1.f})
+        {
+            glm::vec3 t = tangent_for(n, angle_dist(rng));
+
+            glm::vec3 out_n, out_t;
+            float out_w = 0.f;
+            unpack_tangent_frame(pack_tangent_frame(n, t, w), out_n, out_t, out_w);
+
+            EXPECT_EQ(w, out_w) << "handedness must survive the roundtrip";
+
+            EXPECT_NEAR(glm::length(out_n), 1.f, 1e-5f);
+            EXPECT_NEAR(glm::length(out_t), 1.f, 1e-5f);
+
+            // the decoded tangent is orthogonal to the decoded normal by construction
+            EXPECT_NEAR(glm::dot(out_n, out_t), 0.f, 1e-5f);
+
+            float normal_error = angle_between(n, out_n);
+            EXPECT_LT(normal_error, max_normal_error);
+            worst_normal = std::max(worst_normal, normal_error);
+
+            // compare against the input tangent projected into the decoded normal's plane
+            glm::vec3 expected_t = glm::normalize(t - out_n * glm::dot(out_n, t));
+            float tangent_error = angle_between(expected_t, out_t);
+            EXPECT_LT(tangent_error, max_tangent_error);
+            worst_tangent = std::max(worst_tangent, tangent_error);
+        }
+    }
+    spdlog::info("tangent-frame worst-case error: normal {:.4f} deg, tangent {:.4f} deg", worst_normal, worst_tangent);
+}
+
+TEST(OctahedralMap, tangent_frame_non_orthogonal_input)
+{
+    // a skewed tangent must be projected into the tangent-plane, not produce garbage
+    glm::vec3 n(0, 0, 1);
+    glm::vec3 skewed = glm::normalize(glm::vec3(1, 0, 0.5f));
+
+    glm::vec3 out_n, out_t;
+    float out_w = 0.f;
+    unpack_tangent_frame(pack_tangent_frame(n, skewed, 1.f), out_n, out_t, out_w);
+
+    EXPECT_NEAR(glm::dot(out_n, out_t), 0.f, 1e-5f);
+    EXPECT_LT(angle_between(out_t, glm::vec3(1, 0, 0)), 1.5f);
+
+    // a tangent parallel to the normal is degenerate but must stay finite
+    unpack_tangent_frame(pack_tangent_frame(n, n, 1.f), out_n, out_t, out_w);
+    EXPECT_TRUE(std::isfinite(out_t.x) && std::isfinite(out_t.y) && std::isfinite(out_t.z));
+    EXPECT_NEAR(glm::length(out_t), 1.f, 1e-5f);
+}
+
+TEST(OctahedralMap, tangent_frame_bitangent_handedness)
+{
+    // glTF convention: bitangent == cross(normal, tangent) * w
+    glm::vec3 n(0, 0, 1);
+    glm::vec3 t(1, 0, 0);
+
+    glm::vec3 out_n, out_t;
+    float out_w = 0.f;
+
+    unpack_tangent_frame(pack_tangent_frame(n, t, 1.f), out_n, out_t, out_w);
+    glm::vec3 bitangent = glm::cross(out_n, out_t) * out_w;
+    EXPECT_LT(angle_between(bitangent, glm::vec3(0, 1, 0)), 1.5f);
+
+    unpack_tangent_frame(pack_tangent_frame(n, t, -1.f), out_n, out_t, out_w);
+    bitangent = glm::cross(out_n, out_t) * out_w;
+    EXPECT_LT(angle_between(bitangent, glm::vec3(0, -1, 0)), 1.5f);
+}


### PR DESCRIPTION
- packed_vertex_t 24 -> 20 B: oct 12:12 normal + 7-bit tangent-angle around a Duff reference-basis + 1 bit bitangent-handedness
- adds the handedness glTF TANGENT.w carries and we dropped on import, fixing inverted bitangents on mirrored-UV islands
- Geometry::tangents vec3 -> vec4; bitangent reconstruction applies w in g_buffer_uber and raypipeline; mesh_compute passes w through
- fix host octahedral_mapping_to_normalized_vector: 'n.xy() = ...' hit a glm by-value swizzle under GLM_FORCE_XYZW_ONLY, so the lower-hemisphere fold was silently discarded
- create_vertex_attribs(PACKED) exposes the frame at ATTRIB_NORMAL as R32_UINT, drops ATTRIB_TANGENT
- compute_tangents keeps its direction convention, writes w = 1
- new TestOctahedralMap