### PR TITLE
Bone Attachments

### DIFF
--- a/include/vierkant/Mesh.hpp
+++ b/include/vierkant/Mesh.hpp
@@ -246,6 +246,9 @@ public:
     vierkant::nodes::NodePtr root_node, root_bone;
     std::vector<vierkant::nodes::node_animation_t> node_animations;
 
+    //! transform from bone- to model-space, matching the entry-transforms of the skinned entries
+    vierkant::transform_t skin_transform;
+
     //! vertex buffer
     vierkant::BufferPtr vertex_buffer;
 

--- a/include/vierkant/Scene.hpp
+++ b/include/vierkant/Scene.hpp
@@ -94,16 +94,16 @@ public:
     [[nodiscard]] vierkant::Object3DPtr create_object() const;
 
     /**
-     * @brief   'create_bone_mirror' mirrors a skinned mesh's bone-hierarchy as child-objects,
+     * @brief   'ensure_bone_mirror' mirrors a skinned mesh's bone-hierarchy as child-objects,
      *          so that objects can be attached to individual bones.
      *
      * the mirror is derived data, driven by the animation in Scene::update and not serialized.
-     * it is created on demand and this call is idempotent: an existing mirror is returned as-is.
+     * it is created on demand and this call is idempotent: an existing mirror is kept as-is.
+     * does nothing, if the mesh has no skeleton.
      *
      * @param   mesh_object an object, expected to carry a mesh-component
-     * @return  the mirror's root-object or nullptr, if the mesh has no skeleton
      */
-    vierkant::Object3D *create_bone_mirror(const vierkant::Object3DPtr &mesh_object) const;
+    void ensure_bone_mirror(vierkant::Object3D &mesh_object) const;
 
     [[nodiscard]] vierkant::Object3DPtr
     create_camera(const vierkant::camera_component_t &params = {}) const;

--- a/include/vierkant/Scene.hpp
+++ b/include/vierkant/Scene.hpp
@@ -93,6 +93,18 @@ public:
 
     [[nodiscard]] vierkant::Object3DPtr create_object() const;
 
+    /**
+     * @brief   'create_bone_mirror' mirrors a skinned mesh's bone-hierarchy as child-objects,
+     *          so that objects can be attached to individual bones.
+     *
+     * the mirror is derived data, driven by the animation in Scene::update and not serialized.
+     * it is created on demand and this call is idempotent: an existing mirror is returned as-is.
+     *
+     * @param   mesh_object an object, expected to carry a mesh-component
+     * @return  the mirror's root-object or nullptr, if the mesh has no skeleton
+     */
+    vierkant::Object3D *create_bone_mirror(const vierkant::Object3DPtr &mesh_object) const;
+
     [[nodiscard]] vierkant::Object3DPtr
     create_camera(const vierkant::camera_component_t &params = {}) const;
 

--- a/include/vierkant/mesh_component.hpp
+++ b/include/vierkant/mesh_component.hpp
@@ -32,7 +32,7 @@ struct mesh_component_t
  *
  * those objects are derived from a mesh's bone-hierarchy, not authored scene-content: they are
  * driven by the animation each frame and are not serialized. objects attached to them are ordinary
- * scene-content and do persist, anchored by the bone's name.
+ * scene-content and do persist, anchored by the bone's id.
  */
 struct bone_component_t
 {
@@ -40,6 +40,9 @@ struct bone_component_t
 
     //! index of the mirrored bone. absent for the hierarchy's root, which carries the skin-transform.
     std::optional<uint32_t> index = {};
+
+    //! id of the mirrored bone, used to anchor attachments. nil for the hierarchy's root.
+    vierkant::nodes::NodeId node_id = vierkant::nodes::NodeId::nil();
 };
 
 /**
@@ -49,6 +52,15 @@ struct bone_component_t
  * @return  the mirror's root-object or nullptr, if no mirror exists
  */
 Object3D *bone_mirror_root(const vierkant::Object3D &mesh_object);
+
+/**
+ * @brief   bone_object_by_id searches a mesh-object's bone-mirror for a bone.
+ *
+ * @param   mesh_object an object, expected to carry a mesh-component
+ * @param   node_id     id of the searched bone
+ * @return  the bone's object or nullptr, if there is no mirror or no such bone
+ */
+Object3D *bone_object_by_id(const vierkant::Object3D &mesh_object, vierkant::nodes::NodeId node_id);
 
 //! struct grouping host/gpu versions of a mesh
 struct mesh_asset_t

--- a/include/vierkant/mesh_component.hpp
+++ b/include/vierkant/mesh_component.hpp
@@ -26,6 +26,21 @@ struct mesh_component_t
     bool library = false;
 };
 
+/**
+ * @brief   bone_component_t marks an object as part of a mesh's mirrored bone-hierarchy.
+ *
+ * those objects are derived from a mesh's bone-hierarchy, not authored scene-content: they are
+ * driven by the animation each frame and are not serialized. objects attached to them are ordinary
+ * scene-content and do persist, anchored by the bone's name.
+ */
+struct bone_component_t
+{
+    VIERKANT_ENABLE_AS_COMPONENT();
+
+    //! index of the mirrored bone. absent for the hierarchy's root, which carries the skin-transform.
+    std::optional<uint32_t> index = {};
+};
+
 //! struct grouping host/gpu versions of a mesh
 struct mesh_asset_t
 {

--- a/include/vierkant/mesh_component.hpp
+++ b/include/vierkant/mesh_component.hpp
@@ -4,6 +4,7 @@
 #include <unordered_set>
 #include <vector>
 #include <vierkant/Mesh.hpp>
+#include <vierkant/Object3D.hpp>
 #include <vierkant/object_component.hpp>
 
 namespace vierkant
@@ -40,6 +41,14 @@ struct bone_component_t
     //! index of the mirrored bone. absent for the hierarchy's root, which carries the skin-transform.
     std::optional<uint32_t> index = {};
 };
+
+/**
+ * @brief   bone_mirror_root returns a mesh-object's mirrored bone-hierarchy, if one was created.
+ *
+ * @param   mesh_object an object, expected to carry a mesh-component
+ * @return  the mirror's root-object or nullptr, if no mirror exists
+ */
+Object3D *bone_mirror_root(const vierkant::Object3D &mesh_object);
 
 //! struct grouping host/gpu versions of a mesh
 struct mesh_asset_t

--- a/include/vierkant/model/model_loading.hpp
+++ b/include/vierkant/model/model_loading.hpp
@@ -102,6 +102,10 @@ struct model_assets_t
     //! optional bone node-hierarchy
     vierkant::nodes::NodePtr root_bone;
 
+    //! transform from bone- to model-space. bone-transforms are relative to the skinned node,
+    //! this is that node's transform. identity when there is no skin.
+    vierkant::transform_t skin_transform;
+
     //! optional array of animations defined for nodes
     std::vector<vierkant::nodes::node_animation_t> node_animations;
 
@@ -111,7 +115,7 @@ struct model_assets_t
 
 //! schema-version folded into the bundle cache-key; bump on any parsing/serialization change that
 //! would make existing bundles decode wrong. layout-sizes are covered by serialized_layout_hash().
-constexpr uint32_t bundle_schema_version = 4;
+constexpr uint32_t bundle_schema_version = 5;
 
 struct mesh_omm_key_t
 {

--- a/include/vierkant/model/model_loading.hpp
+++ b/include/vierkant/model/model_loading.hpp
@@ -115,7 +115,7 @@ struct model_assets_t
 
 //! schema-version folded into the bundle cache-key; bump on any parsing/serialization change that
 //! would make existing bundles decode wrong. layout-sizes are covered by serialized_layout_hash().
-constexpr uint32_t bundle_schema_version = 5;
+constexpr uint32_t bundle_schema_version = 6;
 
 struct mesh_omm_key_t
 {

--- a/include/vierkant/nodes.hpp
+++ b/include/vierkant/nodes.hpp
@@ -59,6 +59,20 @@ void build_node_matrices_bfs(const NodeConstPtr &root, const node_animation_t &a
                              std::vector<vierkant::transform_t> &transforms);
 
 /**
+ * @brief   Create local transformation matrices, matching the provided node-hierarchy and animation.
+ *          in contrast to build_node_matrices_bfs, transforms are neither accumulated along the
+ *          hierarchy nor combined with a node's offset. useful to drive a mirrored hierarchy that
+ *          performs its own composition.
+ *
+ * @param   root        a root node of a node-hierarchy.
+ * @param   animation   a const-ref for an animation_t object.
+ * @param   time        current time.
+ * @param   transforms  ref to an array of transformation-matrices. will be populated by this function.
+ */
+void build_local_transforms_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+                                std::vector<vierkant::transform_t> &transforms);
+
+/**
  * @brief   Create morph-weights, matching the provided node-hierarchy and animation.
  *
  * @tparam  T               scalar template type (float/double)

--- a/include/vierkant/nodes.hpp
+++ b/include/vierkant/nodes.hpp
@@ -4,6 +4,7 @@
 
 #pragma once
 
+#include <crocore/NamedUUID.hpp>
 #include <list>
 #include <map>
 #include <memory>
@@ -14,12 +15,18 @@
 namespace vierkant::nodes
 {
 
+DEFINE_NAMED_UUID(NodeId)
+
 using NodePtr = std::shared_ptr<struct node_t>;
 using NodeConstPtr = std::shared_ptr<const struct node_t>;
 
 struct node_t
 {
     std::string name;
+
+    //! stable id, derived from the node-name. nil outside bone-hierarchies.
+    NodeId id = NodeId::nil();
+
     vierkant::transform_t transform = {};
     vierkant::transform_t offset = {};
     uint32_t index = 0;

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -29,8 +29,9 @@ static void update_bone_mirror(vierkant::Object3D &mirror_root, const vierkant::
         auto *bone_cmp = object->get_component_ptr<vierkant::bone_component_t>();
         if(!bone_cmp) { continue; }
 
-        // the root has no index, it carries the constant skin-transform
-        if(bone_cmp->index)
+        // the root has no index, it carries the constant skin-transform.
+        // a mesh swapped after mirror-creation can leave stale indices -> freeze instead of read out of bounds.
+        if(bone_cmp->index && *bone_cmp->index < local_transforms.size())
         {
             object->get_component<vierkant::transform_component_t>().transform = local_transforms[*bone_cmp->index];
         }
@@ -94,11 +95,11 @@ vierkant::Object3DPtr Scene::create_primitive_object(vierkant::primitive_type ty
 
 vierkant::Object3DPtr Scene::create_object() const { return m_object_store->create_object(); }
 
-vierkant::Object3D *Scene::create_bone_mirror(const vierkant::Object3DPtr &mesh_object) const
+void Scene::ensure_bone_mirror(vierkant::Object3D &mesh_object) const
 {
-    const auto *mesh_cmp = mesh_object->get_component_ptr<vierkant::mesh_component_t>();
-    if(!mesh_cmp || !mesh_cmp->mesh || !mesh_cmp->mesh->root_bone) { return nullptr; }
-    if(auto *existing = vierkant::bone_mirror_root(*mesh_object)) { return existing; }
+    const auto *mesh_cmp = mesh_object.get_component_ptr<vierkant::mesh_component_t>();
+    if(!mesh_cmp || !mesh_cmp->mesh || !mesh_cmp->mesh->root_bone) { return; }
+    if(vierkant::bone_mirror_root(mesh_object)) { return; }
 
     const auto &mesh = mesh_cmp->mesh;
 
@@ -119,13 +120,12 @@ vierkant::Object3D *Scene::create_bone_mirror(const vierkant::Object3DPtr &mesh_
         auto bone_object = create_object();
         bone_object->name = node->name;
         bone_object->set_transform(node->transform);
-        bone_object->add_component<vierkant::bone_component_t>({.index = node->index});
+        bone_object->add_component<vierkant::bone_component_t>({.index = node->index, .node_id = node->id});
         parent_object->add_child(bone_object);
 
         for(const auto &child_node: node->children) { node_queue.emplace_back(child_node, bone_object); }
     }
-    mesh_object->add_child(mirror_root);
-    return mirror_root.get();
+    mesh_object.add_child(mirror_root);
 }
 
 vierkant::Object3DPtr Scene::create_camera(const vierkant::camera_component_t &params) const

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -2,10 +2,45 @@
 #include "vierkant/Visitor.hpp"
 #include "vierkant/physics_context.hpp"
 
+#include <deque>
 #include <ranges>
+#include <stack>
 
 namespace vierkant
 {
+
+//! write animated local bone-transforms into a mesh-object's mirrored bone-hierarchy
+static void update_bone_mirror(vierkant::Object3D &mirror_root, const vierkant::Mesh &mesh,
+                               const vierkant::animation_component_t &animation_state)
+{
+    std::vector<vierkant::transform_t> local_transforms;
+    vierkant::nodes::build_local_transforms_bfs(mesh.root_bone, mesh.node_animations[animation_state.index],
+                                                static_cast<float>(animation_state.current_time), local_transforms);
+
+    std::stack<vierkant::Object3D *> object_stack;
+    object_stack.push(&mirror_root);
+
+    while(!object_stack.empty())
+    {
+        auto *object = object_stack.top();
+        object_stack.pop();
+
+        // stop at attached content, only the mirror itself is driven
+        auto *bone_cmp = object->get_component_ptr<vierkant::bone_component_t>();
+        if(!bone_cmp) { continue; }
+
+        // the root has no index, it carries the constant skin-transform
+        if(bone_cmp->index)
+        {
+            object->get_component<vierkant::transform_component_t>().transform = local_transforms[*bone_cmp->index];
+        }
+        for(const auto &child: object->children) { object_stack.push(child.get()); }
+    }
+
+    // the transforms above were written in place, bypassing the cache-invalidation in set_transform.
+    // re-setting the root's own transform invalidates the whole sub-tree once, instead of per bone.
+    mirror_root.set_transform(*mirror_root.transform());
+}
 
 struct range_item_t
 {
@@ -58,6 +93,40 @@ vierkant::Object3DPtr Scene::create_primitive_object(vierkant::primitive_type ty
 }
 
 vierkant::Object3DPtr Scene::create_object() const { return m_object_store->create_object(); }
+
+vierkant::Object3D *Scene::create_bone_mirror(const vierkant::Object3DPtr &mesh_object) const
+{
+    const auto *mesh_cmp = mesh_object->get_component_ptr<vierkant::mesh_component_t>();
+    if(!mesh_cmp || !mesh_cmp->mesh || !mesh_cmp->mesh->root_bone) { return nullptr; }
+    if(auto *existing = vierkant::bone_mirror_root(*mesh_object)) { return existing; }
+
+    const auto &mesh = mesh_cmp->mesh;
+
+    // the mirror-root carries the bone- to model-space transform, its children mirror the bones
+    auto mirror_root = create_object();
+    mirror_root->name = "skeleton";
+    mirror_root->set_transform(mesh->skin_transform);
+    mirror_root->add_component<vierkant::bone_component_t>();
+
+    std::deque<std::pair<vierkant::nodes::NodeConstPtr, vierkant::Object3DPtr>> node_queue = {
+            {mesh->root_bone, mirror_root}};
+
+    while(!node_queue.empty())
+    {
+        auto [node, parent_object] = node_queue.front();
+        node_queue.pop_front();
+
+        auto bone_object = create_object();
+        bone_object->name = node->name;
+        bone_object->set_transform(node->transform);
+        bone_object->add_component<vierkant::bone_component_t>({.index = node->index});
+        parent_object->add_child(bone_object);
+
+        for(const auto &child_node: node->children) { node_queue.emplace_back(child_node, bone_object); }
+    }
+    mesh_object->add_child(mirror_root);
+    return mirror_root.get();
+}
 
 vierkant::Object3DPtr Scene::create_camera(const vierkant::camera_component_t &params) const
 {
@@ -165,50 +234,56 @@ void Scene::prune_assets(const std::unordered_set<vierkant::MaterialId> &extra_l
 void Scene::update(double time_delta)
 {
     LambdaVisitor visitor;
-    visitor.traverse(*m_root, [time_delta, animation_delta = time_delta * animation_speed,
-                               frame = m_current_frame](Object3D &obj) -> bool {
-        if(obj.enabled)
-        {
-            auto animation_cmp = obj.get_component_ptr<animation_component_t>();
-            auto mesh_cmp = obj.get_component_ptr<mesh_component_t>();
+    visitor.traverse(*m_root,
+                     [time_delta, animation_delta = time_delta * animation_speed,
+                      frame = m_current_frame](Object3D &obj) -> bool {
+                         if(obj.enabled)
+                         {
+                             auto animation_cmp = obj.get_component_ptr<animation_component_t>();
+                             auto mesh_cmp = obj.get_component_ptr<mesh_component_t>();
 
-            if(auto *flag_cmp = obj.get_component_ptr<flag_component_t>())
-            {
-                for(uint32_t i = 0; i <= msb(flag_component_t::MAX_ENUM); ++i)
-                {
-                    if(flag_cmp->flags & (1U << i)) { flag_cmp->timestamps[i] = frame; }
-                }
+                             if(auto *flag_cmp = obj.get_component_ptr<flag_component_t>())
+                             {
+                                 for(uint32_t i = 0; i <= msb(flag_component_t::MAX_ENUM); ++i)
+                                 {
+                                     if(flag_cmp->flags & (1U << i)) { flag_cmp->timestamps[i] = frame; }
+                                 }
 
-                // clear previous dirt flags
-                flag_cmp->flags = 0;
-            }
-            if(animation_cmp && mesh_cmp)
-            {
-                vierkant::update_animation(mesh_cmp->mesh->node_animations[animation_cmp->index], animation_delta,
-                                           *animation_cmp);
-            }
-            if(auto *update_cmp = obj.get_component_ptr<update_component_t>())
-            {
-                if(update_cmp->update_fn) { update_cmp->update_fn(obj, time_delta); }
-            }
-            if(auto *timer_cmp = obj.get_component_ptr<timer_component_t>())
-            {
-                timer_cmp->duration -= timer_component_t::duration_t(time_delta);
-                if(timer_cmp->duration <= timer_component_t::duration_t(0) && timer_cmp->timer_fn)
-                {
-                    timer_cmp->timer_fn(obj);
+                                 // clear previous dirt flags
+                                 flag_cmp->flags = 0;
+                             }
+                             if(animation_cmp && mesh_cmp)
+                             {
+                                 vierkant::update_animation(mesh_cmp->mesh->node_animations[animation_cmp->index],
+                                                            animation_delta, *animation_cmp);
 
-                    if(timer_cmp->repeat) { timer_cmp->duration += timer_cmp->total; }
-                    else
-                    {
-                        timer_cmp->timer_fn = {};
-                    }
-                }
-            }
-            return true;
-        }
-        return false;
-    });
+                                 if(auto *mirror_root = vierkant::bone_mirror_root(obj))
+                                 {
+                                     update_bone_mirror(*mirror_root, *mesh_cmp->mesh, *animation_cmp);
+                                 }
+                             }
+                             if(auto *update_cmp = obj.get_component_ptr<update_component_t>())
+                             {
+                                 if(update_cmp->update_fn) { update_cmp->update_fn(obj, time_delta); }
+                             }
+                             if(auto *timer_cmp = obj.get_component_ptr<timer_component_t>())
+                             {
+                                 timer_cmp->duration -= timer_component_t::duration_t(time_delta);
+                                 if(timer_cmp->duration <= timer_component_t::duration_t(0) && timer_cmp->timer_fn)
+                                 {
+                                     timer_cmp->timer_fn(obj);
+
+                                     if(timer_cmp->repeat) { timer_cmp->duration += timer_cmp->total; }
+                                     else
+                                     {
+                                         timer_cmp->timer_fn = {};
+                                     }
+                                 }
+                             }
+                             return true;
+                         }
+                         return false;
+                     });
 
     // increase framenumbrs after update
     m_current_frame++;

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -1301,6 +1301,15 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
     ImGui::BulletText("%zu positions", num_vertices);
     ImGui::BulletText("%zu faces", num_faces);
     ImGui::BulletText("%d bones", vierkant::nodes::num_nodes_in_hierarchy(mesh->root_bone));
+
+    // mirror the bones as objects, so things can be attached to them via the scenegraph
+    if(mesh->root_bone)
+    {
+        ImGui::SameLine();
+        ImGui::BeginDisabled(vierkant::bone_mirror_root(*object) != nullptr);
+        if(ImGui::Button("create bone-objects")) { scene->ensure_bone_mirror(*object); }
+        ImGui::EndDisabled();
+    }
     ImGui::Separator();
     ImGui::Spacing();
 

--- a/src/mesh_component.cpp
+++ b/src/mesh_component.cpp
@@ -72,4 +72,13 @@ std::vector<vierkant::AABB> mesh_sub_aabbs(const vierkant::mesh_component_t &cmp
     return ret;
 }
 
+Object3D *bone_mirror_root(const vierkant::Object3D &mesh_object)
+{
+    for(const auto &child: mesh_object.children)
+    {
+        if(child->has_component<vierkant::bone_component_t>()) { return child.get(); }
+    }
+    return nullptr;
+}
+
 }// namespace vierkant

--- a/src/mesh_component.cpp
+++ b/src/mesh_component.cpp
@@ -1,3 +1,4 @@
+#include <stack>
 #include <vierkant/mesh_component.hpp>
 
 namespace vierkant
@@ -77,6 +78,29 @@ Object3D *bone_mirror_root(const vierkant::Object3D &mesh_object)
     for(const auto &child: mesh_object.children)
     {
         if(child->has_component<vierkant::bone_component_t>()) { return child.get(); }
+    }
+    return nullptr;
+}
+
+Object3D *bone_object_by_id(const vierkant::Object3D &mesh_object, vierkant::nodes::NodeId node_id)
+{
+    auto *mirror_root = bone_mirror_root(mesh_object);
+    if(!mirror_root || node_id.is_nil()) { return nullptr; }
+
+    std::stack<vierkant::Object3D *> object_stack;
+    object_stack.push(mirror_root);
+
+    while(!object_stack.empty())
+    {
+        auto *object = object_stack.top();
+        object_stack.pop();
+
+        // stop at attached content, only the mirror itself is searched
+        const auto *bone_cmp = object->get_component_ptr<vierkant::bone_component_t>();
+        if(!bone_cmp) { continue; }
+        if(bone_cmp->node_id == node_id) { return object; }
+
+        for(const auto &child: object->children) { object_stack.push(child.get()); }
     }
     return nullptr;
 }

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -1119,6 +1119,9 @@ std::optional<model_assets_t> gltf(const std::filesystem::path &path, crocore::T
             {
                 const tinygltf::Skin &skin = model.skins[tiny_node.skin];
                 out_assets.root_bone = create_bone_hierarchy_bfs(skin, model, node_map);
+
+                // bone-transforms are relative to this node, keep its transform to get back to model-space
+                out_assets.skin_transform = world_transform;
             }
 
             for(const auto &primitive: mesh.primitives)

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -10,6 +10,7 @@
 
 #include <deque>
 #include <tiny_gltf.h>
+#include <unordered_set>
 
 #include <vierkant/model/gltf.hpp>
 #include <vierkant/transform.hpp>
@@ -722,6 +723,7 @@ vierkant::nodes::NodePtr create_bone_hierarchy_bfs(const tinygltf::Skin &skin, c
     {
         std::deque<node_helper_t> node_queue;
         node_queue.push_back({static_cast<size_t>(skin.skeleton), {}, nullptr});
+        std::unordered_set<vierkant::nodes::NodeId> bone_ids;
 
         while(!node_queue.empty())
         {
@@ -736,6 +738,15 @@ vierkant::nodes::NodePtr create_bone_hierarchy_bfs(const tinygltf::Skin &skin, c
             bone_node->parent = parent_node;
             bone_node->name = skeleton_node.name;
             bone_node->index = joint_map[current_index];
+
+            // derived from the name, so it survives a re-export and a bundle re-bake
+            bone_node->id = vierkant::nodes::NodeId::from_name(
+                    skeleton_node.name.empty() ? "joint_" + std::to_string(bone_node->index) : skeleton_node.name);
+            if(!bone_ids.insert(bone_node->id).second)
+            {
+                spdlog::warn("duplicate bone-name '{}': attachments will resolve to the first one",
+                             skeleton_node.name);
+            }
             bone_node->offset = vierkant::transform_cast(inverse_binding_matrices[joint_map[current_index]]);
             bone_node->transform = local_joint_transform;
 

--- a/src/model/model_loading.cpp
+++ b/src/model/model_loading.cpp
@@ -308,6 +308,7 @@ model::load_mesh_result_t load_mesh(const load_mesh_params_t &params,
 
     // skin + bones
     ret.mesh->root_bone = mesh_assets.root_bone;
+    ret.mesh->skin_transform = mesh_assets.skin_transform;
 
     // node hierarchy
     ret.mesh->root_node = mesh_assets.root_node;

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -11,7 +11,7 @@ namespace vierkant::nodes
 
 using traversal_fn = std::function<bool(const NodeConstPtr &)>;
 
-static inline void bfs(const NodeConstPtr &root, const traversal_fn &fn)
+static void bfs(const NodeConstPtr &root, const traversal_fn &fn)
 {
     if(!root) { return; }
 
@@ -53,6 +53,24 @@ NodeConstPtr node_by_name(const NodeConstPtr &root, const std::string &name)
         return true;
     });
     return ret;
+}
+
+void build_local_transforms_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+                                std::vector<vierkant::transform_t> &transforms)
+{
+    if(!root) { return; }
+    transforms.resize(num_nodes_in_hierarchy(root));
+
+    bfs(root, [&transforms, &animation, time](const NodeConstPtr &node) {
+        auto node_transform = node->transform;
+
+        if(const auto it = animation.keys.find(node); it != animation.keys.end())
+        {
+            create_animation_transform(it->second, time, animation.interpolation_mode, node_transform);
+        }
+        transforms[node->index] = node_transform;
+        return true;
+    });
 }
 
 template<typename T, typename>

--- a/src/serialization/animation_cereal.hpp
+++ b/src/serialization/animation_cereal.hpp
@@ -59,7 +59,8 @@ void serialize(Archive &archive, vierkant::nodes::node_t &n)
             cereal::make_nvp("offset", n.offset),
             cereal::make_nvp("index", n.index),
             cereal::make_nvp("parent", n.parent),
-            cereal::make_nvp("children", n.children));
+            cereal::make_nvp("children", n.children),
+            cereal::make_nvp("id", n.id));
 }
 
 }// namespace vierkant::nodes

--- a/src/serialization/bundle_format.hpp
+++ b/src/serialization/bundle_format.hpp
@@ -217,7 +217,8 @@ void serialize(Archive &archive, vierkant::model::model_assets_t &mesh_assets)
             // only for bundles written by this or a newer version; older bundles get a different
             // cache-filename (see model_bundle_filename) and are re-baked rather than mis-read.
             cereal::make_nvp("omm_data", mesh_assets.omm_data), cereal::make_nvp("lights", mesh_assets.lights),
-            cereal::make_nvp("light_instances", mesh_assets.light_instances));
+            cereal::make_nvp("light_instances", mesh_assets.light_instances),
+            cereal::make_nvp("skin_transform", mesh_assets.skin_transform));
 }
 
 }// namespace vierkant::model

--- a/tests/TestBoneMirror.cpp
+++ b/tests/TestBoneMirror.cpp
@@ -1,0 +1,105 @@
+#include "vierkant/Scene.hpp"
+#include <gtest/gtest.h>
+
+using namespace vierkant;
+
+namespace
+{
+
+//! a two-bone chain plus a non-identity skin-transform, the minimum a mirror needs
+vierkant::MeshPtr create_skinned_mesh()
+{
+    auto mesh = vierkant::Mesh::create();
+
+    auto root_bone = std::make_shared<nodes::node_t>();
+    root_bone->name = "root_bone";
+    root_bone->index = 0;
+    root_bone->transform.translation = {1.f, 0.f, 0.f};
+
+    auto child_bone = std::make_shared<nodes::node_t>();
+    child_bone->name = "child_bone";
+    child_bone->index = 1;
+    child_bone->parent = root_bone;
+    child_bone->transform.translation = {0.f, 2.f, 0.f};
+    root_bone->children = {child_bone};
+
+    mesh->root_bone = root_bone;
+    mesh->skin_transform.translation = {0.f, 0.f, 10.f};
+    mesh->node_animations.resize(1);
+    mesh->node_animations[0].duration = 10.f;
+    return mesh;
+}
+
+}// namespace
+
+TEST(BoneMirror, create_mirrors_the_hierarchy)
+{
+    auto scene = vierkant::Scene::create();
+    auto mesh_object = scene->create_mesh_object({create_skinned_mesh()});
+
+    auto *mirror_root = scene->create_bone_mirror(mesh_object);
+    ASSERT_TRUE(mirror_root);
+
+    // the root is unindexed and carries the skin-transform, the bones below mirror the node-hierarchy
+    ASSERT_TRUE(mirror_root->has_component<bone_component_t>());
+    EXPECT_FALSE(mirror_root->get_component<bone_component_t>().index);
+    EXPECT_EQ(mirror_root->transform()->translation, glm::vec3(0.f, 0.f, 10.f));
+
+    ASSERT_EQ(mirror_root->children.size(), 1);
+    const auto &root_bone = mirror_root->children.front();
+    EXPECT_EQ(root_bone->name, "root_bone");
+    EXPECT_EQ(root_bone->get_component<bone_component_t>().index, 0);
+
+    ASSERT_EQ(root_bone->children.size(), 1);
+    const auto &child_bone = root_bone->children.front();
+    EXPECT_EQ(child_bone->name, "child_bone");
+    EXPECT_EQ(child_bone->get_component<bone_component_t>().index, 1);
+
+    // idempotent: a second call returns the existing mirror instead of adding another one
+    EXPECT_EQ(scene->create_bone_mirror(mesh_object), mirror_root);
+    EXPECT_EQ(mesh_object->children.size(), 1);
+}
+
+TEST(BoneMirror, create_without_skeleton)
+{
+    auto scene = vierkant::Scene::create();
+    auto mesh_object = scene->create_mesh_object({vierkant::Mesh::create()});
+    EXPECT_EQ(scene->create_bone_mirror(mesh_object), nullptr);
+    EXPECT_TRUE(mesh_object->children.empty());
+}
+
+TEST(BoneMirror, update_drives_globals_and_attachments)
+{
+    auto scene = vierkant::Scene::create();
+    auto mesh = create_skinned_mesh();
+
+    // animate the root-bone, so the sampled key has to replace its own transform
+    mesh->node_animations[0].keys[mesh->root_bone].positions[0.f] = {.value = {7.f, 8.f, 9.f}};
+
+    auto mesh_object = scene->create_mesh_object({mesh});
+    mesh_object->set_transform({.translation = {100.f, 0.f, 0.f}});
+    scene->add_object(mesh_object);
+
+    auto *mirror_root = scene->create_bone_mirror(mesh_object);
+    ASSERT_TRUE(mirror_root);
+
+    // an ordinary object attached to the deepest bone
+    auto attachment = scene->create_object();
+    attachment->set_transform({.translation = {0.f, 0.f, 1.f}});
+    mirror_root->children.front()->children.front()->add_child(attachment);
+
+    scene->update(0.0);
+
+    // object * skin_transform, then the animated root-bone, then the unanimated child-bone
+    EXPECT_EQ(mirror_root->global_transform().translation, glm::vec3(100.f, 0.f, 10.f));
+    EXPECT_EQ(mirror_root->children.front()->global_transform().translation, glm::vec3(107.f, 8.f, 19.f));
+
+    const auto &child_bone = mirror_root->children.front()->children.front();
+    EXPECT_EQ(child_bone->global_transform().translation, glm::vec3(107.f, 10.f, 19.f));
+    EXPECT_EQ(attachment->global_transform().translation, glm::vec3(107.f, 10.f, 20.f));
+
+    // moving the mesh-object moves everything below it, the mirror included
+    mesh_object->set_transform({.translation = {0.f, 0.f, 0.f}});
+    scene->update(0.0);
+    EXPECT_EQ(attachment->global_transform().translation, glm::vec3(7.f, 10.f, 20.f));
+}

--- a/tests/TestBoneMirror.cpp
+++ b/tests/TestBoneMirror.cpp
@@ -13,11 +13,13 @@ vierkant::MeshPtr create_skinned_mesh()
 
     auto root_bone = std::make_shared<nodes::node_t>();
     root_bone->name = "root_bone";
+    root_bone->id = nodes::NodeId::from_name(root_bone->name);
     root_bone->index = 0;
     root_bone->transform.translation = {1.f, 0.f, 0.f};
 
     auto child_bone = std::make_shared<nodes::node_t>();
     child_bone->name = "child_bone";
+    child_bone->id = nodes::NodeId::from_name(child_bone->name);
     child_bone->index = 1;
     child_bone->parent = root_bone;
     child_bone->transform.translation = {0.f, 2.f, 0.f};
@@ -37,7 +39,8 @@ TEST(BoneMirror, create_mirrors_the_hierarchy)
     auto scene = vierkant::Scene::create();
     auto mesh_object = scene->create_mesh_object({create_skinned_mesh()});
 
-    auto *mirror_root = scene->create_bone_mirror(mesh_object);
+    scene->ensure_bone_mirror(*mesh_object);
+    auto *mirror_root = vierkant::bone_mirror_root(*mesh_object);
     ASSERT_TRUE(mirror_root);
 
     // the root is unindexed and carries the skin-transform, the bones below mirror the node-hierarchy
@@ -55,16 +58,22 @@ TEST(BoneMirror, create_mirrors_the_hierarchy)
     EXPECT_EQ(child_bone->name, "child_bone");
     EXPECT_EQ(child_bone->get_component<bone_component_t>().index, 1);
 
-    // idempotent: a second call returns the existing mirror instead of adding another one
-    EXPECT_EQ(scene->create_bone_mirror(mesh_object), mirror_root);
+    // idempotent: a second call keeps the existing mirror instead of adding another one
+    scene->ensure_bone_mirror(*mesh_object);
+    EXPECT_EQ(vierkant::bone_mirror_root(*mesh_object), mirror_root);
     EXPECT_EQ(mesh_object->children.size(), 1);
+
+    // bones are addressed by their node-id, the root carries none
+    EXPECT_EQ(bone_object_by_id(*mesh_object, nodes::NodeId::from_name("child_bone")), child_bone.get());
+    EXPECT_EQ(bone_object_by_id(*mesh_object, nodes::NodeId::nil()), nullptr);
+    EXPECT_EQ(bone_object_by_id(*mesh_object, nodes::NodeId::from_name("nope")), nullptr);
 }
 
 TEST(BoneMirror, create_without_skeleton)
 {
     auto scene = vierkant::Scene::create();
     auto mesh_object = scene->create_mesh_object({vierkant::Mesh::create()});
-    EXPECT_EQ(scene->create_bone_mirror(mesh_object), nullptr);
+    scene->ensure_bone_mirror(*mesh_object);
     EXPECT_TRUE(mesh_object->children.empty());
 }
 
@@ -80,7 +89,8 @@ TEST(BoneMirror, update_drives_globals_and_attachments)
     mesh_object->set_transform({.translation = {100.f, 0.f, 0.f}});
     scene->add_object(mesh_object);
 
-    auto *mirror_root = scene->create_bone_mirror(mesh_object);
+    scene->ensure_bone_mirror(*mesh_object);
+    auto *mirror_root = vierkant::bone_mirror_root(*mesh_object);
     ASSERT_TRUE(mirror_root);
 
     // an ordinary object attached to the deepest bone
@@ -102,4 +112,47 @@ TEST(BoneMirror, update_drives_globals_and_attachments)
     mesh_object->set_transform({.translation = {0.f, 0.f, 0.f}});
     scene->update(0.0);
     EXPECT_EQ(attachment->global_transform().translation, glm::vec3(7.f, 10.f, 20.f));
+}
+
+TEST(BoneMirror, attachment_transform_survives_updates)
+{
+    auto scene = vierkant::Scene::create();
+    auto mesh = create_skinned_mesh();
+
+    // a moving root-bone, so the mirror is rewritten on every update
+    auto &keys = mesh->node_animations[0].keys[mesh->root_bone];
+    keys.positions[0.f] = {.value = {0.f, 0.f, 0.f}};
+    keys.positions[5.f] = {.value = {0.f, 100.f, 0.f}};
+
+    auto mesh_object = scene->create_mesh_object({mesh});
+    scene->add_object(mesh_object);
+    scene->ensure_bone_mirror(*mesh_object);
+
+    auto *bone = vierkant::bone_object_by_id(*mesh_object, nodes::NodeId::from_name("child_bone"));
+    ASSERT_TRUE(bone);
+
+    auto attachment = scene->create_object();
+    bone->add_child(attachment);
+
+    // set a local transform, the way the object-UI's text-fields do
+    const vierkant::transform_t local = {.translation = {1.f, 2.f, 3.f}};
+    attachment->set_transform(local);
+
+    const auto global_before = attachment->global_transform().translation;
+    for(uint32_t i = 0; i < 3; ++i) { scene->update(0.1); }
+    ASSERT_TRUE(attachment->transform());
+    EXPECT_EQ(attachment->transform()->translation, local.translation);
+
+    // the bone really did move, so the check above is not vacuous
+    EXPECT_NE(attachment->global_transform().translation, global_before);
+
+    // set a global transform, the way the guizmo does
+    const vierkant::transform_t global = {.translation = {10.f, 20.f, 30.f}};
+    attachment->set_global_transform(global);
+    EXPECT_EQ(attachment->global_transform().translation, global.translation);
+
+    // the bone keeps moving, so the attachment moves with it - but its local transform stays put
+    const auto relative = *attachment->transform();
+    for(uint32_t i = 0; i < 3; ++i) { scene->update(0.1); }
+    EXPECT_EQ(attachment->transform()->translation, relative.translation);
 }

--- a/tests/TestBundle.cpp
+++ b/tests/TestBundle.cpp
@@ -24,6 +24,12 @@ vierkant::model::model_assets_t dummy_assets()
     material.name = "test-material";
     material.roughness = 0.25f;
     assets.materials = {material};
+
+    // a single bone, covering nodes::node_t serialization
+    auto root_bone = std::make_shared<vierkant::nodes::node_t>();
+    root_bone->name = "root_bone";
+    root_bone->id = vierkant::nodes::NodeId::from_name(root_bone->name);
+    assets.root_bone = root_bone;
     return assets;
 }
 
@@ -54,6 +60,10 @@ TEST(Bundle, file_roundtrip)
     ASSERT_EQ(loaded->materials.size(), 1);
     EXPECT_EQ(loaded->materials[0].name, "test-material");
     EXPECT_EQ(loaded->materials[0].roughness, 0.25f);
+
+    ASSERT_TRUE(loaded->root_bone);
+    EXPECT_EQ(loaded->root_bone->name, "root_bone");
+    EXPECT_EQ(loaded->root_bone->id, vierkant::nodes::NodeId::from_name("root_bone"));
 
     const auto &bundle = std::get<vierkant::mesh_buffer_bundle_t>(loaded->geometry_data);
     EXPECT_EQ(bundle.vertex_stride, sizeof(vierkant::packed_vertex_t));

--- a/tests/TestNodes.cpp
+++ b/tests/TestNodes.cpp
@@ -1,0 +1,90 @@
+#include "vierkant/nodes.hpp"
+#include <gtest/gtest.h>
+
+using namespace vierkant;
+
+namespace
+{
+
+//! a two-bone chain: root -> child, both with a non-identity local transform and offset
+struct test_hierarchy_t
+{
+    nodes::NodePtr root, child;
+};
+
+test_hierarchy_t create_test_hierarchy()
+{
+    test_hierarchy_t ret;
+    ret.root = std::make_shared<nodes::node_t>();
+    ret.root->name = "root";
+    ret.root->index = 0;
+    ret.root->transform.translation = {1.f, 0.f, 0.f};
+    ret.root->offset.translation = {-100.f, 0.f, 0.f};
+
+    ret.child = std::make_shared<nodes::node_t>();
+    ret.child->name = "child";
+    ret.child->index = 1;
+    ret.child->parent = ret.root;
+    ret.child->transform.translation = {0.f, 2.f, 0.f};
+    ret.child->offset.translation = {0.f, -100.f, 0.f};
+    ret.root->children = {ret.child};
+    return ret;
+}
+
+}// namespace
+
+TEST(Nodes, build_local_transforms_bfs_without_animation)
+{
+    auto hierarchy = create_test_hierarchy();
+
+    std::vector<transform_t> transforms;
+    nodes::build_local_transforms_bfs(hierarchy.root, {}, 0.f, transforms);
+
+    ASSERT_EQ(transforms.size(), 2);
+
+    // local transforms are returned as-is: neither accumulated along the hierarchy nor offset-combined
+    EXPECT_EQ(transforms[0].translation, hierarchy.root->transform.translation);
+    EXPECT_EQ(transforms[1].translation, hierarchy.child->transform.translation);
+}
+
+TEST(Nodes, build_local_transforms_bfs_animated_node_stays_local)
+{
+    auto hierarchy = create_test_hierarchy();
+
+    // animate the root only
+    nodes::node_animation_t animation = {};
+    animation.keys[hierarchy.root].positions[0.f] = {.value = {7.f, 8.f, 9.f}};
+
+    std::vector<transform_t> transforms;
+    nodes::build_local_transforms_bfs(hierarchy.root, animation, 0.f, transforms);
+
+    ASSERT_EQ(transforms.size(), 2);
+
+    // sampled keys replace the node's own transform ...
+    EXPECT_EQ(transforms[0].translation, glm::vec3(7.f, 8.f, 9.f));
+
+    // ... and do not propagate to the child, in contrast to build_node_matrices_bfs
+    EXPECT_EQ(transforms[1].translation, hierarchy.child->transform.translation);
+}
+
+TEST(Nodes, build_node_matrices_bfs_accumulates_and_applies_offset)
+{
+    auto hierarchy = create_test_hierarchy();
+
+    std::vector<transform_t> matrices;
+    nodes::build_node_matrices_bfs(hierarchy.root, {}, 0.f, matrices);
+
+    ASSERT_EQ(matrices.size(), 2);
+
+    // the existing routine yields skinning-matrices: global * offset
+    EXPECT_EQ(matrices[0].translation, glm::vec3(1.f, 0.f, 0.f) + glm::vec3(-100.f, 0.f, 0.f));
+    EXPECT_EQ(matrices[1].translation, glm::vec3(1.f, 2.f, 0.f) + glm::vec3(0.f, -100.f, 0.f));
+}
+
+TEST(Nodes, num_nodes_and_lookup)
+{
+    auto hierarchy = create_test_hierarchy();
+    EXPECT_EQ(nodes::num_nodes_in_hierarchy(hierarchy.root), 2);
+    EXPECT_EQ(nodes::node_by_name(hierarchy.root, "child"), hierarchy.child);
+    EXPECT_EQ(nodes::node_by_name(hierarchy.root, "nope"), nullptr);
+}

--- a/tools/vierkant_ed/scene_cereal.hpp
+++ b/tools/vierkant_ed/scene_cereal.hpp
@@ -29,7 +29,8 @@ void serialize(Archive &ar, scene_node_t &scene_node)
        cereal::make_optional_nvp("physics_state", scene_node.physics_state),
        cereal::make_optional_nvp("constraints", scene_node.constraints),
        cereal::make_optional_nvp("camera_state", scene_node.camera_state),
-       cereal::make_optional_nvp("light_state", scene_node.light_state));
+       cereal::make_optional_nvp("light_state", scene_node.light_state),
+       cereal::make_optional_nvp("bone_anchor", scene_node.bone_anchor));
 }
 
 template<class Archive>

--- a/tools/vierkant_ed/scene_data.hpp
+++ b/tools/vierkant_ed/scene_data.hpp
@@ -54,6 +54,9 @@ struct scene_node_t
 
     //! optional lightsource-state
     std::optional<vierkant::lightsource_component_t> light_state = {};
+
+    //! optional id of a bone this node is attached to. its parent-node carries the skinned mesh.
+    std::optional<vierkant::nodes::NodeId> bone_anchor = {};
 };
 
 struct scene_data_t

--- a/tools/vierkant_ed/vierkant_ed.cpp
+++ b/tools/vierkant_ed/vierkant_ed.cpp
@@ -459,13 +459,6 @@ void VierkantEd::update(double time_delta)
     m_scene->animation_speed = m_settings.animation_playback ? m_settings.playback_speed : 0.0;
     m_scene->simulation_playback = m_settings.physics_playback;
 
-    // inspecting a skeleton is a mirror-trigger: bones have to exist as objects to be picked.
-    // built before the scene-update, so the mirror is driven the same frame it appears.
-    if(m_settings.draw_node_hierarchy)
-    {
-        for(const auto &obj: m_selected_objects) { m_scene->create_bone_mirror(obj); }
-    }
-
     // update animated objects, step the simulation, clear flags
     m_scene->update(time_delta);
 

--- a/tools/vierkant_ed/vierkant_ed.cpp
+++ b/tools/vierkant_ed/vierkant_ed.cpp
@@ -538,9 +538,13 @@ vierkant::window_delegate_t::draw_result_t VierkantEd::draw(const vierkant::Wind
                     auto &animation_state = obj->get_component<vierkant::animation_component_t>();
                     animation = mesh->node_animations[animation_state.index];
                     auto node = mesh->root_bone ? mesh->root_bone : mesh->root_node;
+
+                    // bone-transforms are relative to the skinned node, the node-hierarchy already
+                    // carries model-space transforms
+                    auto node_transform = mesh->root_bone ? modelview * mesh->skin_transform : modelview;
                     m_draw_context.draw_node_hierarchy(m_renderer_overlay, node, animation,
-                                                       static_cast<float>(animation_state.current_time), modelview,
-                                                       cam_projection);
+                                                       static_cast<float>(animation_state.current_time),
+                                                       node_transform, cam_projection);
                 }
             }
         }

--- a/tools/vierkant_ed/vierkant_ed.cpp
+++ b/tools/vierkant_ed/vierkant_ed.cpp
@@ -459,6 +459,13 @@ void VierkantEd::update(double time_delta)
     m_scene->animation_speed = m_settings.animation_playback ? m_settings.playback_speed : 0.0;
     m_scene->simulation_playback = m_settings.physics_playback;
 
+    // inspecting a skeleton is a mirror-trigger: bones have to exist as objects to be picked.
+    // built before the scene-update, so the mirror is driven the same frame it appears.
+    if(m_settings.draw_node_hierarchy)
+    {
+        for(const auto &obj: m_selected_objects) { m_scene->create_bone_mirror(obj); }
+    }
+
     // update animated objects, step the simulation, clear flags
     m_scene->update(time_delta);
 

--- a/tools/vierkant_ed/vierkant_ed_load_store.cpp
+++ b/tools/vierkant_ed/vierkant_ed_load_store.cpp
@@ -452,6 +452,10 @@ void VierkantEd::save_scene(std::filesystem::path path)
         // editor-layer objects are tool-state, not scene-content. skip them and their subtrees.
         if(obj.layers & vierkant::LAYER_EDITOR) { return false; }
 
+        // bone-objects mirror a mesh's skeleton and are re-created on demand, so they are not
+        // emitted. anything attached below them is ordinary content, so keep descending.
+        if(obj.has_component<vierkant::bone_component_t>()) { return true; }
+
         obj_to_node_index[&obj] = data.nodes.size();
 
         scene_node_t &node = data.nodes.emplace_back();
@@ -539,7 +543,14 @@ void VierkantEd::save_scene(std::filesystem::path path)
             if(flags_cmp->scene_id) { return false; }
         }
         auto &node = data.nodes[obj_to_node_index[&obj]];
-        for(const auto &child: obj.children) { node.children.push_back(obj_to_node_index[child.get()]); }
+        for(const auto &child: obj.children)
+        {
+            // children that were skipped above (editor-layer, bones) have no node to point at
+            if(auto it = obj_to_node_index.find(child.get()); it != obj_to_node_index.end())
+            {
+                node.children.push_back(it->second);
+            }
+        }
 
         if(auto *mesh_component = obj.get_component_ptr<vierkant::mesh_component_t>())
         {

--- a/tools/vierkant_ed/vierkant_ed_load_store.cpp
+++ b/tools/vierkant_ed/vierkant_ed_load_store.cpp
@@ -445,6 +445,9 @@ void VierkantEd::save_scene(std::filesystem::path path)
     std::unordered_set<vierkant::MeshId> mesh_ids;
     std::map<vierkant::Object3D *, size_t> obj_to_node_index;
 
+    // bone-attached objects, paired with the nearest non-bone ancestor they are emitted under
+    std::vector<std::pair<vierkant::Object3D *, uint32_t>> bone_attachments;
+
     vierkant::LambdaVisitor visitor;
     visitor.traverse(*m_scene->root(), [&](vierkant::Object3D &obj) -> bool {
         if(&obj == m_scene->root().get()) { return true; }
@@ -456,13 +459,24 @@ void VierkantEd::save_scene(std::filesystem::path path)
         // emitted. anything attached below them is ordinary content, so keep descending.
         if(obj.has_component<vierkant::bone_component_t>()) { return true; }
 
-        obj_to_node_index[&obj] = data.nodes.size();
+        auto node_index = static_cast<uint32_t>(data.nodes.size());
+        obj_to_node_index[&obj] = node_index;
 
         scene_node_t &node = data.nodes.emplace_back();
         node.name = obj.name;
         node.enabled = obj.enabled;
         if(const auto *obj_transform = obj.transform()) { node.transform = *obj_transform; }
         node.transform_space = obj.transform_space();
+
+        // attached to a bone: anchor by bone-id and emit the node under the nearest non-bone ancestor,
+        // since the bones in between have no node to be a child of.
+        auto *ancestor = obj.parent();
+        if(const auto *bone_cmp = ancestor ? ancestor->get_component_ptr<vierkant::bone_component_t>() : nullptr)
+        {
+            node.bone_anchor = bone_cmp->node_id;
+            while(ancestor && ancestor->has_component<vierkant::bone_component_t>()) { ancestor = ancestor->parent(); }
+            if(ancestor) { bone_attachments.emplace_back(ancestor, node_index); }
+        }
 
         if(auto *flags_cmp = obj.get_component_ptr<vierkant::subscene_component_t>())
         {
@@ -523,8 +537,14 @@ void VierkantEd::save_scene(std::filesystem::path path)
         return true;
     });
 
-    // add top-lvl scenegraph-nodes
-    for(const auto &child: m_scene->root()->children) { data.scene_roots.push_back(obj_to_node_index[child.get()]); }
+    // add top-lvl scenegraph-nodes. children skipped above (editor-layer) have no node to point at.
+    for(const auto &child: m_scene->root()->children)
+    {
+        if(auto it = obj_to_node_index.find(child.get()); it != obj_to_node_index.end())
+        {
+            data.scene_roots.push_back(static_cast<uint32_t>(it->second));
+        }
+    }
 
     // the camera we look through, if it is one of this scene's own nodes. the editor-camera has no
     // node (it is skipped above), and neither has a camera inside a sub-scene instance - both leave
@@ -560,6 +580,15 @@ void VierkantEd::save_scene(std::filesystem::path path)
         }
         return true;
     });
+
+    // link bone-attachments, the loop above only sees direct children
+    for(const auto &[ancestor, node_index]: bone_attachments)
+    {
+        if(auto it = obj_to_node_index.find(ancestor); it != obj_to_node_index.end())
+        {
+            data.nodes[it->second].children.push_back(node_index);
+        }
+    }
 
     std::ofstream ofs(path.string());
     try
@@ -780,6 +809,24 @@ void VierkantEd::build_scene(const std::optional<scene_data_t> &scene_data_in, b
                 {
                     out_objects[i]->add_child(out_objects[child_index]);
                 }
+            }
+
+            // re-attach bone-anchored objects. the save-rule linked them to the mesh-object,
+            // so their current parent is the object owning the skeleton.
+            for(uint32_t i = 0; i < scene_data.nodes.size(); ++i)
+            {
+                const auto &node = scene_data.nodes[i];
+                if(!node.bone_anchor) { continue; }
+
+                vierkant::Object3D *bone_object = nullptr;
+
+                if(auto *mesh_object = out_objects[i]->parent())
+                {
+                    m_scene->ensure_bone_mirror(*mesh_object);
+                    bone_object = vierkant::bone_object_by_id(*mesh_object, *node.bone_anchor);
+                }
+                if(bone_object) { bone_object->add_child(out_objects[i]); }
+                else { spdlog::warn("could not resolve bone-anchor for node: {}", node.name); }
             }
 
             // add scene-roots


### PR DESCRIPTION
- expose bones as regular, mirrored scenegraph-nodes
-> allowing to attach objects to individual bones
-> no animals were harmed by using strings for lookup 