### PR TITLE
pathtracer: nested camera-media, drop the vacuum stack-slot

### DIFF
--- a/include/vierkant/PBRPathTracer.hpp
+++ b/include/vierkant/PBRPathTracer.hpp
@@ -271,8 +271,8 @@ private:
         //! optionally clamp indirect path-throughput
         float max_path_beta = 0.f;
 
-        //! flag: camera starts inside 'camera_media' (seed media-stack, disable back-face culling)
-        uint32_t camera_inside_media = false;
+        //! number of seeded entries in 'camera_media', outermost first. >0 also disables back-face culling
+        uint32_t camera_media_count = 0;
 
         //! debug: force a single direct-light estimator (0: MIS, 1: NEE-only, 2: BSDF-only)
         uint32_t mis_mode = 0;
@@ -313,7 +313,8 @@ private:
     {
         trace_params_t trace_params;
         camera_params_t camera_params;
-        media_t camera_media;
+        //! media the camera is submerged in, outermost first. seeds the path's media-stack
+        media_t camera_media[MAX_MEDIA_STACK_SIZE];
 
         VkDeviceAddress vertex_buffers{};
         VkDeviceAddress index_buffers{};

--- a/include/vierkant/media.hpp
+++ b/include/vierkant/media.hpp
@@ -9,6 +9,9 @@
 namespace vierkant
 {
 
+//! maximum number of nested media a path can track (matches ray_common.slang's MAX_MEDIA_STACK_SIZE)
+constexpr uint32_t MAX_MEDIA_STACK_SIZE = 4;
+
 //! participating-medium description (matches the shader-side ray::media_t)
 struct alignas(16) media_t
 {

--- a/shaders/slang/ray/ray_common.slang
+++ b/shaders/slang/ray/ray_common.slang
@@ -36,6 +36,9 @@ public struct RayCone
 
 public static const uint MISS_INDEX_DEFAULT = 0;
 
+//! maximum number of nested media a path can track (mirrored host-side in vierkant/media.hpp)
+public static const uint MAX_MEDIA_STACK_SIZE = 4;
+
 public enum MediaOp : uint
 {
     NoOp = 0,
@@ -45,13 +48,13 @@ public enum MediaOp : uint
 
 public struct media_t
 {
-    public float3 sigma_s;
-    public float ior;
-    public float3 sigma_a;
-    public float phase_g;
+    public float3 sigma_s = float3(0);
+    public float ior = 1.0;
+    public float3 sigma_a = float3(0);
+    public float phase_g = 0.0;
 
     //! emitted radiance Le. volumetric emission is sigma_a * Le, so it requires absorption
-    public float3 emission;
+    public float3 emission = float3(0);
     float pad;
 };
 
@@ -66,6 +69,10 @@ public struct packed_media_t
 
     public float ior() { return f16tof32(ior_phase & 0xFFFFu); }
 };
+
+//! vacuum/air in packed form: pack_rgb9e5(0) is 0, f32tof16(1.0) is 0x3C00. an empty media-stack
+//! resolves to this, so air never occupies a slot
+public static const packed_media_t VACUUM_MEDIA = {0u, 0u, 0u, 0x3C00u};
 
 public packed_media_t pack_media(media_t m)
 {
@@ -332,8 +339,8 @@ public struct trace_params_t
     //! clamp indirect path-throughput
     public float max_path_beta;
 
-    //! camera starts inside 'camera_media' (seed media-stack, disable back-face culling)
-    public bool camera_inside_media;
+    //! number of seeded entries in 'camera_media', outermost first. >0 also disables back-face culling
+    public uint camera_media_count;
 
     //! debug: force a single direct-light estimator
     public MisMode mis_mode;
@@ -369,7 +376,8 @@ public struct trace_data_t
 {
     public trace_params_t params;
     public camera_ubo_t camera;
-    public media_t camera_media;
+    //! media the camera is submerged in, outermost first. seeds the path's media-stack
+    public media_t camera_media[MAX_MEDIA_STACK_SIZE];
 
     // device pointers
     public Ptr<utils::packed_vertex_t, Access.Read> *vertex_buffers;

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -18,7 +18,8 @@ import "utils/sdf";
 import "utils/phase_function";
 import "utils/procedural_environment";
 
-static const uint MAX_MEDIA_STACK_SIZE = 4;
+// topmost media-stack slot; the stack holds only entered media, air is the empty stack
+static const uint MEDIA_STACK_TOP = ray::MAX_MEDIA_STACK_SIZE - 1;
 
 // path regularization: bounces below the pdf-threshold mark the path, later vertices floor their roughness
 static const float REGULARIZE_PDF_THRESHOLD = 1e3;
@@ -116,26 +117,16 @@ trace_result_t trace(uint2 coord, uint2 size)
         cone.spread_angle = spread_angle;
         cone.width = 0.0;
 
-        uint media_index = 0;
-        ray::packed_media_t media[MAX_MEDIA_STACK_SIZE];
+        // the stack holds entered media only; an empty stack is vacuum/air, so leaving the
+        // outermost medium needs no slot to return to. counts past the stack-size are kept
+        // (indices are clamped instead), so push and pop stay exact inverses at any depth.
+        ray::packed_media_t media[ray::MAX_MEDIA_STACK_SIZE];
 
-        // media[0] is always vacuum/air; leaving any medium returns here.
-        ray::media_t vacuum_media;
-        vacuum_media.sigma_s = float3(0);
-        vacuum_media.ior = 1.0;
-        vacuum_media.sigma_a = float3(0);
-        vacuum_media.phase_g = 0.0;
-        vacuum_media.emission = float3(0);
-        media[0] = ray::pack_media(vacuum_media);
-
-        // when the camera starts submerged, push its medium as the current one. seeding
-        // media_index = 1 also disables back-face culling below, so the surrounding
-        // volume's inner walls are visible and can 'Leave' back into air.
-        if(trace_data.params.camera_inside_media)
-        {
-            media_index = 1;
-            media[media_index] = ray::pack_media(trace_data.camera_media);
-        }
+        // when the camera starts submerged, seed the media it is inside, outermost first.
+        // a non-empty stack also disables back-face culling below, so the surrounding volumes'
+        // inner walls are visible and can 'Leave' back into their enclosing medium.
+        uint media_count = min(trace_data.params.camera_media_count, ray::MAX_MEDIA_STACK_SIZE);
+        for(uint m = 0; m < media_count; ++m) { media[m] = ray::pack_media(trace_data.camera_media[m]); }
 
         float3 beta = float3(1);
         float3 path_radiance = float3(0);
@@ -158,14 +149,15 @@ trace_result_t trace(uint2 coord, uint2 size)
             payload.albedo = float3(0);
             payload.radiance = path_radiance;
             payload.beta = beta;
-            payload.packed_media = media[media_index];
-            payload.last_ior = media[media_index > 0u ? media_index - 1u : 0u].ior();
+            payload.packed_media =
+                    media_count > 0u ? media[min(media_count - 1u, MEDIA_STACK_TOP)] : ray::VACUUM_MEDIA;
+            payload.last_ior = media_count > 1u ? media[min(media_count - 2u, MEDIA_STACK_TOP)].ior() : 1.0;
             payload.disp_lambda = disp_lambda;
             payload.ray = next_ray;
             payload.cone = cone;
             payload.entity_index = utils::MAX_UINT16;
 
-            uint ray_flags = media_index > 0u ? 0u : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
+            uint ray_flags = media_count > 0u ? 0u : RAY_FLAG_CULL_BACK_FACING_TRIANGLES;
 
             RayDesc ray_desc;
             ray_desc.Origin = next_ray.origin;
@@ -191,10 +183,11 @@ trace_result_t trace(uint2 coord, uint2 size)
 
             if(payload.media_op == ray::MediaOp::Enter)
             {
-                media_index = min(media_index + 1, MAX_MEDIA_STACK_SIZE - 1);
-                media[media_index] = payload.packed_media;
+                // past capacity the top slot is overwritten, but the count keeps counting
+                media[min(media_count, MEDIA_STACK_TOP)] = payload.packed_media;
+                media_count++;
             }
-            else if(payload.media_op == ray::MediaOp::Leave) { media_index = media_index > 0u ? media_index - 1u : 0u; }
+            else if(payload.media_op == ray::MediaOp::Leave) { media_count = media_count > 0u ? media_count - 1u : 0u; }
 
             // ghost-light pass: analytic light bodies are additive, non-terminating emitters.
             // front-facing intersections within the traced segment add MIS-weighted emission; the segment

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -1,4 +1,6 @@
 #include "vierkant/PBRPathTracer.hpp"
+
+#include <ranges>
 #include <vierkant/Visitor.hpp>
 #include <vierkant/gpu_timestamp_util.hpp>
 #include <vierkant/punctual_light.hpp>
@@ -26,9 +28,7 @@ struct alignas(16) pixel_buffer_t
 constexpr std::array<uint32_t, 5> atrous_steps = {1, 2, 4, 8, 16};
 
 glm::mat4 projection_view(const vierkant::Object3DPtr &cam)
-{
-    return camera::projection_matrix(cam.get()) * mat4_cast(camera::view_transform(cam.get()));
-}
+{ return camera::projection_matrix(cam.get()) * mat4_cast(camera::view_transform(cam.get())); }
 
 PBRPathTracerPtr PBRPathTracer::create(const DevicePtr &device, const PBRPathTracer::create_info_t &create_info)
 { return vierkant::PBRPathTracerPtr(new PBRPathTracer(device, create_info)); }
@@ -474,18 +474,19 @@ void PBRPathTracer::post_fx_pass(frame_context_t &frame_context)
     }
 }
 
-//! auto-detect a medium the camera is submerged in: the innermost (smallest world-OBB) volumetric
-//! object containing the camera position. mirrors the shader's 'has_volume' test
-//! (finite attenuation_distance). OBB containment is exact for rotated boxes but still loose for
-//! concave hulls; exactly covers the common 'large box with a volumetric material' case.
-static std::optional<vierkant::medium_params_t> detect_camera_medium(const std::vector<vierkant::Object3D *> &objects,
-                                                                     const vierkant::SceneConstPtr &scene,
-                                                                     const vierkant::Object3DPtr &cam)
+//! auto-detect the media a camera is submerged in: every volumetric object whose world-OBB contains
+//! the camera position, returned outermost-first so it can seed the path's media-stack. mirrors the
+//! shader's 'has_volume' test (finite attenuation_distance). OBB containment is exact for rotated
+//! boxes but still loose for concave hulls; exactly covers the common 'large box with a volumetric
+//! material' case.
+static std::vector<vierkant::medium_params_t> detect_camera_media(const std::vector<vierkant::Object3D *> &objects,
+                                                                  const vierkant::SceneConstPtr &scene,
+                                                                  const vierkant::Object3DPtr &cam)
 {
     const glm::vec3 cam_pos = cam->global_transform().translation;
 
-    std::optional<vierkant::medium_params_t> result;
-    float best_volume = std::numeric_limits<float>::max();
+    // (world-OBB volume, medium) pairs; the volume orders the nesting below
+    std::vector<std::pair<float, vierkant::medium_params_t>> found;
 
     for(const auto *object: objects)
     {
@@ -494,10 +495,6 @@ static std::optional<vierkant::medium_params_t> detect_camera_medium(const std::
         // world-space OBB containment test
         auto world_obb = object->obb().transform(object->global_transform());
         if(!world_obb.contains(cam_pos)) { continue; }
-
-        const glm::vec3 &h = world_obb.half_lengths;
-        float volume = 8.f * h.x * h.y * h.z;
-        if(volume >= best_volume) { continue; }
 
         // find a volumetric material (finite attenuation_distance) among this object's entries
         const auto &mesh_component = object->get_component<vierkant::mesh_component_t>();
@@ -528,11 +525,20 @@ static std::optional<vierkant::medium_params_t> detect_camera_medium(const std::
                 params.emission_color = mat->emission;
                 params.emission_intensity = mat->emissive_strength;
             }
-            result = params;
-            best_volume = volume;
+            const glm::vec3 &h = world_obb.half_lengths;
+            found.emplace_back(8.f * h.x * h.y * h.z, params);
             break;
         }
     }
+
+    // outermost -> innermost, inferring nesting from the enclosing volume. exact for properly
+    // nested volumes, arbitrary for merely overlapping ones - same ambiguity the previous
+    // innermost-wins policy resolved by silently picking one
+    std::ranges::sort(found, [](const auto &lhs, const auto &rhs) { return lhs.first > rhs.first; });
+
+    std::vector<vierkant::medium_params_t> result;
+    result.reserve(found.size());
+    for(const auto &params: found | std::views::values) { result.push_back(params); }
     return result;
 }
 
@@ -586,6 +592,7 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
 
     trace_data_t trace_data = {};
 
+
     using namespace std::chrono;
     trace_data.trace_params.time = duration_cast<duration_t>(steady_clock::now() - m_start_time).count();
     trace_data.trace_params.batch_index = m_batch_index;
@@ -606,16 +613,22 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
     vierkant::SelectVisitor<Object3D> scene_visitor(layer_mask);
     scene->root()->accept(scene_visitor);
 
-    // default media: air. submerge the camera in a medium if one is set: an explicit global medium
-    // (settings override) wins, otherwise auto-detect the volumetric object the camera is inside.
-    trace_data.camera_media = {};
-    std::optional<vierkant::medium_params_t> camera_medium = frame_context.settings.camera_medium;
-    if(!camera_medium) { camera_medium = detect_camera_medium(scene_visitor.objects, scene, cam); }
-    if(camera_medium)
+    // media the camera is submerged in, outermost first. an empty stack is air. an explicit global
+    // medium (settings override) is the outermost layer - it has no geometry, so nothing pops it -
+    // and the auto-detected volumetric objects the camera is inside stack on top of it.
+    std::vector<vierkant::medium_params_t> camera_media;
+    if(frame_context.settings.camera_medium) { camera_media.push_back(*frame_context.settings.camera_medium); }
+    auto detected_media = detect_camera_media(scene_visitor.objects, scene, cam);
+    camera_media.insert(camera_media.end(), detected_media.begin(), detected_media.end());
+
+    // keep the innermost entries: those are the media every traced segment actually integrates through
+    const size_t num_camera_media = std::min<size_t>(camera_media.size(), vierkant::MAX_MEDIA_STACK_SIZE);
+    const size_t media_offset = camera_media.size() - num_camera_media;
+    for(size_t i = 0; i < num_camera_media; ++i)
     {
-        trace_data.camera_media = vierkant::to_media(*camera_medium);
-        trace_data.trace_params.camera_inside_media = true;
+        trace_data.camera_media[i] = vierkant::to_media(camera_media[media_offset + i]);
     }
+    trace_data.trace_params.camera_media_count = static_cast<uint32_t>(num_camera_media);
 
     // gather lights into one device-array: optional sunlight (disc-light) folded in as light[0]
     std::vector<vierkant::light_t> lights;


### PR DESCRIPTION
- media-stack holds entered media only; an empty stack resolves to a constant vacuum, so air no longer occupies one of the four slots
- push/pop stay exact inverses past capacity: the count runs free, only the slot-index is clamped. previously a saturated push was still undone by its pop, unwinding the stack too far
- camera-media detection collects every containing volumetric object, outermost first, instead of only the innermost
- an explicit camera-medium is now the outermost stack entry with the detected volumes layered on top, instead of replacing them
- trace_data carries camera_media[MAX_MEDIA_STACK_SIZE] plus a count; the constant is mirrored in media.hpp