### PR TITLE
fix stale gamepad-axes on a freshly connected pad

### DIFF
--- a/include/vierkant/Input.hpp
+++ b/include/vierkant/Input.hpp
@@ -222,6 +222,7 @@ public:
     /**
      * @brief   construct a joystick-state.
      *
+     * @param   device_id           device-handle, stable while the device stays connected.
      * @param   name                display-name.
      * @param   buttons             button-states.
      * @param   axis                axis-values.
@@ -230,8 +231,11 @@ public:
      *
      * @note    @p buttons / @p axis are expected in canonical gamepad-order.
      */
-    Joystick(std::string name, std::vector<uint8_t> buttons, std::vector<float> axis,
+    Joystick(uint64_t device_id, std::string name, std::vector<uint8_t> buttons, std::vector<float> axis,
              const std::vector<uint8_t> &previous_buttons = {}, rumble_fn_t rumble_fn = {});
+
+    //! device-handle, stable while the device stays connected. never reused.
+    uint64_t device_id() const;
 
     const std::string &name() const;
 
@@ -259,6 +263,7 @@ public:
     bool rumble(float strong, float weak, uint32_t duration_ms) const;
 
 private:
+    uint64_t m_device_id = 0;
     std::string m_name;
     std::vector<uint8_t> m_buttons;
     std::vector<float> m_axis;

--- a/src/Input.cpp
+++ b/src/Input.cpp
@@ -58,9 +58,9 @@ static glm::vec2 analog_value(const std::vector<float> &axis, uint32_t index_h, 
             sign_v * glm::smoothstep(dead_zone, 1.f, fabsf(axis[index_v]))};
 }
 
-Joystick::Joystick(std::string name, std::vector<uint8_t> buttons, std::vector<float> axis,
+Joystick::Joystick(uint64_t device_id, std::string name, std::vector<uint8_t> buttons, std::vector<float> axis,
                    const std::vector<uint8_t> &previous_buttons, rumble_fn_t rumble_fn)
-    : m_name(std::move(name)), m_buttons(std::move(buttons)), m_axis(std::move(axis)),
+    : m_device_id(device_id), m_name(std::move(name)), m_buttons(std::move(buttons)), m_axis(std::move(axis)),
       m_rumble_fn(std::move(rumble_fn))
 {
     if(m_buttons.size() == previous_buttons.size())
@@ -76,6 +76,8 @@ Joystick::Joystick(std::string name, std::vector<uint8_t> buttons, std::vector<f
         }
     }
 }
+
+uint64_t Joystick::device_id() const { return m_device_id; }
 
 const std::string &Joystick::name() const { return m_name; }
 

--- a/src/Window.cpp
+++ b/src/Window.cpp
@@ -1,3 +1,4 @@
+#include <algorithm>
 #include <vierkant/Window.hpp>
 
 #define GLFW_INCLUDE_NONE
@@ -103,19 +104,21 @@ std::vector<Joystick> get_joystick_states(const std::vector<Joystick> &previous_
     std::vector<Joystick> ret;
     ret.reserve(gamepad_states.size());
 
-    for(uint32_t i = 0; i < gamepad_states.size(); ++i)
+    for(auto &state: gamepad_states)
     {
-        auto &state = gamepad_states[i];
-
+        // match the previous state by device-id. a position in the list is not an identity,
+        // it shifts when a device is added or removed.
+        auto previous = std::ranges::find_if(
+                previous_joysticks, [&state](const Joystick &js) { return js.device_id() == state.id; });
         std::vector<uint8_t> previous_buttons;
-        if(i < previous_joysticks.size()) { previous_buttons = previous_joysticks[i].buttons(); }
+        if(previous != previous_joysticks.end()) { previous_buttons = previous->buttons(); }
 
         const uint64_t device_id = state.id;
         auto rumble_fn = [device_id](float strong, float weak, uint32_t duration_ms) {
             return gamepad::rumble(device_id, strong, weak, duration_ms);
         };
-        ret.emplace_back(std::move(state.name), std::move(state.buttons), std::move(state.axis), previous_buttons,
-                         std::move(rumble_fn));
+        ret.emplace_back(device_id, std::move(state.name), std::move(state.buttons), std::move(state.axis),
+                         previous_buttons, std::move(rumble_fn));
     }
     return ret;
 }

--- a/src/gamepad_evdev.cpp
+++ b/src/gamepad_evdev.cpp
@@ -43,6 +43,13 @@ float normalize_axis(const input_absinfo &abs, bool centered)
     return centered ? t * 2.f - 1.f : t;
 }
 
+bool axis_unreported(const input_absinfo &abs)
+{
+    // the kernel zero-initializes its axis-values, so an unreported axis reads as 0. on an unsigned
+    // range that is hard-deflection, on a signed one it is the rest-position and nothing is wrong.
+    return abs.minimum >= 0 && abs.value == abs.minimum;
+}
+
 namespace
 {
 
@@ -62,6 +69,9 @@ struct device_t
     bool dpad_is_hat = false;
     bool has_rumble = false;
 
+    //! set while the device has not reported yet - its stick-axes are a kernel-default, not a rest-position.
+    bool sticks_unreported = false;
+
     //! id of a single uploaded FF_RUMBLE-effect, re-uploaded in place. -1 means: none allocated yet.
     int16_t effect_id = -1;
 };
@@ -77,6 +87,17 @@ void close_device(device_t &device)
     if(device.effect_id >= 0) { ioctl(device.fd, EVIOCRMFF, device.effect_id); }
     close(device.fd);
     device.fd = -1;
+}
+
+//! true if any stick still carries the kernel-default, i.e. the device has not reported yet
+bool no_reports_yet(int fd, const axis_layout_t &layout)
+{
+    for(int code: {ABS_X, ABS_Y, layout.right_x, layout.right_y})
+    {
+        input_absinfo abs = {};
+        if(ioctl(fd, EVIOCGABS(code), &abs) == 0 && axis_unreported(abs)) { return true; }
+    }
+    return false;
 }
 
 std::optional<device_t> open_device(const std::string &node, bool &access_denied)
@@ -113,6 +134,7 @@ std::optional<device_t> open_device(const std::string &node, bool &access_denied
     device.layout = detect_axis_layout(abs_bits);
     device.dpad_is_hat = test_bit(ABS_HAT0X, abs_bits);
     device.has_rumble = read_write && test_bit(FF_RUMBLE, ff_bits);
+    device.sticks_unreported = no_reports_yet(fd, device.layout);
 
     if(!read_write && test_bit(FF_RUMBLE, ff_bits))
     {
@@ -180,12 +202,18 @@ void poll_hotplug()
 }
 
 //! drain the device's event-queue. we poll state via ioctl, but an unread queue grows and hides device-loss.
-bool drain_events(const device_t &device)
+bool drain_events(device_t &device)
 {
     input_event events[32];
     for(;;)
     {
         ssize_t num_bytes = read(device.fd, events, sizeof(events));
+
+        // an EV_ABS means the kernel has seen a report, so its axis-values are real from here on
+        for(ssize_t i = 0; device.sticks_unreported && i < num_bytes / static_cast<ssize_t>(sizeof(input_event)); ++i)
+        {
+            if(events[i].type == EV_ABS) { device.sticks_unreported = false; }
+        }
         if(num_bytes < 0) { return errno == EAGAIN || errno == EWOULDBLOCK || errno == EINTR; }
         if(num_bytes < static_cast<ssize_t>(sizeof(events))) { return true; }
     }
@@ -207,6 +235,12 @@ bool read_state(const device_t &device, state_t &out)
     out.axis[GLFW_GAMEPAD_AXIS_LEFT_Y] = read_axis(ABS_Y, true);
     out.axis[GLFW_GAMEPAD_AXIS_RIGHT_X] = read_axis(device.layout.right_x, true);
     out.axis[GLFW_GAMEPAD_AXIS_RIGHT_Y] = read_axis(device.layout.right_y, true);
+
+    if(device.sticks_unreported)
+    {
+        out.axis[GLFW_GAMEPAD_AXIS_LEFT_X] = out.axis[GLFW_GAMEPAD_AXIS_LEFT_Y] = 0.f;
+        out.axis[GLFW_GAMEPAD_AXIS_RIGHT_X] = out.axis[GLFW_GAMEPAD_AXIS_RIGHT_Y] = 0.f;
+    }
 
     // triggers are one-sided, but the canonical layout expects them in [-1, 1]
     out.axis[GLFW_GAMEPAD_AXIS_LEFT_TRIGGER] = read_axis(device.layout.trigger_left, false) * 2.f - 1.f;

--- a/src/gamepad_evdev.hpp
+++ b/src/gamepad_evdev.hpp
@@ -36,6 +36,9 @@ axis_layout_t detect_axis_layout(const unsigned long *abs_bits);
 //! map a raw axis-value into [0, 1], or into [-1, 1] if @p centered.
 float normalize_axis(const input_absinfo &abs, bool centered);
 
+//! true if a centered axis still carries the kernel-default, i.e. no report has arrived yet.
+bool axis_unreported(const input_absinfo &abs);
+
 }// namespace vierkant::gamepad
 
 #endif// __linux__

--- a/tests/TestGamepadEvdev.cpp
+++ b/tests/TestGamepadEvdev.cpp
@@ -85,4 +85,18 @@ TEST(GamepadEvdev, out_of_range_and_degenerate_axes_stay_bounded)
     EXPECT_FLOAT_EQ(normalize_axis(make_absinfo(0, 0, 0), false), 0.f);
 }
 
+//! regression: a pad that has not reported yet used to read as both sticks fully deflected,
+//! because the kernel's zero-initialized axis-value is the minimum of an unsigned stick-range.
+TEST(GamepadEvdev, an_unreported_stick_is_recognized)
+{
+    // hid-generic sticks are 0..65535 and rest near the middle, so 0 cannot be a rest-position
+    EXPECT_TRUE(axis_unreported(make_absinfo(0, 0, 65535)));
+    EXPECT_FALSE(axis_unreported(make_absinfo(32768, 0, 65535)));
+    EXPECT_FALSE(axis_unreported(make_absinfo(65535, 0, 65535)));
+
+    // xpad sticks are -32768..32767 and rest at 0, which is why the defect never showed there
+    EXPECT_FALSE(axis_unreported(make_absinfo(0, -32768, 32767)));
+    EXPECT_FALSE(axis_unreported(make_absinfo(-32768, -32768, 32767)));
+}
+
 #endif// __linux__

--- a/tests/TestInput.cpp
+++ b/tests/TestInput.cpp
@@ -23,7 +23,7 @@ std::vector<uint8_t> canonical_buttons(std::initializer_list<uint32_t> pressed)
 TEST(Input, gamepad_axes_are_read_from_canonical_slots)
 {
     // sticks fully deflected, left trigger fully pressed, right trigger released
-    Joystick js("pad", canonical_buttons({}), canonical_axis(1.f, 0.f, 0.f, -1.f, 1.f, -1.f));
+    Joystick js(1, "pad", canonical_buttons({}), canonical_axis(1.f, 0.f, 0.f, -1.f, 1.f, -1.f));
 
     EXPECT_FLOAT_EQ(js.analog_left().x, 1.f);
     EXPECT_FLOAT_EQ(js.analog_left().y, 0.f);
@@ -37,30 +37,30 @@ TEST(Input, gamepad_axes_are_read_from_canonical_slots)
 
 TEST(Input, gamepad_dpad_is_read_from_canonical_slots)
 {
-    EXPECT_EQ(Joystick("pad", canonical_buttons({11}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
+    EXPECT_EQ(Joystick(1, "pad", canonical_buttons({11}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
               glm::vec2(0.f, 1.f));// up
-    EXPECT_EQ(Joystick("pad", canonical_buttons({12}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
+    EXPECT_EQ(Joystick(1, "pad", canonical_buttons({12}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
               glm::vec2(1.f, 0.f));// right
-    EXPECT_EQ(Joystick("pad", canonical_buttons({13}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
+    EXPECT_EQ(Joystick(1, "pad", canonical_buttons({13}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
               glm::vec2(0.f, -1.f));// down
-    EXPECT_EQ(Joystick("pad", canonical_buttons({14}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
+    EXPECT_EQ(Joystick(1, "pad", canonical_buttons({14}), canonical_axis(0, 0, 0, 0, -1, -1)).dpad(),
               glm::vec2(-1.f, 0.f));// left
 }
 
 TEST(Input, gamepad_button_events_are_edge_triggered)
 {
     auto previous = canonical_buttons({});
-    Joystick pressed("pad", canonical_buttons({0}), canonical_axis(0, 0, 0, 0, -1, -1), previous);
+    Joystick pressed(1, "pad", canonical_buttons({0}), canonical_axis(0, 0, 0, 0, -1, -1), previous);
 
     ASSERT_EQ(pressed.input_events().size(), 1);
     ASSERT_TRUE(pressed.input_events().contains(Joystick::Input::BUTTON_A));
     EXPECT_EQ(pressed.input_events().at(Joystick::Input::BUTTON_A), Joystick::Event::BUTTON_PRESS);
 
     // holding the same button is not an event
-    Joystick held("pad", canonical_buttons({0}), canonical_axis(0, 0, 0, 0, -1, -1), pressed.buttons());
+    Joystick held(1, "pad", canonical_buttons({0}), canonical_axis(0, 0, 0, 0, -1, -1), pressed.buttons());
     EXPECT_TRUE(held.input_events().empty());
 
-    Joystick released("pad", canonical_buttons({}), canonical_axis(0, 0, 0, 0, -1, -1), held.buttons());
+    Joystick released(1, "pad", canonical_buttons({}), canonical_axis(0, 0, 0, 0, -1, -1), held.buttons());
     ASSERT_TRUE(released.input_events().contains(Joystick::Input::BUTTON_A));
     EXPECT_EQ(released.input_events().at(Joystick::Input::BUTTON_A), Joystick::Event::BUTTON_RELEASE);
 }
@@ -73,7 +73,7 @@ TEST(Input, no_button_index_aliases_another_input)
 
     for(uint32_t i = 0; i < 15; ++i)
     {
-        Joystick js("pad", canonical_buttons({i}), canonical_axis(0, 0, 0, 0, -1, -1), canonical_buttons({}));
+        Joystick js(1, "pad", canonical_buttons({i}), canonical_axis(0, 0, 0, 0, -1, -1), canonical_buttons({}));
         ASSERT_EQ(js.input_events().size(), 1) << "button " << i << " produced no unique event";
 
         const auto input = js.input_events().begin()->first;
@@ -86,7 +86,7 @@ TEST(Input, no_button_index_aliases_another_input)
 //! a device reporting fewer axes/buttons than the canonical layout must not read out of bounds
 TEST(Input, degenerate_devices_are_survivable)
 {
-    Joystick empty("nothing", {}, {});
+    Joystick empty(1, "nothing", {}, {});
     EXPECT_EQ(empty.analog_left(), glm::vec2(0.f));
     EXPECT_EQ(empty.analog_right(), glm::vec2(0.f));
     EXPECT_EQ(empty.trigger(), glm::vec2(0.f));
@@ -94,7 +94,7 @@ TEST(Input, degenerate_devices_are_survivable)
     EXPECT_TRUE(empty.input_events().empty());
 
     // two axes, no buttons
-    Joystick partial("stick", {}, {1.f, 1.f});
+    Joystick partial(1, "stick", {}, {1.f, 1.f});
     EXPECT_FLOAT_EQ(partial.analog_left().x, 1.f);
     EXPECT_EQ(partial.analog_right(), glm::vec2(0.f));
     EXPECT_EQ(partial.trigger(), glm::vec2(0.f));


### PR DESCRIPTION
- evdev: ignore stick-axes until the device sends its first report. the kernel's zero-initialized value is hard-deflection on an unsigned stick-range
- Joystick carries its device-id, get_joystick_states matches the previous state by id instead of by list-position
- test: an unreported stick is recognized