### PR TITLE
camera-component: projection-mode instead of a params-variant

### DIFF
--- a/include/vierkant/Camera.hpp
+++ b/include/vierkant/Camera.hpp
@@ -17,7 +17,21 @@ glm::vec2 clipping_distances(const glm::mat4 &projection);
 struct camera_component_t
 {
     VIERKANT_ENABLE_AS_COMPONENT();
-    vierkant::camera_params_variant_t params;
+
+    enum projection_t : uint32_t
+    {
+        PERSPECTIVE = 0,
+        ORTHO = 1
+    };
+
+    //! selects which of the parameter-sets below is used to build the projection
+    projection_t projection = PERSPECTIVE;
+
+    //! lens-properties. also defines the perspective frustum, via fovx()
+    vierkant::physical_camera_params_t physical;
+
+    //! frustum-extents used when 'projection' is ORTHO. kept alongside the lens, so toggling loses nothing
+    vierkant::ortho_camera_params_t ortho;
 };
 
 namespace camera

--- a/include/vierkant/Scene.hpp
+++ b/include/vierkant/Scene.hpp
@@ -5,6 +5,7 @@
 #include <crocore/ThreadPool.hpp>
 
 #include <vierkant/AssetProvider.hpp>
+#include <vierkant/Camera.hpp>
 #include <vierkant/Image.hpp>
 #include <vierkant/Mesh.hpp>
 #include <vierkant/Object3D.hpp>
@@ -93,7 +94,7 @@ public:
     [[nodiscard]] vierkant::Object3DPtr create_object() const;
 
     [[nodiscard]] vierkant::Object3DPtr
-    create_camera(const vierkant::camera_params_variant_t &params = vierkant::physical_camera_params_t{}) const;
+    create_camera(const vierkant::camera_component_t &params = {}) const;
 
     /**
      * @brief   'create_lightsource' registers a lightsource-asset with the asset-provider

--- a/include/vierkant/camera_params.hpp
+++ b/include/vierkant/camera_params.hpp
@@ -4,7 +4,6 @@
 
 #pragma once
 
-#include <variant>
 #include <vierkant/math.hpp>
 
 namespace vierkant
@@ -54,7 +53,5 @@ struct physical_camera_params_t
     //! will adjust focal_length to match provided field-of-view (fov) in radians
     inline void set_fovx(float fovx) { focal_length = 0.5f * sensor_width / std::tan(fovx * 0.5f); }
 };
-
-using camera_params_variant_t = std::variant<ortho_camera_params_t, physical_camera_params_t>;
 
 }// namespace vierkant

--- a/include/vierkant/imgui/imgui_util.h
+++ b/include/vierkant/imgui/imgui_util.h
@@ -39,7 +39,7 @@ void draw_scene_renderer_settings_ui(const vierkant::SceneRendererPtr &scene_ren
 
 void draw_scene_renderer_statistics_ui(const vierkant::SceneRendererPtr &scene_renderer);
 
-void draw_camera_param_ui(vierkant::camera_params_variant_t &camera_params);
+void draw_camera_param_ui(vierkant::camera_component_t &camera_params);
 
 bool draw_transform_guizmo(vierkant::transform_t &transform, const vierkant::Object3DConstPtr &camera, GuizmoType type,
                            GuizmoSpace space = GuizmoSpace::WORLD);

--- a/samples/empty_sample/empty_sample.cpp
+++ b/samples/empty_sample/empty_sample.cpp
@@ -47,8 +47,7 @@ void HelloTriangleApplication::create_context_and_window()
     window_delegate.draw_fn = [this](const vierkant::WindowPtr &w) { return draw(w); };
     window_delegate.resize_fn = [this](uint32_t w, uint32_t h) {
         create_graphics_pipeline();
-        auto &camera_params = std::get<vierkant::physical_camera_params_t>(
-                m_camera->get_component<vierkant::camera_component_t>().params);
+        auto &camera_params = m_camera->get_component<vierkant::camera_component_t>().physical;
         camera_params.aspect = m_window->aspect_ratio();
     };
     window_delegate.close_fn = [this]() { running = false; };
@@ -78,8 +77,7 @@ void HelloTriangleApplication::create_context_and_window()
 
     // camera
     m_camera = m_object_store->create_object();
-    vierkant::physical_camera_params_t params = {};
-    m_camera->add_component<vierkant::camera_component_t>({params});
+    m_camera->add_component<vierkant::camera_component_t>();
     m_camera->name = "default";
 
     m_camera->set_transform({.translation = {0.f, 0.f, 3.f}});

--- a/src/Camera.cpp
+++ b/src/Camera.cpp
@@ -28,23 +28,15 @@ glm::mat4 projection_matrix(const vierkant::Object3D *camera)
     assert(camera);
     if(const auto *camera_cmp = camera->get_component_ptr<camera_component_t>())
     {
-        return std::visit(
-                [](auto &&cam_param) -> glm::mat4 {
-                    using T = std::decay_t<decltype(cam_param)>;
+        const auto &params = *camera_cmp;
 
-                    if constexpr(std::is_same_v<T, vierkant::physical_camera_params_t>)
-                    {
-                        return perspective_infinite_reverse_RH_ZO(cam_param.fovy(), cam_param.aspect,
-                                                                  cam_param.clipping_distances.x);
-                    }
-                    if constexpr(std::is_same_v<T, vierkant::ortho_camera_params_t>)
-                    {
-                        return ortho_reverse_RH_ZO(cam_param.left, cam_param.right, cam_param.bottom, cam_param.top,
-                                                   cam_param.near_, cam_param.far_);
-                    }
-                    return {};
-                },
-                camera_cmp->params);
+        if(params.projection == camera_component_t::ORTHO)
+        {
+            return ortho_reverse_RH_ZO(params.ortho.left, params.ortho.right, params.ortho.bottom, params.ortho.top,
+                                       params.ortho.near_, params.ortho.far_);
+        }
+        return perspective_infinite_reverse_RH_ZO(params.physical.fovy(), params.physical.aspect,
+                                                  params.physical.clipping_distances.x);
     }
     return {};
 }
@@ -54,18 +46,9 @@ float near(const vierkant::Object3D *camera)
     assert(camera);
     if(const auto *camera_cmp = camera->get_component_ptr<camera_component_t>())
     {
-        return std::visit(
-                [](auto &&cam_param) -> float {
-                    using T = std::decay_t<decltype(cam_param)>;
-
-                    if constexpr(std::is_same_v<T, vierkant::physical_camera_params_t>)
-                    {
-                        return cam_param.clipping_distances.x;
-                    }
-                    if constexpr(std::is_same_v<T, vierkant::ortho_camera_params_t>) { return cam_param.near_; }
-                    return 0.f;
-                },
-                camera_cmp->params);
+        const auto &params = *camera_cmp;
+        return params.projection == camera_component_t::ORTHO ? params.ortho.near_
+                                                           : params.physical.clipping_distances.x;
     }
     return 0.f;
 }
@@ -75,18 +58,8 @@ float far(const vierkant::Object3D *camera)
     assert(camera);
     if(const auto *camera_cmp = camera->get_component_ptr<camera_component_t>())
     {
-        return std::visit(
-                [](auto &&cam_param) -> float {
-                    using T = std::decay_t<decltype(cam_param)>;
-
-                    if constexpr(std::is_same_v<T, vierkant::physical_camera_params_t>)
-                    {
-                        return cam_param.clipping_distances.y;
-                    }
-                    if constexpr(std::is_same_v<T, vierkant::ortho_camera_params_t>) { return cam_param.far_; }
-                    return 0.f;
-                },
-                camera_cmp->params);
+        const auto &params = *camera_cmp;
+        return params.projection == camera_component_t::ORTHO ? params.ortho.far_ : params.physical.clipping_distances.y;
     }
     return 0.f;
 }
@@ -96,23 +69,15 @@ vierkant::Frustum frustum(const vierkant::Object3D *camera)
     assert(camera);
     if(const auto *camera_cmp = camera->get_component_ptr<camera_component_t>())
     {
-        return std::visit(
-                [](auto &&cam_param) -> vierkant::Frustum {
-                    using T = std::decay_t<decltype(cam_param)>;
+        const auto &params = *camera_cmp;
 
-                    if constexpr(std::is_same_v<T, vierkant::physical_camera_params_t>)
-                    {
-                        return {cam_param.aspect, cam_param.fovx(), cam_param.clipping_distances.x,
-                                cam_param.clipping_distances.y};
-                    }
-                    if constexpr(std::is_same_v<T, vierkant::ortho_camera_params_t>)
-                    {
-                        return {cam_param.left, cam_param.right, cam_param.bottom,
-                                cam_param.top,  cam_param.near_, cam_param.far_};
-                    }
-                    return {};
-                },
-                camera_cmp->params);
+        if(params.projection == camera_component_t::ORTHO)
+        {
+            return {params.ortho.left, params.ortho.right, params.ortho.bottom,
+                    params.ortho.top,  params.ortho.near_, params.ortho.far_};
+        }
+        return {params.physical.aspect, params.physical.fovx(), params.physical.clipping_distances.x,
+                params.physical.clipping_distances.y};
     }
     return {};
 }
@@ -122,51 +87,41 @@ vierkant::Ray calculate_ray(const vierkant::Object3D *camera, const glm::vec2 &p
     assert(camera);
     if(const auto *camera_cmp = camera->get_component_ptr<camera_component_t>())
     {
-        return std::visit(
-                [camera, &pos, &extent](auto &&cam_param) -> vierkant::Ray {
-                    using T = std::decay_t<decltype(cam_param)>;
+        const auto &params = *camera_cmp;
+        auto t = camera->global_transform();
+        glm::mat3 m = glm::mat3_cast(t.rotation);
 
-                    if constexpr(std::is_same_v<T, vierkant::physical_camera_params_t>)
-                    {
-                        // bring click_pos to range -1, 1
-                        glm::vec2 click_2D(pos);
-                        glm::vec2 offset(extent / 2.0f);
-                        click_2D -= offset;
-                        click_2D /= offset;
-                        click_2D.y = -click_2D.y;
+        if(params.projection == camera_component_t::ORTHO)
+        {
+            const auto &cam_param = params.ortho;
+            const glm::vec2 coord(crocore::map_value<float>(pos.x, 0, extent.x, cam_param.left, cam_param.right),
+                                  crocore::map_value<float>(pos.y, extent.y, 0, cam_param.bottom, cam_param.top));
 
-                        // convert fovy to radians
-                        const float rad = cam_param.fovx();
-                        const float near = cam_param.clipping_distances.x;
-                        const float hLength = std::tan(rad / 2) * near;
-                        const float vLength = hLength / cam_param.aspect;
+            glm::vec3 click_world_pos =
+                    glm::vec3(t.translation) - m[2] * cam_param.near_ + m[0] * coord.x + m[1] * coord.y;
+            glm::vec3 ray_dir = -m[2];
+            spdlog::trace("clicked_world: ({}, {}, {})", click_world_pos.x, click_world_pos.y, click_world_pos.z);
+            return {click_world_pos, ray_dir};
+        }
+        const auto &cam_param = params.physical;
 
-                        auto t = camera->global_transform();
-                        glm::mat3 m = glm::mat3_cast(t.rotation);
-                        glm::vec3 ray_origin = glm::vec3(t.translation) - m[2] * near + m[0] * hLength * click_2D.x +
-                                               m[1] * vLength * click_2D.y;
-                        glm::vec3 ray_dir = ray_origin - glm::vec3(t.translation);
-                        return {ray_origin, ray_dir};
-                    }
+        // bring click_pos to range -1, 1
+        glm::vec2 click_2D(pos);
+        glm::vec2 offset(extent / 2.0f);
+        click_2D -= offset;
+        click_2D /= offset;
+        click_2D.y = -click_2D.y;
 
-                    if constexpr(std::is_same_v<T, vierkant::ortho_camera_params_t>)
-                    {
-                        const glm::vec2 coord(
-                                crocore::map_value<float>(pos.x, 0, extent.x, cam_param.left, cam_param.right),
-                                crocore::map_value<float>(pos.y, extent.y, 0, cam_param.bottom, cam_param.top));
+        // convert fovy to radians
+        const float rad = cam_param.fovx();
+        const float near = cam_param.clipping_distances.x;
+        const float hLength = std::tan(rad / 2) * near;
+        const float vLength = hLength / cam_param.aspect;
 
-                        auto t = camera->global_transform();
-                        glm::mat3 m = glm::mat3_cast(t.rotation);
-                        glm::vec3 click_world_pos =
-                                glm::vec3(t.translation) - m[2] * cam_param.near_ + m[0] * coord.x + m[1] * coord.y;
-                        glm::vec3 ray_dir = -m[2];
-                        spdlog::trace("clicked_world: ({}, {}, {})", click_world_pos.x, click_world_pos.y,
-                                      click_world_pos.z);
-                        return {click_world_pos, ray_dir};
-                    }
-                    return {};
-                },
-                camera_cmp->params);
+        glm::vec3 ray_origin = glm::vec3(t.translation) - m[2] * near + m[0] * hLength * click_2D.x +
+                               m[1] * vLength * click_2D.y;
+        glm::vec3 ray_dir = ray_origin - glm::vec3(t.translation);
+        return {ray_origin, ray_dir};
     }
     return {};
 }

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -628,9 +628,16 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
     frame_context.camera_params.near = camera::near(cull_result.camera.get());
     frame_context.camera_params.far = camera::far(cull_result.camera.get());
 
-    const auto &cam_params = cull_result.camera->get_component_ptr<camera_component_t>()->params;
+    const auto &cam_params = *cull_result.camera->get_component_ptr<camera_component_t>();
 
-    if(std::get_if<physical_camera_params_t>(&cam_params))
+    if(cam_params.projection == vierkant::camera_component_t::ORTHO)
+    {
+        const auto &ortho_params = cam_params.ortho;
+        frame_context.camera_params.ortho = true;
+        frame_context.camera_params.frustum = {ortho_params.left, ortho_params.right, ortho_params.bottom,
+                                               ortho_params.top};
+    }
+    else
     {
         glm::mat4 projectionT = transpose(camera::projection_matrix(cull_result.camera.get()));
         glm::vec4 frustumX = projectionT[3] + projectionT[0];// x + w < 0
@@ -638,12 +645,6 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
         glm::vec4 frustumY = projectionT[3] + projectionT[1];// y + w < 0
         frustumY /= glm::length(frustumY.xyz());
         frame_context.camera_params.frustum = {frustumX.x, frustumX.z, frustumY.y, frustumY.z};
-    }
-    else if(const auto *ortho_params = std::get_if<ortho_camera_params_t>(&cam_params))
-    {
-        frame_context.camera_params.ortho = true;
-        frame_context.camera_params.frustum = {ortho_params->left, ortho_params->right, ortho_params->bottom,
-                                               ortho_params->top};
     }
     camera_params_t cameras[2] = {frame_context.camera_params, last_frame_context.camera_params};
     frame_context.g_buffer_camera_ubo->set_data(&cameras, sizeof(cameras));
@@ -1247,16 +1248,17 @@ vierkant::ImagePtr PBRDeferred::post_fx_pass(const Object3DPtr &cam, const vierk
 
         const auto &cam_cmp = cam->get_component<camera_component_t>();
 
-        if(const auto *cam_params = std::get_if<physical_camera_params_t>(&cam_cmp.params);
-           cam_params && !drawable.descriptors[1].buffers.empty())
+        if(cam_cmp.projection == vierkant::camera_component_t::PERSPECTIVE &&
+           !drawable.descriptors[1].buffers.empty())
         {
+            const auto &cam_params = cam_cmp.physical;
             depth_of_field_params_t dof_params = {};
-            dof_params.focal_distance = cam_params->focal_distance;
-            dof_params.focal_length = cam_params->focal_length;
-            dof_params.sensor_width = cam_params->sensor_width;
-            dof_params.aperture = static_cast<float>(cam_params->aperture_size());
-            dof_params.near = cam_params->clipping_distances.x;
-            dof_params.far = cam_params->clipping_distances.y;
+            dof_params.focal_distance = cam_params.focal_distance;
+            dof_params.focal_length = cam_params.focal_length;
+            dof_params.sensor_width = cam_params.sensor_width;
+            dof_params.aperture = static_cast<float>(cam_params.aperture_size());
+            dof_params.near = cam_params.clipping_distances.x;
+            dof_params.far = cam_params.clipping_distances.y;
             dof_params.debug = frame_context.settings.use_dof_focus_overlay;
             vierkant::staging_copy_info_t staging_copy_info = {};
             staging_copy_info.data = &dof_params;

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -572,17 +572,16 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
 
     // no previous frame yet: reproject through the current matrix, i.e. zero drift everywhere
     camera_params.prev_projection_view = m_prev_projection_view.value_or(camera_params.projection_view);
-    camera_params.ortho = true;
-
     const auto &cam_cmp = cam->get_component<camera_component_t>();
+    camera_params.ortho = cam_cmp.projection == vierkant::camera_component_t::ORTHO;
 
-    if(const auto *perspective_params = std::get_if<physical_camera_params_t>(&cam_cmp.params))
+    if(!camera_params.ortho)
     {
-        camera_params.ortho = false;
-        camera_params.fov = perspective_params->fovy();
+        const auto &perspective_params = cam_cmp.physical;
+        camera_params.fov = perspective_params.fovy();
         camera_params.aperture =
-                frame_context.settings.depth_of_field ? static_cast<float>(perspective_params->aperture_size()) : 0.f;
-        camera_params.focal_distance = perspective_params->focal_distance;
+                frame_context.settings.depth_of_field ? static_cast<float>(perspective_params.aperture_size()) : 0.f;
+        camera_params.focal_distance = perspective_params.focal_distance;
     }
 
     trace_data_t trace_data = {};

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -59,10 +59,10 @@ vierkant::Object3DPtr Scene::create_primitive_object(vierkant::primitive_type ty
 
 vierkant::Object3DPtr Scene::create_object() const { return m_object_store->create_object(); }
 
-vierkant::Object3DPtr Scene::create_camera(const vierkant::camera_params_variant_t &params) const
+vierkant::Object3DPtr Scene::create_camera(const vierkant::camera_component_t &params) const
 {
     auto cam = create_object();
-    cam->add_component<vierkant::camera_component_t>({params});
+    cam->add_component<vierkant::camera_component_t>(params);
     return cam;
 }
 

--- a/src/gpu_culling.cpp
+++ b/src/gpu_culling.cpp
@@ -214,7 +214,7 @@ draw_cull_result_t gpu_cull(const vierkant::gpu_cull_context_ptr &context, const
     draw_cull_data.draw_command_indices_in_post = params.draw_command_indices_in_post->device_address();
     draw_cull_data.draw_result = context->draw_cull_result_buffer->device_address();
 
-    const auto &camera_params = params.camera->get_component<camera_component_t>().params;
+    const auto &camera_params = params.camera->get_component<camera_component_t>();
 
     auto projection = camera::projection_matrix(params.camera.get());
     draw_cull_data.P00 = projection[0][0];
@@ -222,7 +222,13 @@ draw_cull_result_t gpu_cull(const vierkant::gpu_cull_context_ptr &context, const
     draw_cull_data.znear = camera::near(params.camera.get());
     draw_cull_data.zfar = camera::far(params.camera.get());
 
-    if(std::get_if<physical_camera_params_t>(&camera_params))
+    if(camera_params.projection == camera_component_t::ORTHO)
+    {
+        const auto &ortho_params = camera_params.ortho;
+        draw_cull_data.ortho = true;
+        draw_cull_data.frustum = {ortho_params.left, ortho_params.right, ortho_params.bottom, ortho_params.top};
+    }
+    else
     {
         glm::mat4 projectionT = transpose(projection);
         glm::vec4 frustumX = projectionT[3] + projectionT[0];// x + w < 0
@@ -230,11 +236,6 @@ draw_cull_result_t gpu_cull(const vierkant::gpu_cull_context_ptr &context, const
         glm::vec4 frustumY = projectionT[3] + projectionT[1];// y + w < 0
         frustumY /= glm::length(frustumY.xyz());
         draw_cull_data.frustum = {frustumX.x, frustumX.z, frustumY.y, frustumY.z};
-    }
-    else if(const auto *ortho_params = std::get_if<ortho_camera_params_t>(&camera_params))
-    {
-        draw_cull_data.ortho = true;
-        draw_cull_data.frustum = {ortho_params->left, ortho_params->right, ortho_params->bottom, ortho_params->top};
     }
     draw_cull_data.view = vierkant::mat4_cast(camera::view_transform(params.camera.get()));
     draw_cull_data.lod_base = params.lod_base;

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -969,8 +969,10 @@ void draw_scene_ui(const ScenePtr &scene, Object3DPtr &camera, std::set<vierkant
     {
         if(ImGui::Button("add camera"))
         {
-            auto cam = scene->create_camera();
-            scene->add_object(cam);
+            auto new_cam = scene->create_camera();
+            new_cam->name = "camera_" + std::to_string(new_cam->id());
+            new_cam->set_global_transform(camera->global_transform());
+            scene->add_object(new_cam);
         }
 
         // includes the editor-layer, so the viewport-camera is listed alongside the scene-cameras
@@ -2181,6 +2183,15 @@ void draw_transform_guizmo(const std::set<vierkant::Object3DPtr> &object_set, co
 
 void draw_camera_param_ui(vierkant::camera_params_variant_t &camera_params)
 {
+    bool is_ortho = std::holds_alternative<ortho_camera_params_t>(camera_params);
+
+    if(ImGui::RadioButton("perspective", !is_ortho) && is_ortho) { camera_params = physical_camera_params_t(); }
+    ImGui::SameLine();
+    if(ImGui::RadioButton("ortho", is_ortho) && !is_ortho)
+    {
+        camera_params = ortho_camera_params_t();
+    }
+
     if(auto *phys_cam_params = std::get_if<physical_camera_params_t>(&camera_params))
     {
         // focal-length in mm
@@ -2215,6 +2226,23 @@ void draw_camera_param_ui(vierkant::camera_params_variant_t &camera_params)
         ImGui::BulletText("aperture: %.1f mm", phys_cam_params->aperture_size() * 1000);
         ImGui::SliderFloat("f-stop", &phys_cam_params->fstop, f_stop_min, f_stop_max, "%.2f",
                            ImGuiSliderFlags_Logarithmic);
+    }
+    else if(auto *ortho_cam_params = std::get_if<ortho_camera_params_t>(&camera_params))
+    {
+        // frustum extents
+        ImGui::InputFloat("left", &ortho_cam_params->left);
+        ImGui::InputFloat("right", &ortho_cam_params->right);
+        ImGui::InputFloat("bottom", &ortho_cam_params->bottom);
+        ImGui::InputFloat("top", &ortho_cam_params->top);
+
+        ImGui::BulletText("width: %.2f", ortho_cam_params->right - ortho_cam_params->left);
+        ImGui::BulletText("height: %.2f", ortho_cam_params->top - ortho_cam_params->bottom);
+
+        ImGui::Separator();
+
+        // clipping planes
+        ImGui::InputFloat("near", &ortho_cam_params->near_);
+        ImGui::InputFloat("far", &ortho_cam_params->far_);
     }
 }
 

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -988,7 +988,7 @@ void draw_scene_ui(const ScenePtr &scene, Object3DPtr &camera, std::set<vierkant
 
             if(ImGui::TreeNode((void *) (uint64_t) obj.id(), "%s", obj.name.c_str()))
             {
-                vierkant::gui::draw_camera_param_ui(obj.get_component<camera_component_t>().params);
+                vierkant::gui::draw_camera_param_ui(obj.get_component<camera_component_t>());
                 ImGui::Spacing();
                 ImGui::Separator();
                 ImGui::TreePop();
@@ -2113,27 +2113,27 @@ bool draw_transform_guizmo(vierkant::transform_t &transform, const vierkant::Obj
         auto *cam_cmp = camera->get_component_ptr<vierkant::camera_component_t>();
         assert(cam_cmp);
 
-        auto *ortho_params = std::get_if<ortho_camera_params_t>(&cam_cmp->params);
-        auto *perspective_params = std::get_if<physical_camera_params_t>(&cam_cmp->params);
-
-        ImGuizmo::SetOrthographic(ortho_params);
+        const bool is_ortho = cam_cmp->projection == vierkant::camera_component_t::ORTHO;
+        ImGuizmo::SetOrthographic(is_ortho);
 
         const ImGuizmo::MODE mode = space == GuizmoSpace::WORLD ? ImGuizmo::WORLD : ImGuizmo::LOCAL;
         auto sz = ImGui::GetIO().DisplaySize;
         auto view = vierkant::mat4_cast(camera::view_transform(camera.get()));
 
-        if(ortho_params)
+        if(is_ortho)
         {
-            auto proj = glm::orthoRH(ortho_params->left, ortho_params->right, ortho_params->bottom, ortho_params->top,
-                                     ortho_params->near_, ortho_params->far_);
+            const auto &ortho_params = cam_cmp->ortho;
+            auto proj = glm::orthoRH(ortho_params.left, ortho_params.right, ortho_params.bottom, ortho_params.top,
+                                     ortho_params.near_, ortho_params.far_);
             changed = ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj),
                                            ImGuizmo::OPERATION(current_gizmo), mode, glm::value_ptr(m));
         }
-        else if(perspective_params)
+        else
         {
-            auto proj = glm::perspectiveRH(perspective_params->fovy(), sz.x / sz.y,
-                                           perspective_params->clipping_distances.x,
-                                           perspective_params->clipping_distances.y);
+            const auto &perspective_params = cam_cmp->physical;
+            auto proj = glm::perspectiveRH(perspective_params.fovy(), sz.x / sz.y,
+                                           perspective_params.clipping_distances.x,
+                                           perspective_params.clipping_distances.y);
             changed = ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj),
                                            ImGuizmo::OPERATION(current_gizmo), mode, glm::value_ptr(m));
         }
@@ -2181,19 +2181,20 @@ void draw_transform_guizmo(const std::set<vierkant::Object3DPtr> &object_set, co
     else if(!object_set.empty()) { draw_transform_guizmo(*object_set.begin(), camera, type, space); }
 }
 
-void draw_camera_param_ui(vierkant::camera_params_variant_t &camera_params)
+void draw_camera_param_ui(vierkant::camera_component_t &camera_params)
 {
-    bool is_ortho = std::holds_alternative<ortho_camera_params_t>(camera_params);
+    const bool is_ortho = camera_params.projection == vierkant::camera_component_t::ORTHO;
 
-    if(ImGui::RadioButton("perspective", !is_ortho) && is_ortho) { camera_params = physical_camera_params_t(); }
-    ImGui::SameLine();
-    if(ImGui::RadioButton("ortho", is_ortho) && !is_ortho)
+    if(ImGui::RadioButton("perspective", !is_ortho))
     {
-        camera_params = ortho_camera_params_t();
+        camera_params.projection = vierkant::camera_component_t::PERSPECTIVE;
     }
+    ImGui::SameLine();
+    if(ImGui::RadioButton("ortho", is_ortho)) { camera_params.projection = vierkant::camera_component_t::ORTHO; }
 
-    if(auto *phys_cam_params = std::get_if<physical_camera_params_t>(&camera_params))
+    if(!is_ortho)
     {
+        auto *phys_cam_params = &camera_params.physical;
         // focal-length in mm
         float focal_length_mm = 1000.f * phys_cam_params->focal_length;
         if(ImGui::SliderFloat("focal-length (mm)", &focal_length_mm, 0.1f, 500.f))
@@ -2227,8 +2228,10 @@ void draw_camera_param_ui(vierkant::camera_params_variant_t &camera_params)
         ImGui::SliderFloat("f-stop", &phys_cam_params->fstop, f_stop_min, f_stop_max, "%.2f",
                            ImGuiSliderFlags_Logarithmic);
     }
-    else if(auto *ortho_cam_params = std::get_if<ortho_camera_params_t>(&camera_params))
+    else
     {
+        auto *ortho_cam_params = &camera_params.ortho;
+
         // frustum extents
         ImGui::InputFloat("left", &ortho_cam_params->left);
         ImGui::InputFloat("right", &ortho_cam_params->right);

--- a/tests/TestAssetProvider.cpp
+++ b/tests/TestAssetProvider.cpp
@@ -95,7 +95,7 @@ TEST(TestAssetProvider, populate_sampler_override)
 
     auto scene = vierkant::Scene::create({}, provider);
     auto cam = scene->create_object();
-    cam->add_component<vierkant::camera_component_t>({vierkant::physical_camera_params_t{}});
+    cam->add_component<vierkant::camera_component_t>();
     auto mesh_node = scene->create_mesh_object({result.mesh});
     scene->add_object(mesh_node);
 

--- a/tests/TestPBRDeferred.cpp
+++ b/tests/TestPBRDeferred.cpp
@@ -41,7 +41,7 @@ TEST(TestPBRDeferred, basic)
     auto scene = vierkant::Scene::create();
 
     auto cam = scene->create_object();
-    cam->add_component<vierkant::camera_component_t>({vierkant::physical_camera_params_t{}});
+    cam->add_component<vierkant::camera_component_t>();
     EXPECT_TRUE(cam);
 
     auto mesh_node = scene->create_mesh_object({mesh});


### PR DESCRIPTION
- camera_component_t carries projection + both physical/ortho params
- toggling perspective/ortho keeps both parameter-sets
- ortho framing derives from the camera's fovx, not a hardcoded constant
- drop camera_params_variant_t
- ortho params editable in the imgui camera-ui