### PR TITLE
tangent-frame: re-split to 11:11 octahedral + 9-bit angle

### DIFF
--- a/include/vierkant/octahedral_map.hpp
+++ b/include/vierkant/octahedral_map.hpp
@@ -82,28 +82,70 @@ inline uint32_t pack_snorm_2x16(glm::vec2 v)
 }
 
 /**
- * @brief   unpack two 12-bit snorm values from the low 24 bits of a dword.
+ * @brief   unpack two 11-bit snorm values from the low 22 bits of a dword.
  *
- * @param   packed  two 12-bit snorm in bits [11:0] and [23:12].
+ * @param   packed  two 11-bit snorm in bits [10:0] and [21:11].
  * @return  two float values in [-1,1].
  */
-inline glm::vec2 unpack_snorm_2x12(uint32_t packed)
+inline glm::vec2 unpack_snorm_2x11(uint32_t packed)
 {
-    glm::ivec2 bits = glm::ivec2(packed << 20, packed << 8) >> 20;
-    return glm::max(glm::vec2(bits) / 2047.f, glm::vec2(-1.f));
+    glm::ivec2 bits = glm::ivec2(packed << 21, packed << 10) >> 21;
+    return glm::max(glm::vec2(bits) / 1023.f, glm::vec2(-1.f));
 }
 
 /**
- * @brief   pack two floats into 12-bit snorm values in the low 24 bits of a dword.
+ * @brief   pack two floats into 11-bit snorm values in the low 22 bits of a dword.
  *
  * @param   v   two provided floats
- * @return  two 12-bit snorm in bits [11:0] and [23:12].
+ * @return  two 11-bit snorm in bits [10:0] and [21:11].
  */
-inline uint32_t pack_snorm_2x12(glm::vec2 v)
+inline uint32_t pack_snorm_2x11(glm::vec2 v)
 {
     v = any(isnan(v)) ? glm::vec2(0) : glm::clamp(v, glm::vec2(-1.f), glm::vec2(1.f));
-    auto iv = glm::ivec2(glm::round(v * 2047.f));
-    return (iv.x & 0xfff) | ((iv.y & 0xfff) << 12);
+    auto iv = glm::ivec2(glm::round(v * 1023.f));
+    return (iv.x & 0x7ff) | ((iv.y & 0x7ff) << 11);
+}
+
+/**
+ * @brief   encode a direction as an 11:11 octahedral mapping, picking the rounding of the two
+ *          components that minimizes the resulting angular error.
+ *
+ *          Rounding each component to nearest is only optimal for independent axes, which these are
+ *          not - the octahedral fold couples them. Trying all four floor/ceil combinations cuts the
+ *          worst-case error by ~30% (0.117 -> 0.082 degrees) for four extra decodes at bake-time.
+ *
+ * @attention   not mirrored in octahedral_map.slang, which keeps plain rounding. That is safe - the
+ *              choice only affects which of four legal encodings the packer emits, and decoding is
+ *              identical either way - but it does mean vertices repacked by mesh_compute (skin and
+ *              morph) keep the coarser 0.117 degrees.
+ *
+ * @param   n   a normalized direction.
+ * @return  two 11-bit snorm in bits [10:0] and [21:11].
+ */
+inline uint32_t pack_octahedral_2x11(const glm::vec3 &n)
+{
+    constexpr float scale = 1023.f;
+    glm::vec2 p = normalized_vector_to_octahedral_mapping(n);
+    p = any(isnan(p)) ? glm::vec2(0) : glm::clamp(p, glm::vec2(-1.f), glm::vec2(1.f));
+    glm::vec2 base = glm::floor(p * scale);
+
+    uint32_t best = 0;
+    float best_dot = -2.f;
+
+    for(uint32_t i = 0; i < 4; ++i)
+    {
+        auto iv = glm::ivec2(glm::clamp(base + glm::vec2(i & 1u, (i >> 1) & 1u), -scale, scale));
+        uint32_t packed = (static_cast<uint32_t>(iv.x) & 0x7ff) | ((static_cast<uint32_t>(iv.y) & 0x7ff) << 11);
+
+        // NOTE: a non-finite 'n' leaves every comparison false -> best stays 0, matching the NaN-guards above
+        float d = glm::dot(n, octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(packed)));
+        if(d > best_dot)
+        {
+            best_dot = d;
+            best = packed;
+        }
+    }
+    return best;
 }
 
 /**
@@ -130,8 +172,8 @@ inline void reference_basis(const glm::vec3 &n, glm::vec3 &b1, glm::vec3 &b2)
 }
 
 //! bit-layout of a packed tangent-frame: octahedral normal | tangent-angle | handedness
-constexpr uint32_t tangent_frame_oct_bits = 24;
-constexpr uint32_t tangent_frame_angle_bits = 7;
+constexpr uint32_t tangent_frame_oct_bits = 22;
+constexpr uint32_t tangent_frame_angle_bits = 9;
 constexpr uint32_t tangent_frame_angle_steps = 1u << tangent_frame_angle_bits;
 constexpr uint32_t tangent_frame_angle_mask = tangent_frame_angle_steps - 1;
 constexpr uint32_t tangent_frame_sign_bit = 1u << 31;
@@ -139,7 +181,7 @@ constexpr uint32_t tangent_frame_sign_bit = 1u << 31;
 /**
  * @brief   pack an orthonormal tangent-frame into a single dword.
  *
- *          The normal is stored as a 12:12 octahedral mapping, the tangent as its rotation around
+ *          The normal is stored as an 11:11 octahedral mapping, the tangent as its rotation around
  *          that normal relative to reference_basis(), plus one bit of bitangent-handedness.
  *          The angle is measured against the *quantized* normal, so the two quantization-errors
  *          do not compound.
@@ -151,10 +193,10 @@ constexpr uint32_t tangent_frame_sign_bit = 1u << 31;
  */
 inline uint32_t pack_tangent_frame(const glm::vec3 &n, const glm::vec3 &t, float w)
 {
-    uint32_t oct = pack_snorm_2x12(normalized_vector_to_octahedral_mapping(n));
+    uint32_t oct = pack_octahedral_2x11(n);
 
     // re-derive the basis from the quantized normal, exactly as the unpack-side will
-    glm::vec3 quantized_normal = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(oct));
+    glm::vec3 quantized_normal = octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(oct));
     glm::vec3 b1, b2;
     reference_basis(quantized_normal, b1, b2);
 
@@ -174,7 +216,7 @@ inline uint32_t pack_tangent_frame(const glm::vec3 &n, const glm::vec3 &t, float
  */
 inline void unpack_tangent_frame(uint32_t packed, glm::vec3 &n, glm::vec3 &t, float &w)
 {
-    n = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(packed));
+    n = octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(packed));
     glm::vec3 b1, b2;
     reference_basis(n, b1, b2);
 

--- a/shaders/slang/utils/octahedral_map.slang
+++ b/shaders/slang/utils/octahedral_map.slang
@@ -54,22 +54,22 @@ public uint pack_snorm_2x16(float2 v)
     return packed;
 }
 
-// Unpack two 12-bit snorm values from the low 24 bits of a dword.
-//  - packed: Two 12-bit snorm in bits [11:0] and [23:12].
+// Unpack two 11-bit snorm values from the low 22 bits of a dword.
+//  - packed: Two 11-bit snorm in bits [10:0] and [21:11].
 //  - returns: Two float values in [-1,1].
-public float2 unpack_snorm_2x12(uint packed)
+public float2 unpack_snorm_2x11(uint packed)
 {
-    int2 bits = int2(packed << 20, packed << 8) >> 20;
-    return max(float2(bits) / 2047.0, -1.0);
+    int2 bits = int2(packed << 21, packed << 10) >> 21;
+    return max(float2(bits) / 1023.0, -1.0);
 }
 
-// Pack two floats into 12-bit snorm values in the low 24 bits of a dword.
-//  - returns: Two 12-bit snorm in bits [11:0] and [23:12].
-public uint pack_snorm_2x12(float2 v)
+// Pack two floats into 11-bit snorm values in the low 22 bits of a dword.
+//  - returns: Two 11-bit snorm in bits [10:0] and [21:11].
+public uint pack_snorm_2x11(float2 v)
 {
     v = any(isnan(v)) ? float2(0, 0) : clamp(v, -1.0, 1.0);
-    int2 iv = int2(round(v * 2047.0));
-    return (iv.x & 0xfff) | ((iv.y & 0xfff) << 12);
+    int2 iv = int2(round(v * 1023.0));
+    return (iv.x & 0x7ff) | ((iv.y & 0x7ff) << 11);
 }
 
 // Construct a deterministic orthonormal basis for a direction.
@@ -89,8 +89,8 @@ public void reference_basis(float3 n, out float3 b1, out float3 b2)
 }
 
 // bit-layout of a packed tangent-frame: octahedral normal | tangent-angle | handedness
-public static const uint tangent_frame_oct_bits = 24;
-public static const uint tangent_frame_angle_bits = 7;
+public static const uint tangent_frame_oct_bits = 22;
+public static const uint tangent_frame_angle_bits = 9;
 public static const uint tangent_frame_angle_steps = 1u << tangent_frame_angle_bits;
 public static const uint tangent_frame_angle_mask = tangent_frame_angle_steps - 1;
 public static const uint tangent_frame_sign_bit = 1u << 31;
@@ -98,18 +98,22 @@ public static const uint tangent_frame_sign_bit = 1u << 31;
 static const float TWO_PI = 6.28318530717958647692;
 
 // Pack an orthonormal tangent-frame into a single dword.
-// The normal is stored as a 12:12 octahedral mapping, the tangent as its rotation around that
+// The normal is stored as an 11:11 octahedral mapping, the tangent as its rotation around that
 // normal relative to reference_basis(), plus one bit of bitangent-handedness. The angle is measured
 // against the *quantized* normal, so the two quantization-errors do not compound.
+//
+// NOTE: the host packs with vierkant::pack_octahedral_2x11, which searches all four floor/ceil
+// roundings of the octahedral pair and reaches 0.082 vs. the 0.117 degrees here. Decoding is
+// identical either way, so the two may differ - but vertices repacked below (skin/morph) stay coarser.
 //  - n: normalized normal.
 //  - t: tangent, not required to be orthogonal to n (the projection is implicit).
 //  - w: bitangent handedness, glTF convention: bitangent = cross(n, t) * w.
 public uint pack_tangent_frame(float3 n, float3 t, float w)
 {
-    uint oct = pack_snorm_2x12(normalized_vector_to_octahedral_mapping(n));
+    uint oct = pack_snorm_2x11(normalized_vector_to_octahedral_mapping(n));
 
     // re-derive the basis from the quantized normal, exactly as the unpack-side will
-    float3 quantized_normal = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(oct));
+    float3 quantized_normal = octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(oct));
     float3 b1, b2;
     reference_basis(quantized_normal, b1, b2);
 
@@ -126,7 +130,7 @@ public uint pack_tangent_frame(float3 n, float3 t, float w)
 //  - w: output bitangent handedness, bitangent = cross(n, t) * w.
 public void unpack_tangent_frame(uint packed, out float3 n, out float3 t, out float w)
 {
-    n = octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(packed));
+    n = octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(packed));
     float3 b1, b2;
     reference_basis(n, b1, b2);
 
@@ -140,7 +144,7 @@ public void unpack_tangent_frame(uint packed, out float3 n, out float3 t, out fl
 // Prefer this in paths that never sample a normal-map (shadow-rays, alpha-test any-hit).
 public float3 unpack_tangent_frame_normal(uint packed)
 {
-    return octahedral_mapping_to_normalized_vector(unpack_snorm_2x12(packed));
+    return octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(packed));
 }
 
 }

--- a/tests/TestOctahedralMap.cpp
+++ b/tests/TestOctahedralMap.cpp
@@ -52,28 +52,52 @@ glm::vec3 tangent_for(const glm::vec3 &n, float angle)
 
 }// namespace
 
-TEST(OctahedralMap, snorm_2x12_roundtrip)
+TEST(OctahedralMap, snorm_2x11_roundtrip)
 {
-    // 12-bit snorm: 1/2047 quantum, so worst-case error is half of that
-    constexpr float max_error = 0.5f / 2047.f + 1e-6f;
+    // 11-bit snorm: 1/1023 quantum, so worst-case error is half of that
+    constexpr float max_error = 0.5f / 1023.f + 1e-6f;
 
-    for(int i = -2047; i <= 2047; ++i)
+    for(int i = -1023; i <= 1023; ++i)
     {
-        glm::vec2 v(static_cast<float>(i) / 2047.f, static_cast<float>(-i) / 2047.f);
-        glm::vec2 rt = unpack_snorm_2x12(pack_snorm_2x12(v));
+        glm::vec2 v(static_cast<float>(i) / 1023.f, static_cast<float>(-i) / 1023.f);
+        glm::vec2 rt = unpack_snorm_2x11(pack_snorm_2x11(v));
         EXPECT_NEAR(v.x, rt.x, max_error);
         EXPECT_NEAR(v.y, rt.y, max_error);
     }
 
     // the two components must not bleed into each other
-    EXPECT_EQ(pack_snorm_2x12({1.f, 0.f}) >> 12, 0u);
-    EXPECT_EQ(pack_snorm_2x12({0.f, 1.f}) & 0xfff, 0u);
+    EXPECT_EQ(pack_snorm_2x11({1.f, 0.f}) >> 11, 0u);
+    EXPECT_EQ(pack_snorm_2x11({0.f, 1.f}) & 0x7ff, 0u);
 
-    // nothing may escape the low 24 bits
+    // nothing may escape the low 22 bits - neither packer
     for(const auto &d: random_directions(4096))
     {
-        EXPECT_EQ(pack_snorm_2x12(normalized_vector_to_octahedral_mapping(d)) & 0xff000000u, 0u);
+        EXPECT_EQ(pack_snorm_2x11(normalized_vector_to_octahedral_mapping(d)) & 0xffc00000u, 0u);
+        EXPECT_EQ(pack_octahedral_2x11(d) & 0xffc00000u, 0u);
     }
+}
+
+TEST(OctahedralMap, octahedral_2x11_optimal_rounding)
+{
+    // searching all four floor/ceil combinations may never lose against rounding to nearest
+    float worst_optimal = 0.f, worst_nearest = 0.f;
+
+    for(const auto &n: random_directions(65536))
+    {
+        auto decode = [](uint32_t p) { return octahedral_mapping_to_normalized_vector(unpack_snorm_2x11(p)); };
+
+        float optimal = angle_between(n, decode(pack_octahedral_2x11(n)));
+        float nearest = angle_between(n, decode(pack_snorm_2x11(normalized_vector_to_octahedral_mapping(n))));
+
+        EXPECT_LE(optimal, nearest + 1e-4f);
+        worst_optimal = std::max(worst_optimal, optimal);
+        worst_nearest = std::max(worst_nearest, nearest);
+    }
+
+    // measured: 0.082 vs 0.117 degrees
+    EXPECT_LT(worst_optimal, 0.09f);
+    spdlog::info("octahedral 11:11 worst-case error: optimal {:.4f} deg, nearest {:.4f} deg", worst_optimal,
+                 worst_nearest);
 }
 
 TEST(OctahedralMap, reference_basis_orthonormal)
@@ -102,11 +126,11 @@ TEST(OctahedralMap, reference_basis_orthonormal)
 
 TEST(OctahedralMap, tangent_frame_roundtrip)
 {
-    // 12:12 octahedral - measured worst case is ~0.056 degrees (at the octahedral cell-corners)
+    // 11:11 octahedral with optimal rounding - measured worst case ~0.082 degrees
     constexpr float max_normal_error = 0.1f;
 
-    // 7-bit angle -> 360/128 == 2.8125 degree steps, worst case half a step
-    constexpr float max_tangent_error = 0.5f * 360.f / 128.f + 0.05f;
+    // 9-bit angle -> 360/512 == 0.703 degree steps, worst case half a step
+    constexpr float max_tangent_error = 0.5f * 360.f / 512.f + 0.05f;
 
     std::mt19937 rng(0xc0ffee);
     std::uniform_real_distribution<float> angle_dist(-glm::pi<float>(), glm::pi<float>());
@@ -159,7 +183,7 @@ TEST(OctahedralMap, tangent_frame_non_orthogonal_input)
     unpack_tangent_frame(pack_tangent_frame(n, skewed, 1.f), out_n, out_t, out_w);
 
     EXPECT_NEAR(glm::dot(out_n, out_t), 0.f, 1e-5f);
-    EXPECT_LT(angle_between(out_t, glm::vec3(1, 0, 0)), 1.5f);
+    EXPECT_LT(angle_between(out_t, glm::vec3(1, 0, 0)), 0.5f);
 
     // a tangent parallel to the normal is degenerate but must stay finite
     unpack_tangent_frame(pack_tangent_frame(n, n, 1.f), out_n, out_t, out_w);
@@ -178,9 +202,9 @@ TEST(OctahedralMap, tangent_frame_bitangent_handedness)
 
     unpack_tangent_frame(pack_tangent_frame(n, t, 1.f), out_n, out_t, out_w);
     glm::vec3 bitangent = glm::cross(out_n, out_t) * out_w;
-    EXPECT_LT(angle_between(bitangent, glm::vec3(0, 1, 0)), 1.5f);
+    EXPECT_LT(angle_between(bitangent, glm::vec3(0, 1, 0)), 0.5f);
 
     unpack_tangent_frame(pack_tangent_frame(n, t, -1.f), out_n, out_t, out_w);
     bitangent = glm::cross(out_n, out_t) * out_w;
-    EXPECT_LT(angle_between(bitangent, glm::vec3(0, -1, 0)), 1.5f);
+    EXPECT_LT(angle_between(bitangent, glm::vec3(0, -1, 0)), 0.5f);
 }


### PR DESCRIPTION
- shift bits from the normal to the tangent: worst-case tangent error 1.406 -> 0.352 deg, normal 0.063 -> 0.082 deg
- pack_snorm_2x12 -> pack_snorm_2x11, host and slang
- add pack_octahedral_2x11: picks the best of four floor/ceil roundings, cuts worst-case normal error by 31%. host-only, decode is unchanged
- tighten test tolerances to the new step size