### PR TITLE
projector-cookies for spot/omni lights

### DIFF
--- a/include/vierkant/punctual_light.hpp
+++ b/include/vierkant/punctual_light.hpp
@@ -5,9 +5,11 @@
 #pragma once
 
 #include <limits>
+#include <optional>
 #include <string>
 
 #include <crocore/NamedUUID.hpp>
+#include <vierkant/Material.hpp>
 #include <vierkant/math.hpp>
 #include <vierkant/object_component.hpp>
 #include <vierkant/transform.hpp>
@@ -54,6 +56,10 @@ struct lightsource_t
 
     //! area-light extents: x = radius (Sphere/Disk/Tube) or half-width (Rect), y = half-height (Rect) / half-length (Tube)
     glm::vec2 size = glm::vec2(1.f);
+
+    //! optional projector-cookie, modulating emitted radiance. Spot: projected through the cone (gobo/slide),
+    //! Omni: lat-long over the full sphere (photometric profile). ignored for all other types
+    std::optional<vierkant::texture_data_t> cookie;
 };
 
 //! lightsource object-component, referencing a lightsource-asset. position/direction come from the object-transform
@@ -86,8 +92,18 @@ struct alignas(16) light_t
 
     //! area-light extent: radius (Sphere/Disk/Tube) / half-width (Rect)
     float size_x;
+
+    //! projector-cookie uv-scale. Spot: 1/tan(outer_cone_angle), folded in to keep the shader trig-free
+    glm::vec2 uv_scale;
+
+    //! index into the renderer's texture-array, 0 marks 'no cookie' (index 0 is a solid-white placeholder)
+    uint32_t texture_index;
+
+    //! explicit trailing padding. the shader-side buffer-reference layout derives its array-stride from the
+    //! declared members only and does not round up to the struct-alignment, so the pad has to be spelled out
+    uint32_t pad;
 };
-static_assert(sizeof(light_t) == 80, "light_t layout must match shader-side (ray_common.slang)");
+static_assert(sizeof(light_t) == 96, "light_t layout must match shader-side (ray_common.slang)");
 
 static inline light_t convert_light(const vierkant::lightsource_t &light, const vierkant::transform_t &t)
 {
@@ -107,6 +123,10 @@ static inline light_t convert_light(const vierkant::lightsource_t &light, const 
     ret.tangent = t.rotation * glm::vec3(1.f, 0.f, 0.f);
     ret.size_x = light.size.x;
     ret.size_y = light.size.y;
+
+    // projector-cookie: the spot-map divides by tan(outer_cone_angle), pre-inverted here.
+    // texture_index stays 0 ('no cookie'), renderers own their texture-array and resolve it.
+    ret.uv_scale = glm::vec2(1.f / std::max(1.e-4f, std::tan(light.outer_cone_angle)));
     return ret;
 }
 

--- a/shaders/slang/ray/direct_lighting.slang
+++ b/shaders/slang/ray/direct_lighting.slang
@@ -28,8 +28,40 @@ public struct light_sample_t
     public float3 radiance;
 };
 
+//! projector-cookie: radiance-multiplier for one sampled direction, white when the light carries no cookie.
+//! Spot projects through its cone (gobo/slide), Omni maps the full sphere in lat-long (photometric profile).
+//! delta lights only - a pure multiplier, invisible to pdf/MIS
+float3 cookie_factor(light_t l, float3 dir_to_light, Sampler2D textures[])
+{
+    if(l.texture_index == 0) { return float3(1); }
+
+    // direction from the light toward the shading point, expressed in the light-frame
+    float3 D = -dir_to_light;
+    float3 p = float3(dot(D, l.tangent), dot(D, cross(l.direction, l.tangent)), dot(D, l.direction));
+    float2 uv;
+
+    if(l.type == LightType::Spot)
+    {
+        // behind the projector
+        if(p.z <= 0.0) { return float3(0); }
+
+        // uv_scale carries 1/tan(outer_cone_angle): the cookie-square circumscribes the cone,
+        // its corners are cut by the cone's angular attenuation
+        uv = 0.5 + 0.5 * p.xy * l.uv_scale / p.z;
+        if(any(uv != saturate(uv))) { return float3(0); }
+    }
+    else
+    {
+        // lat-long, covering the full sphere: no guards needed
+        uv = float2(atan2(p.y, p.x) * 0.5 * utils::ONE_OVER_PI + 0.5, acos(clamp(p.z, -1.0, 1.0)) * utils::ONE_OVER_PI);
+    }
+
+    // lod 0: NEE takes one sample per light per bounce, accumulation averages the aliasing away
+    return textures[NonUniformResourceIndex(l.texture_index)].SampleLevel(uv, 0).rgb;
+}
+
 //! sample an incident direction and unshadowed radiance for one light
-public light_sample_t sample_light(light_t l, float3 P, float2 Xi)
+public light_sample_t sample_light(light_t l, float3 P, float2 Xi, Sampler2D textures[])
 {
     light_sample_t ret;
     ret.pdf = 1.0;
@@ -131,7 +163,7 @@ public light_sample_t sample_light(light_t l, float3 P, float2 Xi)
             float angular_attenuation = clamp(cd * l.spot_angle_scale + l.spot_angle_offset, 0.0, 1.0);
             attenuation *= angular_attenuation * angular_attenuation;
         }
-        ret.radiance *= attenuation;
+        ret.radiance *= attenuation * cookie_factor(l, ret.direction, textures);
     }
     return ret;
 }
@@ -301,7 +333,7 @@ public float3 nee_surface(material_t material, trace_data_t trace_data, Raytraci
     uint num_lights = trace_data.params.num_lights;
     uint index = num_lights > 1 ? min(uint(utils::rnd(rng_state) * num_lights), num_lights - 1) : 0;
     float2 Xi = float2(utils::rnd(rng_state), utils::rnd(rng_state));
-    light_sample_t ls = sample_light(trace_data.lights[index], pos, Xi);
+    light_sample_t ls = sample_light(trace_data.lights[index], pos, Xi, textures);
 
     // skip the shadow ray for black samples (beyond range, inside a sphere-light)
     if(!any(ls.radiance > 0.0)) { return float3(0); }
@@ -340,7 +372,7 @@ public float3 nee_volume(Ray ray, trace_data_t trace_data, RaytracingAcceleratio
     uint num_lights = trace_data.params.num_lights;
     uint index = num_lights > 1 ? min(uint(utils::rnd(rng_state) * num_lights), num_lights - 1) : 0;
     float2 Xi = float2(utils::rnd(rng_state), utils::rnd(rng_state));
-    light_sample_t ls = sample_light(trace_data.lights[index], ray.origin, Xi);
+    light_sample_t ls = sample_light(trace_data.lights[index], ray.origin, Xi, textures);
 
     // skip the shadow ray for black samples (beyond range, inside a sphere-light)
     if(!any(ls.radiance > 0.0)) { return float3(0); }

--- a/shaders/slang/ray/ray_common.slang
+++ b/shaders/slang/ray/ray_common.slang
@@ -128,6 +128,16 @@ public struct light_t
 
     //! area-light extent: radius (Sphere/Disk/Tube) / half-width (Rect)
     public float size_x;
+
+    //! projector-cookie uv-scale. Spot: 1/tan(outer_cone_angle)
+    public float2 uv_scale;
+
+    //! index into the bound texture-array, 0 marks 'no cookie'
+    public uint texture_index;
+
+    //! explicit padding: the buffer-reference array-stride follows the declared members, without
+    //! rounding up to the struct-alignment. must stay in sync with vierkant::light_t::pad
+    public uint pad;
 };
 
 //! simple struct to group rayhit-parameters

--- a/shaders/slang/renderer/point_light.slang
+++ b/shaders/slang/renderer/point_light.slang
@@ -10,7 +10,7 @@ static const uint LIGHT_TYPE_POINT = 0;
 static const uint LIGHT_TYPE_SPOT = 1;
 static const uint LIGHT_TYPE_DIRECTIONAL = 2;
 
-//! matches host-side vierkant::light_t (80 bytes), same layout as ray_common's light_t
+//! matches host-side vierkant::light_t (96 bytes), same layout as ray_common's light_t
 public struct lightsource_t
 {
     public float3 position;
@@ -33,6 +33,15 @@ public struct lightsource_t
 
     //! area-light extent: radius (Sphere/Disk/Tube) / half-width (Rect)
     public float size_x;
+
+    //! projector-cookie uv-scale, unused here (cookies are path-tracer only, layout is shared)
+    public float2 uv_scale;
+
+    //! projector-cookie texture-index, unused here (see above)
+    public uint texture_index;
+
+    //! explicit padding, see vierkant::light_t::pad
+    public uint pad;
 };
 
 float GeometrySchlickGGX(float NdotV, float roughness)

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -552,10 +552,10 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
     desc_trace_data.stage_flags = VK_SHADER_STAGE_ALL;
     desc_trace_data.buffers = {frame_context.trace_data_ubo};
 
+    // images are assigned during the light-gather below: scene-textures plus any projector-cookies
     vierkant::descriptor_t &desc_textures = frame_context.tracable.descriptors[2];
     desc_textures.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     desc_textures.stage_flags = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR | VK_SHADER_STAGE_ANY_HIT_BIT_KHR;
-    desc_textures.images = frame_context.scene_ray_acceleration.textures;
 
     if(m_environment)
     {
@@ -636,6 +636,11 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
         lights.push_back(sun);
     }
 
+    // projector-cookies are appended behind the material-textures the ray-builder collected,
+    // so their indices stay valid for the descriptor-array assembled below
+    auto cookie_textures = frame_context.scene_ray_acceleration.textures;
+    std::unordered_map<vierkant::texture_key_t, uint32_t> cookie_indices;
+
     // scene lightsources: resolve component light-ids via asset-provider
     for(const auto *object: scene_visitor.objects)
     {
@@ -646,10 +651,30 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
             // Area stays reserved for emissive triangles (extracted, not authored)
             if(light_asset && light_asset->intensity > 0.f && light_asset->type != vierkant::LightType::Area)
             {
-                lights.push_back(vierkant::convert_light(*light_asset, object->global_transform()));
+                auto light = vierkant::convert_light(*light_asset, object->global_transform());
+
+                // cookies are sampled for Spot/Omni only. texture-index 0 (solid-white placeholder) means 'none'
+                if(light_asset->cookie &&
+                   (light_asset->type == vierkant::LightType::Spot || light_asset->type == vierkant::LightType::Omni))
+                {
+                    vierkant::texture_key_t key = {light_asset->cookie->texture_id, light_asset->cookie->sampler_id};
+
+                    if(auto it = cookie_indices.find(key); it != cookie_indices.end())
+                    {
+                        light.texture_index = it->second;
+                    }
+                    else if(auto img = scene->asset_provider()->texture(key))
+                    {
+                        light.texture_index = cookie_textures.size();
+                        cookie_indices[key] = light.texture_index;
+                        cookie_textures.push_back(std::move(img));
+                    }
+                }
+                lights.push_back(light);
             }
         }
     }
+    desc_textures.images = std::move(cookie_textures);
     if(!lights.empty()) { frame_context.lights_buffer->set_data(lights); }
     trace_data.trace_params.num_lights = lights.size();
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -113,7 +113,6 @@ void Scene::prune_assets(const std::unordered_set<vierkant::MaterialId> &extra_l
                          const std::unordered_set<vierkant::LightId> &extra_live_lights)
 {
     vierkant::asset_live_set_t live;
-    live.lights = extra_live_lights;
 
     // mark a material live, along with the textures/samplers it references
     auto mark_material = [this, &live](const vierkant::MaterialId &mat_id) {
@@ -129,11 +128,23 @@ void Scene::prune_assets(const std::unordered_set<vierkant::MaterialId> &extra_l
         }
     };
 
+    // mark a light live, along with the projector-cookie it references
+    auto mark_light = [this, &live](const vierkant::LightId &light_id) {
+        if(!live.lights.insert(light_id).second) { return; }
+
+        if(const auto *light = m_asset_provider->light(light_id); light && light->cookie)
+        {
+            live.textures.insert({light->cookie->texture_id, light->cookie->sampler_id});
+            if(light->cookie->sampler_id) { live.samplers.insert(light->cookie->sampler_id); }
+        }
+    };
+
     // caller-provided roots (e.g. a user-authored material-library) that outlive scene-graph references
     for(const auto &mat_id: extra_live_materials) { mark_material(mat_id); }
+    for(const auto &light_id: extra_live_lights) { mark_light(light_id); }
 
     LambdaVisitor visitor;
-    visitor.traverse(*root(), [&live, &mark_material](auto &obj) {
+    visitor.traverse(*root(), [&live, &mark_material, &mark_light](auto &obj) {
         if(auto *mesh_cmp = obj.template get_component_ptr<vierkant::mesh_component_t>(); mesh_cmp && mesh_cmp->mesh)
         {
             live.meshes.insert(mesh_cmp->mesh->id);
@@ -143,7 +154,7 @@ void Scene::prune_assets(const std::unordered_set<vierkant::MaterialId> &extra_l
         }
         if(auto *light_cmp = obj.template get_component_ptr<vierkant::lightsource_component_t>())
         {
-            live.lights.insert(light_cmp->light_id);
+            mark_light(light_cmp->light_id);
         }
         return true;
     });

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -1258,6 +1258,26 @@ bool draw_light_ui(vierkant::lightsource_t &light)
         changed |= ImGui::InputFloat("radius", &light.size.x);
         changed |= ImGui::InputFloat("half_length", &light.size.y);
     }
+
+    // projector-cookie: only Spot/Omni sample one, hide the field elsewhere so it cannot be authored
+    if(light.type == LightType::Spot || light.type == LightType::Omni)
+    {
+        *text_buf = 0;
+        if(light.cookie) { strcpy(text_buf, light.cookie->texture_id.str().c_str()); }
+
+        if(ImGui::InputText("cookie texture-id", text_buf, buf_size, ImGuiInputTextFlags_EnterReturnsTrue))
+        {
+            // a hand-assigned raw texture has no realized sampler-permutation -> resolve to the {id, nil} base
+            if(*text_buf)
+            {
+                vierkant::texture_data_t tex_data = {};
+                tex_data.texture_id = vierkant::TextureId::from_string(text_buf);
+                light.cookie = tex_data;
+            }
+            else { light.cookie.reset(); }
+            changed = true;
+        }
+    }
     return changed;
 }
 


### PR DESCRIPTION
- lightsource_t: optional cookie texture-reference, serialized as optional field
- light_t: 80 -> 96 bytes, uv_scale + texture_index, explicit pad to match the shader-side buffer-reference array-stride
- sample_light: cookie as a radiance-multiplier, spot projects through its cone, omni maps lat-long over the sphere
- PBRPathTracer: append cookie-textures behind the scene-textures, resolve indices
- Scene::prune_assets: keep cookie-textures alive
- imgui: cookie texture-id field on spot/omni lights