### PR TITLE
animation: per-object interpolation-mode override

### DIFF
--- a/include/vierkant/DrawContext.hpp
+++ b/include/vierkant/DrawContext.hpp
@@ -129,12 +129,14 @@ public:
      * @param   node            a provided vierkant::nodes::NodeConstPtr.
      * @param   animation       an optional vierkant::nodes::node_animation_t
      * @param   animation_time  current animation-time
+     * @param   interpolation   a vierkant::InterpolationMode
      * @param   transform   a modelview transform
      * @param   projection      the projection matrix to use for drawing.
      */
     void draw_node_hierarchy(vierkant::Rasterizer &renderer, const vierkant::nodes::NodeConstPtr &node,
                              const vierkant::nodes::node_animation_t &animation, float animation_time,
-                             const vierkant::transform_t &transform, const glm::mat4 &projection);
+                             vierkant::InterpolationMode interpolation, const vierkant::transform_t &transform,
+                             const glm::mat4 &projection);
 
     /**
      * @brief   Render a skybox.

--- a/include/vierkant/Geometry.hpp
+++ b/include/vierkant/Geometry.hpp
@@ -6,7 +6,6 @@
 
 #include <vierkant/Device.hpp>
 #include <vierkant/math.hpp>
-#include <vierkant/nodes.hpp>
 
 namespace vierkant
 {

--- a/include/vierkant/Mesh.hpp
+++ b/include/vierkant/Mesh.hpp
@@ -9,6 +9,7 @@
 #include "vierkant/Geometry.hpp"
 #include "vierkant/Material.hpp"
 #include <vierkant/intersection.hpp>
+#include <vierkant/nodes.hpp>
 #include <vierkant/transform.hpp>
 #include <vierkant/vertex_attrib.hpp>
 

--- a/include/vierkant/animation.hpp
+++ b/include/vierkant/animation.hpp
@@ -57,6 +57,10 @@ template<typename T>
 struct animation_t
 {
     std::string name;
+
+    //! time of the first key. clips need not start at zero.
+    float start_time = 0.f;
+
     float duration = 0.f;
     float ticks_per_sec = 1.f;
     std::map<T, animation_keys_t> keys;
@@ -100,8 +104,9 @@ void update_animation(const animation_t<T> &animation, double time_delta,
     if(animation_state.playing)
     {
         animation_state.current_time += time_delta * animation.ticks_per_sec * animation_state.animation_speed;
-        if(animation_state.current_time > animation.duration) { animation_state.current_time -= animation.duration; }
-        animation_state.current_time += animation_state.current_time < 0.f ? animation.duration : 0.f;
+        const auto end_time = animation.start_time + animation.duration;
+        if(animation_state.current_time > end_time) { animation_state.current_time -= animation.duration; }
+        animation_state.current_time += animation_state.current_time < animation.start_time ? animation.duration : 0.f;
     }
 }
 

--- a/include/vierkant/animation.hpp
+++ b/include/vierkant/animation.hpp
@@ -77,6 +77,9 @@ struct animation_component_t_
     //! index into an array of animations
     uint32_t index = 0;
 
+    //! interpolation-mode, seeded from the selected animation
+    InterpolationMode interpolation_mode = InterpolationMode::Linear;
+
     //! true if animation is playing
     bool playing = true;
 

--- a/include/vierkant/drawable.hpp
+++ b/include/vierkant/drawable.hpp
@@ -129,6 +129,7 @@ struct create_mesh_drawables_params_t
     int32_t lod_index = 0;
 
     uint32_t animation_index = 0;
+    vierkant::InterpolationMode interpolation_mode = vierkant::InterpolationMode::Linear;
     float animation_time = 0.f;
 };
 

--- a/include/vierkant/model/model_loading.hpp
+++ b/include/vierkant/model/model_loading.hpp
@@ -10,8 +10,6 @@
 
 #include <crocore/Image.hpp>
 #include <crocore/ThreadPoolClassic.hpp>
-
-#include <vierkant/Geometry.hpp>
 #include <vierkant/Material.hpp>
 #include <vierkant/Mesh.hpp>
 #include <vierkant/camera_params.hpp>
@@ -48,26 +46,26 @@ struct camera_t
 
 struct omm_gen_params_t
 {
-    int   max_level   = 4;
+    int max_level = 4;
     float target_edge = 0.5f;
-    int   states      = 4;  // 4 = VK_OPACITY_MICROMAP_FORMAT_4_STATE_EXT
+    int states = 4;// 4 = VK_OPACITY_MICROMAP_FORMAT_4_STATE_EXT
 };
 
 struct mesh_omm_entry_t
 {
-    std::vector<uint8_t>               data;
+    std::vector<uint8_t> data;
     std::vector<VkMicromapTriangleEXT> triangles;
-    std::vector<int32_t>               indices;
+    std::vector<int32_t> indices;
 };
 
 //! bundle-relative OMM data: keyed only on {entry_index, color_texture_id} (no runtime mesh_id),
 //! so it can be serialized into the asset-bundle and adopted at load-time.
 struct mesh_omm_data_t
 {
-    uint32_t            entry_index = 0;
+    uint32_t entry_index = 0;
     //! the Color-texture id determines the baked alpha-mask; captured at bake time
     vierkant::TextureId color_texture_id;
-    mesh_omm_entry_t    entry;
+    mesh_omm_entry_t entry;
 };
 
 /**
@@ -119,8 +117,8 @@ constexpr uint32_t bundle_schema_version = 6;
 
 struct mesh_omm_key_t
 {
-    vierkant::MeshId    mesh_id;
-    uint32_t            entry_index = 0;
+    vierkant::MeshId mesh_id;
+    uint32_t entry_index = 0;
     //! the Color-texture id determines the baked alpha-mask; keying on it (rather than material-id)
     //! dedupes materials sharing a texture and invalidates correctly when a material is re-textured
     vierkant::TextureId color_texture_id;

--- a/include/vierkant/model/model_loading.hpp
+++ b/include/vierkant/model/model_loading.hpp
@@ -113,7 +113,7 @@ struct model_assets_t
 
 //! schema-version folded into the bundle cache-key; bump on any parsing/serialization change that
 //! would make existing bundles decode wrong. layout-sizes are covered by serialized_layout_hash().
-constexpr uint32_t bundle_schema_version = 6;
+constexpr uint32_t bundle_schema_version = 7;
 
 struct mesh_omm_key_t
 {

--- a/include/vierkant/nodes.hpp
+++ b/include/vierkant/nodes.hpp
@@ -6,10 +6,8 @@
 
 #include <crocore/NamedUUID.hpp>
 #include <list>
-#include <map>
 #include <memory>
 #include <vierkant/animation.hpp>
-#include <vierkant/math.hpp>
 #include <vierkant/transform.hpp>
 
 namespace vierkant::nodes
@@ -52,18 +50,19 @@ uint32_t num_nodes_in_hierarchy(const NodeConstPtr &root);
  * @param   name    the name to search for.
  * @return  the found NodePtr or nullptr, if the name could not be found in the hierarchy.
  */
-NodeConstPtr node_by_name(const NodeConstPtr& root, const std::string &name);
+NodeConstPtr node_by_name(const NodeConstPtr &root, const std::string &name);
 
 /**
  * @brief   Create transformation matrices, matching the provided node-hierarchy and animation.
  *
- * @param   root        a root node of a node-hierarchy.
- * @param   animation   a const-ref for an animation_t object.
- * @param   time        current time.
- * @param   matrices    ref to an array of transformation-matrices. will be populated by this function.
+ * @param   root            a root node of a node-hierarchy.
+ * @param   animation       a const-ref for an animation_t object.
+ * @param   time            current time.
+ * @param   interpolation   a vierkant::InterpolationMode
+ * @param   transforms      ref to an array of transformation-matrices. will be populated by this function.
  */
 void build_node_matrices_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
-                             std::vector<vierkant::transform_t> &transforms);
+                             vierkant::InterpolationMode interpolation, std::vector<vierkant::transform_t> &transforms);
 
 /**
  * @brief   Create local transformation matrices, matching the provided node-hierarchy and animation.
@@ -74,9 +73,11 @@ void build_node_matrices_bfs(const NodeConstPtr &root, const node_animation_t &a
  * @param   root        a root node of a node-hierarchy.
  * @param   animation   a const-ref for an animation_t object.
  * @param   time        current time.
+ * @param   interpolation   a vierkant::InterpolationMode
  * @param   transforms  ref to an array of transformation-matrices. will be populated by this function.
  */
 void build_local_transforms_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+                                vierkant::InterpolationMode interpolation,
                                 std::vector<vierkant::transform_t> &transforms);
 
 /**
@@ -86,10 +87,11 @@ void build_local_transforms_bfs(const NodeConstPtr &root, const node_animation_t
  * @param   root            a root node of a node-hierarchy.
  * @param   animation       a const-ref for an animation_t object.
  * @param   time            current time.
+ * @param   interpolation   a vierkant::InterpolationMode
  * @param   morph_weights   ref to an array of morph-weights. will be populated by this function.
  */
 template<typename T = float, typename = std::enable_if<std::is_floating_point_v<T>>>
 void build_morph_weights_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
-                             std::vector<std::vector<T>> &morph_weights);
+                             vierkant::InterpolationMode interpolation, std::vector<std::vector<T>> &morph_weights);
 
 }// namespace vierkant::nodes

--- a/src/DrawContext.cpp
+++ b/src/DrawContext.cpp
@@ -171,6 +171,7 @@ void DrawContext::draw_mesh(vierkant::Rasterizer &renderer, const vierkant::Mesh
 
 void DrawContext::draw_node_hierarchy(vierkant::Rasterizer &renderer, const vierkant::nodes::NodeConstPtr &root_node,
                                       const vierkant::nodes::node_animation_t &animation, float animation_time,
+                                      vierkant::InterpolationMode interpolation,
                                       const vierkant::transform_t &transform, const glm::mat4 &projection)
 {
     if(!root_node) { return; }
@@ -193,7 +194,7 @@ void DrawContext::draw_node_hierarchy(vierkant::Rasterizer &renderer, const vier
         if(it != animation.keys.end())
         {
             const auto &animation_keys = it->second;
-            create_animation_transform(animation_keys, animation_time, animation.interpolation_mode, node_transform);
+            create_animation_transform(animation_keys, animation_time, interpolation, node_transform);
         }
         joint_transform = joint_transform * node_transform;
 

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -333,10 +333,10 @@ void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr
                 flag_cmp.timestamp(flag_component_t::DIRTY_LIGHT) + m_frame_contexts.size() >= frame_thresh;
         if(light_dirty || object->has_component<vierkant::lightsource_component_t>())
         {
-            frame_context.lights_dirty = frame_context.lights_dirty || light_dirty ||
-                                         last_inherited_flag_update(object, flag_component_t::DIRTY_TRANSFORM) +
-                                                         m_frame_contexts.size() >=
-                                                 frame_thresh;
+            frame_context.lights_dirty =
+                    frame_context.lights_dirty || light_dirty ||
+                    last_inherited_flag_update(object, flag_component_t::DIRTY_TRANSFORM) + m_frame_contexts.size() >=
+                            frame_thresh;
         }
 
         const auto *mesh_component = object->get_component_ptr<mesh_component_t>();
@@ -362,10 +362,11 @@ void PBRDeferred::update_recycling(const SceneConstPtr &scene, const Object3DPtr
 
         if(animation_update)
         {
-            const vierkant::object_component auto &animation_state = object->get_component<animation_component_t>();
-            const auto &animation = mesh->node_animations[animation_state.index];
+            const vierkant::object_component auto &animation_cmp = object->get_component<animation_component_t>();
+            const auto &animation = mesh->node_animations[animation_cmp.index];
             vierkant::nodes::build_node_matrices_bfs(mesh->root_node, animation,
-                                                     static_cast<float>(animation_state.current_time), node_transforms);
+                                                     static_cast<float>(animation_cmp.current_time),
+                                                     animation_cmp.interpolation_mode, node_transforms);
             flag_cmp.flags |= flag_component_t::DIRTY_TRANSFORM;
         }
 
@@ -1248,8 +1249,7 @@ vierkant::ImagePtr PBRDeferred::post_fx_pass(const Object3DPtr &cam, const vierk
 
         const auto &cam_cmp = cam->get_component<camera_component_t>();
 
-        if(cam_cmp.projection == vierkant::camera_component_t::PERSPECTIVE &&
-           !drawable.descriptors[1].buffers.empty())
+        if(cam_cmp.projection == vierkant::camera_component_t::PERSPECTIVE && !drawable.descriptors[1].buffers.empty())
         {
             const auto &cam_params = cam_cmp.physical;
             depth_of_field_params_t dof_params = {};

--- a/src/RayBuilder.cpp
+++ b/src/RayBuilder.cpp
@@ -478,13 +478,14 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
 
         if(!(mesh->root_bone || mesh->morph_buffer) && object->has_component<animation_component_t>())
         {
-            vierkant::object_component auto &animation_state = object->get_component<animation_component_t>();
+            vierkant::object_component auto &animation_cmp = object->get_component<animation_component_t>();
 
-            if(animation_state.index < mesh->node_animations.size())
+            if(animation_cmp.index < mesh->node_animations.size())
             {
-                const auto &animation = mesh->node_animations[animation_state.index];
-                vierkant::nodes::build_node_matrices_bfs(
-                        mesh->root_node, animation, static_cast<float>(animation_state.current_time), node_transforms);
+                const auto &animation = mesh->node_animations[animation_cmp.index];
+                vierkant::nodes::build_node_matrices_bfs(mesh->root_node, animation,
+                                                         static_cast<float>(animation_cmp.current_time),
+                                                         animation_cmp.interpolation_mode, node_transforms);
             }
         }
         auto obj_global_transform = object->global_transform();
@@ -578,7 +579,8 @@ RayBuilder::scene_acceleration_data_t RayBuilder::create_toplevel(const scene_ac
 
                     for(const auto &[type_flag, tex_data]: mat->texture_data)
                     {
-                        const auto &tex = params.scene->asset_provider()->texture({tex_data.texture_id, tex_data.sampler_id});
+                        const auto &tex =
+                                params.scene->asset_provider()->texture({tex_data.texture_id, tex_data.sampler_id});
 
                         material.texture_type_flags |= static_cast<uint32_t>(type_flag);
 

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -64,6 +64,7 @@ vierkant::Object3DPtr Scene::create_mesh_object(const mesh_component_t &mesh_com
     {
         auto &anim_cmp = object->add_component<vierkant::animation_component_t>();
         anim_cmp.interpolation_mode = mesh_component.mesh->node_animations[0].interpolation_mode;
+        anim_cmp.current_time = mesh_component.mesh->node_animations[0].start_time;
     }
 
     vierkant::object_component auto &aabb_component = object->add_component<vierkant::aabb_component_t>();

--- a/src/Scene.cpp
+++ b/src/Scene.cpp
@@ -15,7 +15,8 @@ static void update_bone_mirror(vierkant::Object3D &mirror_root, const vierkant::
 {
     std::vector<vierkant::transform_t> local_transforms;
     vierkant::nodes::build_local_transforms_bfs(mesh.root_bone, mesh.node_animations[animation_state.index],
-                                                static_cast<float>(animation_state.current_time), local_transforms);
+                                                static_cast<float>(animation_state.current_time),
+                                                animation_state.interpolation_mode, local_transforms);
 
     std::stack<vierkant::Object3D *> object_stack;
     object_stack.push(&mirror_root);
@@ -59,7 +60,11 @@ vierkant::Object3DPtr Scene::create_mesh_object(const mesh_component_t &mesh_com
     object->set_transform({});
 
     object->add_component(mesh_component);
-    if(!mesh_component.mesh->node_animations.empty()) { object->add_component<vierkant::animation_component_t>(); }
+    if(!mesh_component.mesh->node_animations.empty())
+    {
+        auto &anim_cmp = object->add_component<vierkant::animation_component_t>();
+        anim_cmp.interpolation_mode = mesh_component.mesh->node_animations[0].interpolation_mode;
+    }
 
     vierkant::object_component auto &aabb_component = object->add_component<vierkant::aabb_component_t>();
 

--- a/src/animation.cpp
+++ b/src/animation.cpp
@@ -219,6 +219,7 @@ std::hash<vierkant::animation_component_t_<T>>::operator()(vierkant::animation_c
 {
     size_t h = 0;
     vierkant::hash_combine(h, animation_state.index);
+    vierkant::hash_combine(h, animation_state.interpolation_mode);
     vierkant::hash_combine(h, animation_state.current_time);
     vierkant::hash_combine(h, animation_state.animation_speed);
     vierkant::hash_combine(h, animation_state.playing);

--- a/src/culling.cpp
+++ b/src/culling.cpp
@@ -50,6 +50,7 @@ public:
                 {
                     const auto &animation_state = object.get_component<animation_component_t>();
                     drawable_params.animation_index = animation_state.index;
+                    drawable_params.interpolation_mode = animation_state.interpolation_mode;
                     drawable_params.animation_time = static_cast<float>(animation_state.current_time);
                 }
                 auto mesh_drawables = vierkant::create_mesh_drawables(*mesh_component, drawable_params);

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -55,8 +55,10 @@ std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_com
     if(!mesh_component.library && !mesh->root_bone && params.animation_index < mesh->node_animations.size())
     {
         const auto &animation = mesh->node_animations[params.animation_index];
-        vierkant::nodes::build_node_matrices_bfs(mesh->root_node, animation, params.animation_time, node_transforms);
-        vierkant::nodes::build_morph_weights_bfs(mesh->root_node, animation, params.animation_time, node_morph_weights);
+        vierkant::nodes::build_node_matrices_bfs(mesh->root_node, animation, params.animation_time,
+                                                 params.interpolation_mode, node_transforms);
+        vierkant::nodes::build_morph_weights_bfs(mesh->root_node, animation, params.animation_time,
+                                                 params.interpolation_mode, node_morph_weights);
     }
 
     bool use_meshlets = mesh->meshlets && mesh->meshlet_vertices && mesh->meshlet_triangles;

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -1284,7 +1284,10 @@ bool draw_light_ui(vierkant::lightsource_t &light)
                 tex_data.texture_id = vierkant::TextureId::from_string(text_buf);
                 light.cookie = tex_data;
             }
-            else { light.cookie.reset(); }
+            else
+            {
+                light.cookie.reset();
+            }
             changed = true;
         }
     }
@@ -1471,26 +1474,30 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
     // animation
     if(!mesh->node_animations.empty() && ImGui::TreeNode("animation") && object->has_component<animation_component_t>())
     {
-        auto &animation_state = object->get_component<animation_component_t>();
+        auto &animation_cmp = object->get_component<animation_component_t>();
 
         // animation index
-        int animation_index = static_cast<int>(animation_state.index);
+        int animation_index = static_cast<int>(animation_cmp.index);
 
         std::vector<const char *> animation_items;
         for(auto &anim: mesh->node_animations) { animation_items.push_back(anim.name.c_str()); }
 
         if(ImGui::Combo("name", &animation_index, animation_items.data(), static_cast<int>(animation_items.size())))
         {
-            animation_state.index = animation_index;
+            animation_cmp.index = animation_index;
+            if(mesh->node_animations.size() > animation_cmp.index)
+            {
+                animation_cmp.interpolation_mode = mesh->node_animations[animation_index].interpolation_mode;
+            }
         }
 
-        auto &animation = mesh->node_animations[animation_state.index];
+        auto &animation = mesh->node_animations[animation_cmp.index];
 
         // animation speed
-        auto speed = static_cast<float>(animation_state.animation_speed);
-        if(ImGui::SliderFloat("speed", &speed, -3.f, 3.f)) { animation_state.animation_speed = speed; }
+        auto speed = static_cast<float>(animation_cmp.animation_speed);
+        if(ImGui::SliderFloat("speed", &speed, -3.f, 3.f)) { animation_cmp.animation_speed = speed; }
         ImGui::SameLine();
-        if(ImGui::Checkbox("play", &animation_state.playing)) {}
+        if(ImGui::Checkbox("play", &animation_cmp.playing)) {}
 
         // interpolation-mode
         const char *interpolation_mode_items[] = {"Linear", "Step", "CubicSpline"};
@@ -1498,25 +1505,24 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
                                                              InterpolationMode::CubicSpline};
         int mode_index = 0;
 
-        for(auto mode: interpolation_modes)
+        for(const auto mode: interpolation_modes)
         {
-            if(animation.interpolation_mode == mode) { break; }
+            if(animation_cmp.interpolation_mode == mode) { break; }
             mode_index++;
         }
 
         if(ImGui::Combo("interpolation", &mode_index, interpolation_mode_items, IM_ARRAYSIZE(interpolation_mode_items)))
         {
-            //            animation.interpolation_mode = interpolation_modes[mode_index];
-            spdlog::error("cannot assign interpolation-mode here -> FIX");
+            animation_cmp.interpolation_mode = interpolation_modes[mode_index];
         }
 
-        float current_time = static_cast<float>(animation_state.current_time) / animation.ticks_per_sec;
+        float current_time = static_cast<float>(animation_cmp.current_time) / animation.ticks_per_sec;
         float duration = animation.duration / animation.ticks_per_sec;
 
         // animation current time / max time
         if(ImGui::SliderFloat(("/ " + crocore::to_string(duration, 2) + " s").c_str(), &current_time, 0.f, duration))
         {
-            animation_state.current_time = current_time * animation.ticks_per_sec;
+            animation_cmp.current_time = current_time * animation.ticks_per_sec;
         }
         ImGui::Separator();
         ImGui::TreePop();
@@ -2170,9 +2176,9 @@ bool draw_transform_guizmo(vierkant::transform_t &transform, const vierkant::Obj
         else
         {
             const auto &perspective_params = cam_cmp->physical;
-            auto proj = glm::perspectiveRH(perspective_params.fovy(), sz.x / sz.y,
-                                           perspective_params.clipping_distances.x,
-                                           perspective_params.clipping_distances.y);
+            auto proj =
+                    glm::perspectiveRH(perspective_params.fovy(), sz.x / sz.y, perspective_params.clipping_distances.x,
+                                       perspective_params.clipping_distances.y);
             changed = ImGuizmo::Manipulate(glm::value_ptr(view), glm::value_ptr(proj),
                                            ImGuizmo::OPERATION(current_gizmo), mode, glm::value_ptr(m));
         }

--- a/src/imgui/imgui_util.cpp
+++ b/src/imgui/imgui_util.cpp
@@ -1517,10 +1517,12 @@ void draw_mesh_ui(const vierkant::ScenePtr &scene, const vierkant::Object3DPtr &
         }
 
         float current_time = static_cast<float>(animation_cmp.current_time) / animation.ticks_per_sec;
+        float start_time = animation.start_time / animation.ticks_per_sec;
         float duration = animation.duration / animation.ticks_per_sec;
 
         // animation current time / max time
-        if(ImGui::SliderFloat(("/ " + crocore::to_string(duration, 2) + " s").c_str(), &current_time, 0.f, duration))
+        if(ImGui::SliderFloat(("/ " + crocore::to_string(duration, 2) + " s").c_str(), &current_time, start_time,
+                              start_time + duration))
         {
             animation_cmp.current_time = current_time * animation.ticks_per_sec;
         }

--- a/src/mesh_component.cpp
+++ b/src/mesh_component.cpp
@@ -15,7 +15,8 @@ AABB mesh_aabb(const vierkant::mesh_component_t &cmp, const std::optional<vierka
     {
         const auto &animation = cmp.mesh->node_animations[anim_state->index];
         vierkant::nodes::build_node_matrices_bfs(cmp.mesh->root_node, animation,
-                                                 static_cast<float>(anim_state->current_time), node_transforms);
+                                                 static_cast<float>(anim_state->current_time),
+                                                 anim_state->interpolation_mode, node_transforms);
     }
 
     auto add_entry_to_aabb = [&ret, &node_transforms](const Mesh::entry_t &entry, bool mesh_library) {
@@ -50,7 +51,8 @@ std::vector<vierkant::AABB> mesh_sub_aabbs(const vierkant::mesh_component_t &cmp
     {
         const auto &animation = cmp.mesh->node_animations[anim_state->index];
         vierkant::nodes::build_node_matrices_bfs(cmp.mesh->root_node, animation,
-                                                 static_cast<float>(anim_state->current_time), node_transforms);
+                                                 static_cast<float>(anim_state->current_time),
+                                                 anim_state->interpolation_mode, node_transforms);
     }
 
     auto add_aabb = [&ret, &node_transforms](const Mesh::entry_t &entry, bool mesh_library) {

--- a/src/mesh_compute.cpp
+++ b/src/mesh_compute.cpp
@@ -163,7 +163,7 @@ mesh_compute_result_t mesh_compute(const mesh_compute_context_handle &context, c
 
     for(const auto &[id, item]: params.mesh_compute_items)
     {
-        const auto &[mesh, animation_state] = item;
+        const auto &[mesh, animation_cmp] = item;
 
         // avoid computing duplicates
         auto cache_it = cached_offsets.find(item);
@@ -177,11 +177,11 @@ mesh_compute_result_t mesh_compute(const mesh_compute_context_handle &context, c
         assert(vertex_stride == sizeof(packed_vertex_t));
 
         bool animation_update =
-                mesh && animation_state.index < mesh->node_animations.size() && (mesh->root_bone || mesh->morph_buffer);
+                mesh && animation_cmp.index < mesh->node_animations.size() && (mesh->root_bone || mesh->morph_buffer);
 
         if(animation_update)
         {
-            const auto &animation = mesh->node_animations[animation_state.index];
+            const auto &animation = mesh->node_animations[animation_cmp.index];
 
             // store current offset for this id
             ret.vertex_buffer_offsets[id] = vertex_offset;
@@ -191,8 +191,9 @@ mesh_compute_result_t mesh_compute(const mesh_compute_context_handle &context, c
             {
                 // create array of bone-transformations for this mesh+animation-state
                 std::vector<vierkant::transform_t> bone_transforms;
-                vierkant::nodes::build_node_matrices_bfs(
-                        mesh->root_bone, animation, static_cast<float>(animation_state.current_time), bone_transforms);
+                vierkant::nodes::build_node_matrices_bfs(mesh->root_bone, animation,
+                                                         static_cast<float>(animation_cmp.current_time),
+                                                         animation_cmp.interpolation_mode, bone_transforms);
 
                 // keep track of offsets
                 size_t bone_offset = combined_bone_data.size() * sizeof(vierkant::transform_t);
@@ -233,8 +234,8 @@ mesh_compute_result_t mesh_compute(const mesh_compute_context_handle &context, c
                 // morph-target weights
                 std::vector<std::vector<float>> node_morph_weights;
                 vierkant::nodes::build_morph_weights_bfs(mesh->root_node, animation,
-                                                         static_cast<float>(animation_state.current_time),
-                                                         node_morph_weights);
+                                                         static_cast<float>(animation_cmp.current_time),
+                                                         animation_cmp.interpolation_mode, node_morph_weights);
 
                 for(uint32_t i = 0; i < mesh->entries.size(); ++i)
                 {

--- a/src/model/gltf.cpp
+++ b/src/model/gltf.cpp
@@ -825,6 +825,9 @@ vierkant::nodes::node_animation_t create_node_animation(const tinygltf::Animatio
     vierkant::nodes::node_animation_t animation;
     animation.name = tiny_animation.name;
 
+    // track the key-time span, clips need not start at zero
+    float t_min = std::numeric_limits<float>::max(), t_max = std::numeric_limits<float>::lowest();
+
     for(const auto &channel: tiny_animation.channels)
     {
         auto it = node_map.find(channel.target_node);
@@ -851,8 +854,9 @@ vierkant::nodes::node_animation_t create_node_animation(const tinygltf::Animatio
                 auto data = buffer.data.data() + accessor.byteOffset + buffer_view.byteOffset;
                 auto ptr = reinterpret_cast<const float *>(data);
                 input_times = {ptr, ptr + accessor.count};
-                animation.duration =
-                        std::max(animation.duration, *std::max_element(input_times.begin(), input_times.end()));
+                auto [min_it, max_it] = std::minmax_element(input_times.begin(), input_times.end());
+                t_min = std::min(t_min, *min_it);
+                t_max = std::max(t_max, *max_it);
 
                 animation.interpolation_mode = vierkant::InterpolationMode::Linear;
 
@@ -955,6 +959,12 @@ vierkant::nodes::node_animation_t create_node_animation(const tinygltf::Animatio
                 }
             }
         }
+    }
+
+    if(t_min <= t_max)
+    {
+        animation.start_time = t_min;
+        animation.duration = t_max - t_min;
     }
     return animation;
 }

--- a/src/nodes.cpp
+++ b/src/nodes.cpp
@@ -56,17 +56,18 @@ NodeConstPtr node_by_name(const NodeConstPtr &root, const std::string &name)
 }
 
 void build_local_transforms_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+                                vierkant::InterpolationMode interpolation,
                                 std::vector<vierkant::transform_t> &transforms)
 {
     if(!root) { return; }
     transforms.resize(num_nodes_in_hierarchy(root));
 
-    bfs(root, [&transforms, &animation, time](const NodeConstPtr &node) {
+    bfs(root, [&transforms, &animation, time, interpolation](const NodeConstPtr &node) {
         auto node_transform = node->transform;
 
         if(const auto it = animation.keys.find(node); it != animation.keys.end())
         {
-            create_animation_transform(it->second, time, animation.interpolation_mode, node_transform);
+            create_animation_transform(it->second, time, interpolation, node_transform);
         }
         transforms[node->index] = node_transform;
         return true;
@@ -75,12 +76,12 @@ void build_local_transforms_bfs(const NodeConstPtr &root, const node_animation_t
 
 template<typename T, typename>
 void build_morph_weights_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
-                             std::vector<std::vector<T>> &morph_weights)
+                             vierkant::InterpolationMode interpolation, std::vector<std::vector<T>> &morph_weights)
 {
     if(!root) { return; }
     morph_weights.resize(num_nodes_in_hierarchy(root));
 
-    bfs(root, [&morph_weights, &animation, time](auto &node) {
+    bfs(root, [&morph_weights, &animation, time, interpolation](auto &node) {
         auto it = animation.keys.find(node);
 
         if(it != animation.keys.end())
@@ -90,7 +91,7 @@ void build_morph_weights_bfs(const NodeConstPtr &root, const node_animation_t &a
             if(!animation_keys.morph_weights.empty())
             {
                 std::vector<double> tmp_weights;
-                create_morph_weights(animation_keys, time, animation.interpolation_mode, tmp_weights);
+                create_morph_weights(animation_keys, time, interpolation, tmp_weights);
                 morph_weights[node->index].resize(tmp_weights.size());
                 std::transform(tmp_weights.begin(), tmp_weights.end(), morph_weights[node->index].begin(),
                                [](double w) -> T { return static_cast<T>(w); });
@@ -102,12 +103,15 @@ void build_morph_weights_bfs(const NodeConstPtr &root, const node_animation_t &a
 
 // explicit template-specializations
 template void build_morph_weights_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+                                      vierkant::InterpolationMode interpolation,
                                       std::vector<std::vector<float>> &morph_weights);
 
 template void build_morph_weights_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+                                      vierkant::InterpolationMode interpolation,
                                       std::vector<std::vector<double>> &morph_weights);
 
-void build_node_matrices_bfs(const NodeConstPtr &root, const node_animation_t &animation, float time,
+void build_node_matrices_bfs(const NodeConstPtr &root, const node_animation_t &animation, const float time,
+                             const vierkant::InterpolationMode interpolation,
                              std::vector<vierkant::transform_t> &transforms)
 {
     if(!root) { return; }
@@ -127,7 +131,7 @@ void build_node_matrices_bfs(const NodeConstPtr &root, const node_animation_t &a
         if(it != animation.keys.end())
         {
             const auto &animation_keys = it->second;
-            create_animation_transform(animation_keys, time, animation.interpolation_mode, node_transform);
+            create_animation_transform(animation_keys, time, interpolation, node_transform);
         }
         global_joint_transform = global_joint_transform * node_transform;
 

--- a/src/serialization/animation_cereal.hpp
+++ b/src/serialization/animation_cereal.hpp
@@ -31,7 +31,8 @@ void serialize(Archive &archive, vierkant::animation_keys_t_<T> &keys)
 template<class Archive, class T>
 void serialize(Archive &archive, vierkant::animation_t<T> &animation)
 {
-    archive(cereal::make_nvp("name", animation.name), cereal::make_nvp("duration", animation.duration),
+    archive(cereal::make_nvp("name", animation.name), cereal::make_nvp("start_time", animation.start_time),
+            cereal::make_nvp("duration", animation.duration),
             cereal::make_nvp("ticks_per_sec", animation.ticks_per_sec), cereal::make_nvp("keys", animation.keys),
             cereal::make_nvp("interpolation_mode", animation.interpolation_mode));
 }

--- a/src/serialization/animation_cereal.hpp
+++ b/src/serialization/animation_cereal.hpp
@@ -4,6 +4,9 @@
 
 #pragma once
 
+#include "optional_nvp_cereal.hpp"
+
+
 #include <cereal/cereal.hpp>
 #include <vierkant/animation.hpp>
 #include <vierkant/nodes.hpp>
@@ -14,36 +17,30 @@ namespace vierkant
 template<class Archive, class T>
 void serialize(Archive &archive, vierkant::animation_value_t<T> &v)
 {
-    archive(cereal::make_nvp("value", v.value),
-            cereal::make_nvp("in_tangent", v.in_tangent),
+    archive(cereal::make_nvp("value", v.value), cereal::make_nvp("in_tangent", v.in_tangent),
             cereal::make_nvp("out_tangent", v.out_tangent));
 }
 
 template<class Archive, class T>
 void serialize(Archive &archive, vierkant::animation_keys_t_<T> &keys)
 {
-    archive(cereal::make_nvp("positions", keys.positions),
-            cereal::make_nvp("rotations", keys.rotations),
-            cereal::make_nvp("scales", keys.scales),
-            cereal::make_nvp("morph_weights", keys.morph_weights));
+    archive(cereal::make_nvp("positions", keys.positions), cereal::make_nvp("rotations", keys.rotations),
+            cereal::make_nvp("scales", keys.scales), cereal::make_nvp("morph_weights", keys.morph_weights));
 }
 
 template<class Archive, class T>
 void serialize(Archive &archive, vierkant::animation_t<T> &animation)
 {
-    archive(cereal::make_nvp("name", animation.name),
-            cereal::make_nvp("duration", animation.duration),
-            cereal::make_nvp("ticks_per_sec", animation.ticks_per_sec),
-            cereal::make_nvp("keys", animation.keys),
+    archive(cereal::make_nvp("name", animation.name), cereal::make_nvp("duration", animation.duration),
+            cereal::make_nvp("ticks_per_sec", animation.ticks_per_sec), cereal::make_nvp("keys", animation.keys),
             cereal::make_nvp("interpolation_mode", animation.interpolation_mode));
 }
 
 template<class Archive, class T>
 void serialize(Archive &archive, vierkant::animation_component_t_<T> &a)
 {
-    archive(cereal::make_nvp("index", a.index),
-            cereal::make_nvp("playing", a.playing),
-            cereal::make_nvp("animation_speed", a.animation_speed),
+    archive(cereal::make_nvp("index", a.index), cereal::make_optional_nvp("interpolation_mode", a.interpolation_mode),
+            cereal::make_nvp("playing", a.playing), cereal::make_nvp("animation_speed", a.animation_speed),
             cereal::make_nvp("current_time", a.current_time));
 }
 
@@ -54,12 +51,9 @@ namespace vierkant::nodes
 template<class Archive>
 void serialize(Archive &archive, vierkant::nodes::node_t &n)
 {
-    archive(cereal::make_nvp("name", n.name),
-            cereal::make_nvp("transform", n.transform),
-            cereal::make_nvp("offset", n.offset),
-            cereal::make_nvp("index", n.index),
-            cereal::make_nvp("parent", n.parent),
-            cereal::make_nvp("children", n.children),
+    archive(cereal::make_nvp("name", n.name), cereal::make_nvp("transform", n.transform),
+            cereal::make_nvp("offset", n.offset), cereal::make_nvp("index", n.index),
+            cereal::make_nvp("parent", n.parent), cereal::make_nvp("children", n.children),
             cereal::make_nvp("id", n.id));
 }
 

--- a/tests/TestAnimation.cpp
+++ b/tests/TestAnimation.cpp
@@ -1,0 +1,53 @@
+#include "vierkant/nodes.hpp"
+#include <gtest/gtest.h>
+
+using namespace vierkant;
+
+//! a clip whose first key is not at zero, like a Blender/Mixamo export starting at frame 1
+constexpr float test_start_time = 1.f / 30.f;
+constexpr float test_duration = 1.f;
+
+TEST(Animation, update_animation_wraps_into_clip_range)
+{
+    nodes::node_animation_t animation;
+    animation.start_time = test_start_time;
+    animation.duration = test_duration;
+
+    animation_component_t animation_cmp;
+    animation_cmp.current_time = animation.start_time;
+
+    // two full cycles at 60Hz
+    for(uint32_t i = 0; i < 120; ++i)
+    {
+        update_animation(animation, 1.0 / 60.0, animation_cmp);
+        EXPECT_GE(animation_cmp.current_time, animation.start_time);
+        EXPECT_LE(animation_cmp.current_time, animation.start_time + animation.duration);
+    }
+}
+
+TEST(Animation, clip_tail_is_not_wrapped_before_the_first_key)
+{
+    animation_value_t<glm::vec3> first = {}, last = {};
+    first.value = glm::vec3(0.f);
+    last.value = glm::vec3(10.f, 0.f, 0.f);
+
+    animation_keys_t keys;
+    keys.positions[test_start_time] = first;
+    keys.positions[test_start_time + test_duration] = last;
+
+    nodes::node_animation_t animation;
+    animation.start_time = test_start_time;
+    animation.duration = test_duration;
+
+    animation_component_t animation_cmp;
+    animation_cmp.current_time = animation.start_time + animation.duration - 2.f / 60.f;
+
+    // the tail of the clip is past duration, but not past the last key: no wrap here
+    update_animation(animation, 1.0 / 60.0, animation_cmp);
+    EXPECT_GT(animation_cmp.current_time, animation.start_time);
+
+    transform_t transform;
+    ASSERT_TRUE(create_animation_transform(keys, static_cast<float>(animation_cmp.current_time),
+                                           InterpolationMode::Linear, transform));
+    EXPECT_GT(transform.translation.x, 0.f);
+}

--- a/tests/TestNodes.cpp
+++ b/tests/TestNodes.cpp
@@ -38,7 +38,7 @@ TEST(Nodes, build_local_transforms_bfs_without_animation)
     auto hierarchy = create_test_hierarchy();
 
     std::vector<transform_t> transforms;
-    nodes::build_local_transforms_bfs(hierarchy.root, {}, 0.f, transforms);
+    nodes::build_local_transforms_bfs(hierarchy.root, {}, 0.f, vierkant::InterpolationMode::Linear, transforms);
 
     ASSERT_EQ(transforms.size(), 2);
 
@@ -56,7 +56,7 @@ TEST(Nodes, build_local_transforms_bfs_animated_node_stays_local)
     animation.keys[hierarchy.root].positions[0.f] = {.value = {7.f, 8.f, 9.f}};
 
     std::vector<transform_t> transforms;
-    nodes::build_local_transforms_bfs(hierarchy.root, animation, 0.f, transforms);
+    nodes::build_local_transforms_bfs(hierarchy.root, animation, 0.f, vierkant::InterpolationMode::Linear, transforms);
 
     ASSERT_EQ(transforms.size(), 2);
 
@@ -72,7 +72,7 @@ TEST(Nodes, build_node_matrices_bfs_accumulates_and_applies_offset)
     auto hierarchy = create_test_hierarchy();
 
     std::vector<transform_t> matrices;
-    nodes::build_node_matrices_bfs(hierarchy.root, {}, 0.f, matrices);
+    nodes::build_node_matrices_bfs(hierarchy.root, {}, 0.f, vierkant::InterpolationMode::Linear, matrices);
 
     ASSERT_EQ(matrices.size(), 2);
 

--- a/tools/vierkant_ed/vierkant_ed.cpp
+++ b/tools/vierkant_ed/vierkant_ed.cpp
@@ -544,7 +544,8 @@ vierkant::window_delegate_t::draw_result_t VierkantEd::draw(const vierkant::Wind
                     auto node_transform = mesh->root_bone ? modelview * mesh->skin_transform : modelview;
                     m_draw_context.draw_node_hierarchy(m_renderer_overlay, node, animation,
                                                        static_cast<float>(animation_state.current_time),
-                                                       node_transform, cam_projection);
+                                                       animation_state.interpolation_mode, node_transform,
+                                                       cam_projection);
                 }
             }
         }


### PR DESCRIPTION
- add animation_component_t::interpolation_mode, seeded from the mesh-animation
- pass an explicit InterpolationMode into nodes::build_*_bfs and DrawContext::draw_node_hierarchy instead of reading animation_t
- add create_mesh_drawables_params_t::interpolation_mode, filled from the component in culling
- imgui: interpolation-combo writes the component, replacing the disabled stub
- serialize the new field via make_optional_nvp
- untangle include-cycle: nodes.hpp no longer pulls model_loading.hpp, Mesh.hpp owns it
- add animation_t::start_time, derive duration accordingly