### PR TITLE
remove descriptor-buffer path, add device-wide sampler-cache

### DIFF
--- a/include/vierkant/Device.hpp
+++ b/include/vierkant/Device.hpp
@@ -18,6 +18,46 @@ DEFINE_CLASS_PTR(Device)
 //! define a shared handle for a VkQueryPool
 using QueryPoolPtr = std::shared_ptr<VkQueryPool_T>;
 
+//! define a shared handle for a VkSampler
+using VkSamplerPtr = std::shared_ptr<VkSampler_T>;
+
+/**
+ * @brief   sampler_state_t describes the sampling-state a VkSampler is created from.
+ *          it is default-constructable, comparable and hashable, used as key by vierkant::Device::sampler.
+ *
+ *          note: the mip-range is deliberately not part of the state. a sampler's maxLod is set to
+ *          VK_LOD_CLAMP_NONE, because the sampled mip-level is already clamped to the image-view's
+ *          level-range. keeping a per-image maxLod would only fragment the cache.
+ */
+struct sampler_state_t
+{
+    VkFilter min_filter = VK_FILTER_LINEAR;
+    VkFilter mag_filter = VK_FILTER_LINEAR;
+    VkSamplerAddressMode address_mode_u = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    VkSamplerAddressMode address_mode_v = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    VkSamplerAddressMode address_mode_w = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
+    VkSamplerMipmapMode mipmap_mode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
+    VkSamplerReductionMode reduction_mode = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;
+    float max_anisotropy = 0.f;
+    bool normalized_coords = true;
+
+    bool operator==(const sampler_state_t &other) const = default;
+};
+
+}// namespace vierkant
+
+namespace std
+{
+template<>
+struct hash<vierkant::sampler_state_t>
+{
+    size_t operator()(const vierkant::sampler_state_t &state) const;
+};
+}// namespace std
+
+namespace vierkant
+{
+
 QueryPoolPtr create_query_pool(const vierkant::DevicePtr &device, uint32_t query_count, VkQueryType query_type);
 
 /**
@@ -64,7 +104,6 @@ public:
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_pipeline;
         VkPhysicalDeviceOpacityMicromapPropertiesEXT micromap_opacity;
         VkPhysicalDeviceMeshShaderPropertiesEXT mesh_shader;
-        VkPhysicalDeviceDescriptorBufferPropertiesEXT descriptor_buffer;
     };
 
     struct create_info_t
@@ -175,6 +214,15 @@ public:
      */
     void set_object_name(uint64_t handle, VkObjectType type, const std::string &name) const;
 
+    /**
+     * @brief   sampler returns a shared VkSampler for a provided sampler-state.
+     *          samplers are cached and shared device-wide, distinct sampler-states are rare.
+     *
+     * @param   state   a provided sampler_state_t
+     * @return  a retrieved or newly created, shared VkSampler
+     */
+    VkSamplerPtr sampler(const sampler_state_t &state);
+
 private:
     explicit Device(const create_info_t &create_info);
 
@@ -204,6 +252,10 @@ private:
 
     // transient command pool (transfer queue)
     VkCommandPool m_command_pool_transfer = VK_NULL_HANDLE;
+
+    // device-wide cache of shared samplers (assets can be loaded from worker-threads)
+    std::unordered_map<sampler_state_t, VkSamplerPtr> m_samplers;
+    std::mutex m_sampler_mutex;
 };
 
 }// namespace vierkant

--- a/include/vierkant/Image.hpp
+++ b/include/vierkant/Image.hpp
@@ -14,7 +14,6 @@ DEFINE_CLASS_PTR(Image)
 using VkImagePtr = std::shared_ptr<VkImage_T>;
 using VkImageViewPtr = std::shared_ptr<VkImageView_T>;
 using VkImageLayoutPtr = std::shared_ptr<VkImageLayout>;
-using VkSamplerPtr = std::shared_ptr<VkSampler_T>;
 
 VkDeviceSize num_bytes(VkFormat format);
 

--- a/include/vierkant/Image.hpp
+++ b/include/vierkant/Image.hpp
@@ -38,22 +38,15 @@ public:
         VkSharingMode sharing_mode = VK_SHARING_MODE_EXCLUSIVE;
         VkImageViewType view_type = VK_IMAGE_VIEW_TYPE_2D;
         VkImageUsageFlags usage = VK_IMAGE_USAGE_SAMPLED_BIT;
-        VkSamplerAddressMode address_mode_u = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-        VkSamplerAddressMode address_mode_v = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-        VkSamplerAddressMode address_mode_w = VK_SAMPLER_ADDRESS_MODE_CLAMP_TO_EDGE;
-        VkFilter min_filter = VK_FILTER_LINEAR;
-        VkFilter mag_filter = VK_FILTER_LINEAR;
 
-        VkSamplerReductionMode reduction_mode = VK_SAMPLER_REDUCTION_MODE_WEIGHTED_AVERAGE;
+        //! sampling-state, only used for images created with VK_IMAGE_USAGE_SAMPLED_BIT
+        vierkant::sampler_state_t sampler_state = {};
 
         VkComponentMapping component_swizzle = {VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY,
                                                 VK_COMPONENT_SWIZZLE_IDENTITY, VK_COMPONENT_SWIZZLE_IDENTITY};
-        float max_anisotropy = 0.f;
         bool initial_layout_transition = true;
         bool use_mipmap = false;
         bool autogenerate_mipmaps = true;
-        VkSamplerMipmapMode mipmap_mode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-        bool normalized_coords = true;
         VkSampleCountFlagBits sample_count = VK_SAMPLE_COUNT_1_BIT;
         uint32_t num_layers = 1;
         VmaMemoryUsage memory_usage = VMA_MEMORY_USAGE_GPU_ONLY;

--- a/include/vierkant/descriptor.hpp
+++ b/include/vierkant/descriptor.hpp
@@ -87,12 +87,10 @@ DescriptorPoolPtr create_descriptor_pool(const vierkant::DevicePtr &device, cons
  *
  * @param   device                  handle for the vierkant::Device to create the DescriptorSetLayout
  * @param   descriptors             an array of descriptor_t to create a layout from
- * @param   use_descriptor_buffer   flag indicating if the layout is intended for use with descriptor-buffers
  * @return  the newly created DescriptorSetLayoutPtr
  */
 DescriptorSetLayoutPtr create_descriptor_set_layout(const vierkant::DevicePtr &device,
-                                                    const descriptor_map_t &descriptors,
-                                                    bool use_descriptor_buffer = false);
+                                                    const descriptor_map_t &descriptors);
 
 /**
  * @brief   Create a shared VkDescriptorSet (DescriptorSetPtr) for a provided set-layout.
@@ -114,17 +112,6 @@ DescriptorSetPtr create_descriptor_set(const vierkant::DevicePtr &device, const 
  */
 void update_descriptor_set(const vierkant::DevicePtr &device, const descriptor_map_t &descriptors,
                            const DescriptorSetPtr &descriptor_set);
-
-/**
- * @brief   Update an existing shared vierkant::Buffer, used as descriptor-buffer,
- *          with a provided array of vierkant::descriptor_t.
- *
- * @param   device          handle for the vierkant::Device to update the DescriptorSet
- * @param   descriptors     an array of descriptor_t to use for updating the descriptor-buffer
- * @param   descriptor_set  handle for a shared VkDescriptorSet to update
- */
-void update_descriptor_buffer(const vierkant::DevicePtr &device, const DescriptorSetLayoutPtr &layout,
-                              const descriptor_map_t &descriptors, const vierkant::BufferPtr &out_descriptor_buffer);
 
 /**
  * @brief   find_or_create_set_layout can be used to search for an existing descriptor-set-layout or create a new one.

--- a/include/vierkant/model/model_loading.hpp
+++ b/include/vierkant/model/model_loading.hpp
@@ -250,14 +250,12 @@ vierkant::ImagePtr create_compressed_texture(const vierkant::DevicePtr &device,
                                              vierkant::Image::Format format, VkQueue load_queue);
 
 /**
- * @brief   create_sampler creates a VkSampler from a texture_sampler_t descriptor.
+ * @brief   create_sampler retrieves a shared VkSampler for a texture_sampler_t descriptor.
  *
  * @param   device      handle to a vierkant::Device
  * @param   ts          a texture_sampler_t descriptor
- * @param   num_mips    number of mip-levels the sampler should address
- * @return  a newly created, ref-counted VkSampler
+ * @return  a retrieved or newly created, ref-counted VkSampler
  */
-vierkant::VkSamplerPtr create_sampler(const vierkant::DevicePtr &device, const vierkant::texture_sampler_t &ts,
-                                      uint32_t num_mips);
+vierkant::VkSamplerPtr create_sampler(const vierkant::DevicePtr &device, const vierkant::texture_sampler_t &ts);
 
 }// namespace vierkant::model

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -2,6 +2,7 @@
 #include <set>
 #include <vierkant/Device.hpp>
 #include <vierkant/git_hash.h>
+#include <vierkant/hash.hpp>
 
 #define VMA_IMPLEMENTATION
 #include <vk_mem_alloc.h>
@@ -171,13 +172,11 @@ Device::Device(const create_info_t &create_info) : m_physical_device(create_info
         m_properties.ray_pipeline.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
         m_properties.mesh_shader.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT;
         m_properties.micromap_opacity.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT;
-        m_properties.descriptor_buffer.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT;
         physical_device_properties.pNext = &m_properties.vulkan13;
         m_properties.vulkan13.pNext = &m_properties.acceleration_structure;
         m_properties.acceleration_structure.pNext = &m_properties.ray_pipeline;
         m_properties.ray_pipeline.pNext = &m_properties.mesh_shader;
         m_properties.mesh_shader.pNext = &m_properties.micromap_opacity;
-        m_properties.micromap_opacity.pNext = &m_properties.descriptor_buffer;
         vkGetPhysicalDeviceProperties2(create_info.physical_device, &physical_device_properties);
         m_properties.core = physical_device_properties.properties;
     }
@@ -314,11 +313,6 @@ Device::Device(const create_info_t &create_info) : m_physical_device(create_info
     mesh_shader_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_FEATURES_EXT;
     update_pnext(mesh_shader_features, VK_EXT_MESH_SHADER_EXTENSION_NAME);
 
-    //------------------------------------ VK_EXT_descriptor_buffer ----------------------------------------------------
-    VkPhysicalDeviceDescriptorBufferFeaturesEXT descriptor_buffer_features = {};
-    descriptor_buffer_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_FEATURES_EXT;
-    update_pnext(descriptor_buffer_features, VK_EXT_DESCRIPTOR_BUFFER_EXTENSION_NAME);
-
     //------------------------------------ VK_KHR_fragment_shader_barycentric ------------------------------------------
     VkPhysicalDeviceFragmentShaderBarycentricFeaturesKHR barycentric_features = {};
     barycentric_features.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_FRAGMENT_SHADER_BARYCENTRIC_FEATURES_KHR;
@@ -437,6 +431,10 @@ Device::Device(const create_info_t &create_info) : m_physical_device(create_info
 
 Device::~Device()
 {
+    // cached samplers are shared with images, which keep this device alive -> safe to drop here,
+    // and it needs to happen before vkDestroyDevice, unlike member-destruction order.
+    m_samplers.clear();
+
     if(m_command_pool_transfer)
     {
         vkDestroyCommandPool(m_device, m_command_pool_transfer, nullptr);
@@ -507,4 +505,69 @@ void Device::set_object_name(uint64_t handle, VkObjectType type, const std::stri
 
 void Device::wait_idle() const { vkDeviceWaitIdle(m_device); }
 
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+VkSamplerPtr Device::sampler(const sampler_state_t &state)
+{
+    std::unique_lock lock(m_sampler_mutex);
+    auto it = m_samplers.find(state);
+    if(it != m_samplers.end()) { return it->second; }
+
+    VkSamplerReductionModeCreateInfo reduction_mode_info = {};
+    reduction_mode_info.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
+    reduction_mode_info.reductionMode = state.reduction_mode;
+
+    VkSamplerCreateInfo sampler_create_info = {};
+    sampler_create_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
+    sampler_create_info.pNext = &reduction_mode_info;
+    sampler_create_info.magFilter = state.mag_filter;
+    sampler_create_info.minFilter = state.min_filter;
+    sampler_create_info.addressModeU = state.address_mode_u;
+    sampler_create_info.addressModeV = state.address_mode_v;
+    sampler_create_info.addressModeW = state.address_mode_w;
+    sampler_create_info.anisotropyEnable = static_cast<VkBool32>(state.max_anisotropy > 0.f);
+    sampler_create_info.maxAnisotropy = state.max_anisotropy;
+    sampler_create_info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+    sampler_create_info.unnormalizedCoordinates = static_cast<VkBool32>(!state.normalized_coords);
+    sampler_create_info.compareEnable = VK_FALSE;
+    sampler_create_info.compareOp = VK_COMPARE_OP_ALWAYS;
+    sampler_create_info.mipmapMode = state.mipmap_mode;
+    sampler_create_info.mipLodBias = 0.0f;
+    sampler_create_info.minLod = 0.0f;
+
+    // the sampled mip-level is already clamped to the image-view's level-range, so an unclamped maxLod
+    // is equivalent to a per-image one and keeps the cache from fragmenting.
+    // unnormalized coordinates require minLod == maxLod == 0 though.
+    sampler_create_info.maxLod = state.normalized_coords ? VK_LOD_CLAMP_NONE : 0.f;
+
+    VkSampler sampler_handle;
+    vkCheck(vkCreateSampler(m_device, &sampler_create_info, nullptr, &sampler_handle),
+            "failed to create texture sampler!");
+
+    // capturing the raw handle is fine: users of a sampler hold a DevicePtr, and ~Device drops the cache
+    // before vkDestroyDevice.
+    auto ret = VkSamplerPtr(sampler_handle,
+                            [device = m_device](VkSampler s) { vkDestroySampler(device, s, nullptr); });
+    m_samplers[state] = ret;
+    spdlog::trace("created sampler - distinct sampler-states: {}", m_samplers.size());
+    return ret;
+}
+
 }// namespace vierkant
+
+////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
+
+size_t std::hash<vierkant::sampler_state_t>::operator()(const vierkant::sampler_state_t &state) const
+{
+    size_t h = 0;
+    vierkant::hash_combine(h, state.min_filter);
+    vierkant::hash_combine(h, state.mag_filter);
+    vierkant::hash_combine(h, state.address_mode_u);
+    vierkant::hash_combine(h, state.address_mode_v);
+    vierkant::hash_combine(h, state.address_mode_w);
+    vierkant::hash_combine(h, state.mipmap_mode);
+    vierkant::hash_combine(h, state.reduction_mode);
+    vierkant::hash_combine(h, state.max_anisotropy);
+    vierkant::hash_combine(h, state.normalized_coords);
+    return h;
+}

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -353,40 +353,20 @@ Image::Image(DevicePtr device, const void *data, const VkImagePtr &shared_image,
 
     if(img_usage & VK_IMAGE_USAGE_SAMPLED_BIT)
     {
-        VkSamplerCreateInfo sampler_create_info = {};
-        sampler_create_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-        sampler_create_info.magFilter = m_format.mag_filter;
-        sampler_create_info.minFilter = m_format.min_filter;
-        sampler_create_info.addressModeU = m_format.address_mode_u;
-        sampler_create_info.addressModeV = m_format.address_mode_v;
-        sampler_create_info.addressModeW = m_format.address_mode_w;
-
-        sampler_create_info.anisotropyEnable = static_cast<VkBool32>(m_format.max_anisotropy > 0.f);
-        sampler_create_info.maxAnisotropy = m_format.max_anisotropy;
-
-        sampler_create_info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
+        vierkant::sampler_state_t sampler_state = {};
+        sampler_state.min_filter = m_format.min_filter;
+        sampler_state.mag_filter = m_format.mag_filter;
+        sampler_state.address_mode_u = m_format.address_mode_u;
+        sampler_state.address_mode_v = m_format.address_mode_v;
+        sampler_state.address_mode_w = m_format.address_mode_w;
+        sampler_state.mipmap_mode = m_format.mipmap_mode;
+        sampler_state.reduction_mode = m_format.reduction_mode;
+        sampler_state.max_anisotropy = m_format.max_anisotropy;
 
         // [0 ... tex_width] vs. [0 ... 1]
-        sampler_create_info.unnormalizedCoordinates = static_cast<VkBool32>(!m_format.normalized_coords);
+        sampler_state.normalized_coords = m_format.normalized_coords;
 
-        sampler_create_info.compareEnable = VK_FALSE;
-        sampler_create_info.compareOp = VK_COMPARE_OP_ALWAYS;
-
-        sampler_create_info.mipmapMode = m_format.mipmap_mode;
-        sampler_create_info.mipLodBias = 0.0f;
-        sampler_create_info.minLod = 0.0f;
-        sampler_create_info.maxLod = static_cast<float>(m_num_mip_levels);
-
-        VkSamplerReductionModeCreateInfo reduction_mode_info = {};
-        reduction_mode_info.sType = VK_STRUCTURE_TYPE_SAMPLER_REDUCTION_MODE_CREATE_INFO;
-        reduction_mode_info.reductionMode = m_format.reduction_mode;
-        sampler_create_info.pNext = &reduction_mode_info;
-
-        VkSampler sampler;
-        vkCheck(vkCreateSampler(m_device->handle(), &sampler_create_info, nullptr, &sampler),
-                "failed to create texture sampler!");
-        m_sampler = VkSamplerPtr(sampler,
-                                 [device = m_device](VkSampler s) { vkDestroySampler(device->handle(), s, nullptr); });
+        m_sampler = m_device->sampler(sampler_state);
     }
 
     ////////////////////////////////////////// layout transitions //////////////////////////////////////////////////////

--- a/src/Image.cpp
+++ b/src/Image.cpp
@@ -351,23 +351,7 @@ Image::Image(DevicePtr device, const void *data, const VkImagePtr &shared_image,
     }
     ////////////////////////////////////////// create image sampler ////////////////////////////////////////////////////
 
-    if(img_usage & VK_IMAGE_USAGE_SAMPLED_BIT)
-    {
-        vierkant::sampler_state_t sampler_state = {};
-        sampler_state.min_filter = m_format.min_filter;
-        sampler_state.mag_filter = m_format.mag_filter;
-        sampler_state.address_mode_u = m_format.address_mode_u;
-        sampler_state.address_mode_v = m_format.address_mode_v;
-        sampler_state.address_mode_w = m_format.address_mode_w;
-        sampler_state.mipmap_mode = m_format.mipmap_mode;
-        sampler_state.reduction_mode = m_format.reduction_mode;
-        sampler_state.max_anisotropy = m_format.max_anisotropy;
-
-        // [0 ... tex_width] vs. [0 ... 1]
-        sampler_state.normalized_coords = m_format.normalized_coords;
-
-        m_sampler = m_device->sampler(sampler_state);
-    }
+    if(img_usage & VK_IMAGE_USAGE_SAMPLED_BIT) { m_sampler = m_device->sampler(m_format.sampler_state); }
 
     ////////////////////////////////////////// layout transitions //////////////////////////////////////////////////////
 
@@ -765,19 +749,11 @@ bool Image::Format::operator==(const Image::Format &other) const
     if(sharing_mode != other.sharing_mode) { return false; }
     if(view_type != other.view_type) { return false; }
     if(usage != other.usage) { return false; }
-    if(address_mode_u != other.address_mode_u) { return false; }
-    if(address_mode_v != other.address_mode_v) { return false; }
-    if(address_mode_w != other.address_mode_w) { return false; }
-    if(min_filter != other.min_filter) { return false; }
-    if(mag_filter != other.mag_filter) { return false; }
-    if(reduction_mode != other.reduction_mode) { return false; }
+    if(sampler_state != other.sampler_state) { return false; }
     if(memcmp(&component_swizzle, &other.component_swizzle, sizeof(VkComponentMapping)) != 0) { return false; }
-    if(max_anisotropy != other.max_anisotropy) { return false; }
     if(initial_layout_transition != other.initial_layout_transition) { return false; }
     if(use_mipmap != other.use_mipmap) { return false; }
     if(autogenerate_mipmaps != other.autogenerate_mipmaps) { return false; }
-    if(mipmap_mode != other.mipmap_mode) { return false; }
-    if(normalized_coords != other.normalized_coords) { return false; }
     if(sample_count != other.sample_count) { return false; }
     if(num_layers != other.num_layers) { return false; }
     if(memory_usage != other.memory_usage) { return false; }
@@ -805,22 +781,14 @@ size_t std::hash<vierkant::Image::Format>::operator()(vierkant::Image::Format co
     hash_combine(h, fmt.sharing_mode);
     hash_combine(h, fmt.view_type);
     hash_combine(h, fmt.usage);
-    hash_combine(h, fmt.address_mode_u);
-    hash_combine(h, fmt.address_mode_v);
-    hash_combine(h, fmt.address_mode_w);
-    hash_combine(h, fmt.min_filter);
-    hash_combine(h, fmt.mag_filter);
-    hash_combine(h, fmt.reduction_mode);
+    hash_combine(h, fmt.sampler_state);
     hash_combine(h, fmt.component_swizzle.r);
     hash_combine(h, fmt.component_swizzle.g);
     hash_combine(h, fmt.component_swizzle.b);
     hash_combine(h, fmt.component_swizzle.a);
-    hash_combine(h, fmt.max_anisotropy);
     hash_combine(h, fmt.initial_layout_transition);
     hash_combine(h, fmt.use_mipmap);
     hash_combine(h, fmt.autogenerate_mipmaps);
-    hash_combine(h, fmt.mipmap_mode);
-    hash_combine(h, fmt.normalized_coords);
     hash_combine(h, fmt.sample_count);
     hash_combine(h, fmt.num_layers);
     hash_combine(h, fmt.memory_usage);

--- a/src/descriptor.cpp
+++ b/src/descriptor.cpp
@@ -42,7 +42,7 @@ DescriptorPoolPtr create_descriptor_pool(const vierkant::DevicePtr &device, cons
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 DescriptorSetLayoutPtr create_descriptor_set_layout(const vierkant::DevicePtr &device,
-                                                    const descriptor_map_t &descriptors, bool use_descriptor_buffer)
+                                                    const descriptor_map_t &descriptors)
 {
     constexpr VkDescriptorBindingFlags default_flags =
             VK_DESCRIPTOR_BINDING_UPDATE_UNUSED_WHILE_PENDING_BIT | VK_DESCRIPTOR_BINDING_UPDATE_AFTER_BIND_BIT;
@@ -81,8 +81,6 @@ DescriptorSetLayoutPtr create_descriptor_set_layout(const vierkant::DevicePtr &d
     layout_info.bindingCount = static_cast<uint32_t>(bindings.size());
     layout_info.pBindings = bindings.data();
     layout_info.flags = VK_DESCRIPTOR_SET_LAYOUT_CREATE_UPDATE_AFTER_BIND_POOL_BIT;
-
-    if(use_descriptor_buffer) { layout_info.flags |= VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT; }
 
     VkDescriptorSetLayout descriptor_set_layout = VK_NULL_HANDLE;
     vkCheck(vkCreateDescriptorSetLayout(device->handle(), &layout_info, nullptr, &descriptor_set_layout),
@@ -307,172 +305,6 @@ DescriptorSetLayoutPtr find_or_create_set_layout(const vierkant::DevicePtr &devi
         set_it = next.insert(std::make_pair(std::move(descriptors), std::move(new_set))).first;
     }
     return set_it->second;
-}
-
-////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
-
-struct descriptor_size_fn_t
-{
-    explicit descriptor_size_fn_t(VkPhysicalDevice physical_device)
-    {
-        properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_DESCRIPTOR_BUFFER_PROPERTIES_EXT;
-        VkPhysicalDeviceProperties2 device_properties = {};
-        device_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
-        device_properties.pNext = &properties;
-        vkGetPhysicalDeviceProperties2(physical_device, &device_properties);
-    }
-
-    inline size_t operator()(VkDescriptorType t) const
-    {
-        switch(t)
-        {
-            case VK_DESCRIPTOR_TYPE_SAMPLER: return properties.samplerDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER: return properties.combinedImageSamplerDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE: return properties.sampledImageDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE: return properties.storageImageDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_UNIFORM_TEXEL_BUFFER: return properties.uniformTexelBufferDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_STORAGE_TEXEL_BUFFER: return properties.storageTexelBufferDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER: return properties.uniformBufferDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER: return properties.storageBufferDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_INPUT_ATTACHMENT: return properties.inputAttachmentDescriptorSize;
-            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR: return properties.accelerationStructureDescriptorSize;
-
-            default: throw std::runtime_error("descriptor-type not support in descriptor-buffer");
-        }
-    }
-    VkPhysicalDeviceDescriptorBufferPropertiesEXT properties = {};
-};
-
-void update_descriptor_buffer(const vierkant::DevicePtr &device, const DescriptorSetLayoutPtr &layout,
-                              const descriptor_map_t &descriptors,
-                              const vierkant::BufferPtr & /*out_descriptor_buffer*/)
-{
-    assert(vkGetDescriptorSetLayoutSizeEXT && vkGetDescriptorSetLayoutBindingOffsetEXT && vkGetDescriptorEXT &&
-           vkGetAccelerationStructureDeviceAddressKHR);
-
-    auto descriptor_size_fn = descriptor_size_fn_t(device->physical_device());
-
-    // query buffer-size for provided layout
-    VkDeviceSize size;
-    vkGetDescriptorSetLayoutSizeEXT(device->handle(), layout.get(), &size);
-
-    std::vector<uint8_t> out_data(size);
-
-    for(const auto &[binding, descriptor]: descriptors)
-    {
-        VkDeviceSize offset;
-        vkGetDescriptorSetLayoutBindingOffsetEXT(device->handle(), layout.get(), binding, &offset);
-        uint8_t *data_ptr = out_data.data() + offset;
-
-        auto desc_stride = descriptor_size_fn(descriptor.type);
-
-        VkDescriptorGetInfoEXT descriptor_get_info = {};
-        descriptor_get_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_GET_INFO_EXT;
-        descriptor_get_info.type = descriptor.type;
-
-        switch(descriptor.type)
-        {
-            case VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER:
-            case VK_DESCRIPTOR_TYPE_STORAGE_BUFFER:
-            {
-                for(uint32_t i = 0; i < descriptor.buffers.size(); ++i)
-                {
-                    const auto &buf = descriptor.buffers[i];
-
-                    if(buf)
-                    {
-                        descriptor_t::buffer_range_t buf_range = {};
-                        if(descriptor.buffer_ranges.size() > i) { buf_range = descriptor.buffer_ranges[i]; }
-
-                        VkDescriptorAddressInfoEXT address_info = {};
-                        address_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_ADDRESS_INFO_EXT;
-                        address_info.format = VK_FORMAT_UNDEFINED;
-                        address_info.address = buf->device_address() + buf_range.offset;
-                        address_info.range = buf_range.range ? buf_range.range : buf->num_bytes() - buf_range.offset;
-
-                        if(descriptor_get_info.type == VK_DESCRIPTOR_TYPE_STORAGE_BUFFER)
-                        {
-                            descriptor_get_info.data.pStorageBuffer = &address_info;
-                        }
-                        else
-                        {
-                            descriptor_get_info.data.pUniformBuffer = &address_info;
-                        }
-
-                        vkGetDescriptorEXT(device->handle(), &descriptor_get_info, desc_stride,
-                                           data_ptr + i * desc_stride);
-                    }
-                }
-            }
-            break;
-
-            case VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE:
-            case VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER:
-            case VK_DESCRIPTOR_TYPE_STORAGE_IMAGE:
-            {
-                for(uint32_t i = 0; i < descriptor.images.size(); ++i)
-                {
-                    const auto &img = descriptor.images[i];
-
-                    if(img)
-                    {
-                        const auto &image_view =
-                                i < descriptor.image_views.size() ? descriptor.image_views[i] : img->image_view();
-
-                        VkDescriptorImageInfo image_info;
-                        image_info.sampler = img->sampler().get();
-                        image_info.imageView = image_view;
-                        image_info.imageLayout = img->image_layout();
-
-                        if(descriptor.type == VK_DESCRIPTOR_TYPE_SAMPLED_IMAGE)
-                        {
-                            descriptor_get_info.data.pSampledImage = &image_info;
-                        }
-                        else if(descriptor.type == VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER)
-                        {
-                            descriptor_get_info.data.pCombinedImageSampler = &image_info;
-                        }
-                        else
-                        {
-                            descriptor_get_info.data.pStorageImage = &image_info;
-                        }
-
-                        vkGetDescriptorEXT(device->handle(), &descriptor_get_info, desc_stride,
-                                           data_ptr + i * desc_stride);
-                    }
-                }
-            }
-            break;
-
-            case VK_DESCRIPTOR_TYPE_ACCELERATION_STRUCTURE_KHR:
-            {
-                for(uint32_t i = 0; i < descriptor.acceleration_structures.size(); ++i)
-                {
-                    const auto &acceleration_structure = descriptor.acceleration_structures[i];
-
-                    // get device address
-                    VkAccelerationStructureDeviceAddressInfoKHR address_info = {};
-                    address_info.sType = VK_STRUCTURE_TYPE_ACCELERATION_STRUCTURE_DEVICE_ADDRESS_INFO_KHR;
-                    address_info.accelerationStructure = acceleration_structure.get();
-
-                    descriptor_get_info.data.accelerationStructure =
-                            vkGetAccelerationStructureDeviceAddressKHR(device->handle(), &address_info);
-                    vkGetDescriptorEXT(device->handle(), &descriptor_get_info, desc_stride, data_ptr + i * desc_stride);
-                }
-                break;
-            }
-
-            default:
-                throw std::runtime_error("update_descriptor_buffer: unsupported descriptor-type -> " +
-                                         std::to_string(descriptor.type));
-        }
-    }
-    // set-layout needs alternative flag:
-    // VK_DESCRIPTOR_SET_LAYOUT_CREATE_DESCRIPTOR_BUFFER_BIT_EXT
-
-    // buffers additional flags:
-    // VK_BUFFER_USAGE_SAMPLER_DESCRIPTOR_BUFFER_BIT_EXT
-    // VK_BUFFER_USAGE_RESOURCE_DESCRIPTOR_BUFFER_BIT_EXT
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////

--- a/src/gpu_culling.cpp
+++ b/src/gpu_culling.cpp
@@ -92,7 +92,7 @@ vierkant::ImagePtr create_depth_pyramid(const vierkant::gpu_cull_context_ptr &co
         depth_pyramid_fmt.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
         depth_pyramid_fmt.use_mipmap = true;
         depth_pyramid_fmt.autogenerate_mipmaps = false;
-        depth_pyramid_fmt.reduction_mode = VK_SAMPLER_REDUCTION_MODE_MIN;
+        depth_pyramid_fmt.sampler_state.reduction_mode = VK_SAMPLER_REDUCTION_MODE_MIN;
         depth_pyramid_fmt.initial_layout = VK_IMAGE_LAYOUT_GENERAL;
         depth_pyramid_fmt.initial_cmd_buffer = context->depth_pyramid_cmd_buffer.handle();
         context->depth_pyramid_img = vierkant::Image::create(context->device, depth_pyramid_fmt);
@@ -372,7 +372,7 @@ gpu_cull_context_ptr create_gpu_cull_context(const DevicePtr &device, const glm:
         depth_pyramid_fmt.usage = VK_IMAGE_USAGE_STORAGE_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
         depth_pyramid_fmt.use_mipmap = true;
         depth_pyramid_fmt.autogenerate_mipmaps = false;
-        depth_pyramid_fmt.reduction_mode = VK_SAMPLER_REDUCTION_MODE_MIN;
+        depth_pyramid_fmt.sampler_state.reduction_mode = VK_SAMPLER_REDUCTION_MODE_MIN;
         depth_pyramid_fmt.initial_layout = VK_IMAGE_LAYOUT_GENERAL;
         // TODO: pass in cmd-buffer for layout-transition
         ret->depth_pyramid_img = vierkant::Image::create(device, depth_pyramid_fmt);

--- a/src/model/model_loading.cpp
+++ b/src/model/model_loading.cpp
@@ -270,8 +270,8 @@ model::load_mesh_result_t load_mesh(const load_mesh_params_t &params,
         fmt.format = vk_format(img);
         fmt.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
         fmt.extent = {img->width(), img->height(), 1};
-        fmt.address_mode_u = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-        fmt.address_mode_v = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        fmt.sampler_state.address_mode_u = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+        fmt.sampler_state.address_mode_v = VK_SAMPLER_ADDRESS_MODE_REPEAT;
         fmt.use_mipmap = true;
         fmt.initial_layout = VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL;
         fmt.initial_cmd_buffer = cmd_buf_handle;
@@ -332,7 +332,7 @@ model::load_mesh_result_t load_mesh(const load_mesh_params_t &params,
                     {
                         vierkant::Image::Format fmt;
                         fmt.usage = VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
-                        fmt.max_anisotropy = params.device->properties().core.limits.maxSamplerAnisotropy;
+                        fmt.sampler_state.max_anisotropy = params.device->properties().core.limits.maxSamplerAnisotropy;
                         ret.textures[key] = create_compressed_texture(params.device, img, fmt, params.load_queue);
                     }
                 },
@@ -426,8 +426,8 @@ vierkant::ImagePtr create_texture(const vierkant::DevicePtr &device, const croco
     fmt.format = vk_format(img);
     fmt.usage |= VK_IMAGE_USAGE_SAMPLED_BIT | VK_IMAGE_USAGE_TRANSFER_DST_BIT;
     fmt.extent = {img->width(), img->height(), 1};
-    fmt.address_mode_u = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    fmt.address_mode_v = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    fmt.sampler_state.address_mode_u = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    fmt.sampler_state.address_mode_v = VK_SAMPLER_ADDRESS_MODE_REPEAT;
     fmt.use_mipmap = true;
     fmt.initial_layout = VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL;
     fmt.initial_cmd_buffer = command_buffer.handle();
@@ -453,8 +453,8 @@ vierkant::ImagePtr create_compressed_texture(const vierkant::DevicePtr &device,
     format.usage |= VK_IMAGE_USAGE_TRANSFER_DST_BIT | VK_IMAGE_USAGE_SAMPLED_BIT;
     format.format = compression_result.mode == bcn::BC7 ? VK_FORMAT_BC7_UNORM_BLOCK : VK_FORMAT_BC5_UNORM_BLOCK;
     format.extent = {compression_result.base_width, compression_result.base_height, 1};
-    format.address_mode_u = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-    format.address_mode_v = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    format.sampler_state.address_mode_u = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    format.sampler_state.address_mode_v = VK_SAMPLER_ADDRESS_MODE_REPEAT;
     format.use_mipmap = compression_result.levels.size() > 1;
     format.autogenerate_mipmaps = false;
     format.initial_layout_transition = false;

--- a/src/model/model_loading.cpp
+++ b/src/model/model_loading.cpp
@@ -49,33 +49,16 @@ VkFilter vk_filter(const vierkant::texture_sampler_t::Filter &filter)
     return VK_FILTER_NEAREST;
 }
 
-vierkant::VkSamplerPtr create_sampler(const vierkant::DevicePtr &device, const vierkant::texture_sampler_t &ts,
-                                      uint32_t num_mips)
+vierkant::VkSamplerPtr create_sampler(const vierkant::DevicePtr &device, const vierkant::texture_sampler_t &ts)
 {
-    VkSamplerCreateInfo sampler_create_info = {};
-    sampler_create_info.sType = VK_STRUCTURE_TYPE_SAMPLER_CREATE_INFO;
-    sampler_create_info.magFilter = vk_filter(ts.mag_filter);
-    sampler_create_info.minFilter = vk_filter(ts.min_filter);
-    sampler_create_info.addressModeU = vk_sampler_address_mode(ts.address_mode_u);
-    sampler_create_info.addressModeV = vk_sampler_address_mode(ts.address_mode_v);
-    sampler_create_info.addressModeW = VK_SAMPLER_ADDRESS_MODE_REPEAT;
-
-    sampler_create_info.anisotropyEnable = true;
-    sampler_create_info.maxAnisotropy = device->properties().core.limits.maxSamplerAnisotropy;
-
-    sampler_create_info.borderColor = VK_BORDER_COLOR_INT_OPAQUE_BLACK;
-    sampler_create_info.unnormalizedCoordinates = false;
-    sampler_create_info.compareEnable = VK_FALSE;
-    sampler_create_info.compareOp = VK_COMPARE_OP_ALWAYS;
-    sampler_create_info.mipmapMode = VK_SAMPLER_MIPMAP_MODE_LINEAR;
-    sampler_create_info.mipLodBias = 0.0f;
-    sampler_create_info.minLod = 0.0f;
-    sampler_create_info.maxLod = static_cast<float>(num_mips);
-
-    VkSampler sampler;
-    vkCheck(vkCreateSampler(device->handle(), &sampler_create_info, nullptr, &sampler),
-            "failed to create texture sampler!");
-    return {sampler, [device](VkSampler s) { vkDestroySampler(device->handle(), s, nullptr); }};
+    vierkant::sampler_state_t sampler_state = {};
+    sampler_state.min_filter = vk_filter(ts.min_filter);
+    sampler_state.mag_filter = vk_filter(ts.mag_filter);
+    sampler_state.address_mode_u = vk_sampler_address_mode(ts.address_mode_u);
+    sampler_state.address_mode_v = vk_sampler_address_mode(ts.address_mode_v);
+    sampler_state.address_mode_w = VK_SAMPLER_ADDRESS_MODE_REPEAT;
+    sampler_state.max_anisotropy = device->properties().core.limits.maxSamplerAnisotropy;
+    return device->sampler(sampler_state);
 }
 
 bool compress_textures(vierkant::model::model_assets_t &mesh_assets, crocore::ThreadPoolClassic *pool)
@@ -387,7 +370,7 @@ model::load_mesh_result_t load_mesh(const load_mesh_params_t &params,
             else if(auto desc_it = mesh_assets.texture_samplers.find(tex_data.sampler_id);
                     desc_it != mesh_assets.texture_samplers.end())
             {
-                vk_sampler = create_sampler(params.device, desc_it->second, base_img->num_mip_levels());
+                vk_sampler = create_sampler(params.device, desc_it->second);
                 ret.samplers[tex_data.sampler_id] = vk_sampler;
             }
             else


### PR DESCRIPTION
- drop update_descriptor_buffer/descriptor_size_fn_t, the use_descriptor_buffer set-layout flag and the descriptor-buffer device properties/features
- add Device::sampler(sampler_state_t), a shared mutex-guarded sampler-cache
- Image::init and model::create_sampler share samplers instead of creating one each
- samplers use VK_LOD_CLAMP_NONE: the sampled mip-level is already clamped to the image-view's level-range, so a per-image maxLod only fragmented the cache