### PR TITLE
Rasterizer BDA migration

### DIFF
--- a/include/vierkant/Device.hpp
+++ b/include/vierkant/Device.hpp
@@ -99,6 +99,7 @@ public:
     struct properties_t
     {
         VkPhysicalDeviceProperties core;
+        VkPhysicalDeviceVulkan12Properties vulkan12;
         VkPhysicalDeviceVulkan13Properties vulkan13;
         VkPhysicalDeviceAccelerationStructurePropertiesKHR acceleration_structure;
         VkPhysicalDeviceRayTracingPipelinePropertiesKHR ray_pipeline;

--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -394,6 +394,9 @@ private:
     std::default_random_engine m_random_engine;
 
     uint32_t m_mesh_task_count = 0;
+
+    //! 1x1 placeholder for BINDING_DEPTH_PYRAMID
+    vierkant::ImagePtr m_placeholder_image;
 };
 
 }//namespace vierkant

--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -36,16 +36,9 @@ class Rasterizer
 public:
     enum DescriptorBinding
     {
-        BINDING_VERTICES = 0,
-        BINDING_DRAW_COMMANDS = 2,
-        BINDING_MESH_DRAWS = 3,
-        BINDING_MATERIAL = 4,
+        BINDING_RENDER_DATA = 0,
         BINDING_TEXTURES = 5,
         BINDING_JITTER_OFFSET = 9,
-        BINDING_MESHLETS = 13,
-        BINDING_MESHLET_VERTICES = 14,
-        BINDING_MESHLET_TRIANGLES = 15,
-        BINDING_MESHLET_VISIBILITY = 16,
         BINDING_DEPTH_PYRAMID = 17,
     };
 
@@ -55,9 +48,30 @@ public:
         matrix_struct_t last_matrices = {};
         uint32_t mesh_index = 0;
         uint32_t material_index = 0;
-        uint32_t vertex_buffer_index = 0;
+        uint32_t mesh_buffer_index = 0;
         uint16_t lod_index = 0;
         uint16_t lod_count = 1;
+    };
+
+    //! per-drawable buffer-addresses, indexed with mesh_draw_t::mesh_buffer_index
+    struct mesh_buffers_t
+    {
+        VkDeviceAddress vertices = 0;
+        VkDeviceAddress meshlets = 0;
+        VkDeviceAddress meshlet_vertices = 0;
+        VkDeviceAddress meshlet_triangles = 0;
+    };
+
+    static_assert(sizeof(mesh_buffers_t) == 32, "unexpected mesh_buffers_t size");
+
+    //! frame-global buffers, provided as device-addresses in a single UBO (set 0, binding 0)
+    struct render_data_t
+    {
+        VkDeviceAddress mesh_draws = 0;
+        VkDeviceAddress materials = 0;
+        VkDeviceAddress mesh_buffers = 0;
+        VkDeviceAddress draw_commands = 0;
+        VkDeviceAddress meshlet_visibilities = 0;
     };
 
     struct mesh_entry_t
@@ -109,8 +123,8 @@ public:
         //! host-memory array of mesh_draw_t
         const mesh_draw_t *mesh_draws_host = nullptr;
 
-        //! device array containing an array of vertex-buffer device-addresses
-        vierkant::BufferPtr vertex_buffer_addresses;
+        //! device array containing an array of mesh_buffers_t
+        vierkant::BufferPtr mesh_buffers;
 
         //! device array containing an array of mesh_entry_t
         vierkant::BufferPtr mesh_entries;
@@ -311,11 +325,14 @@ private:
         descriptor_set_map_t descriptor_sets;
 
         // SSBOs containing everything (using gpu-mem iff a queue was provided)
-        vierkant::BufferPtr vertex_buffer_refs;
+        vierkant::BufferPtr mesh_buffers;
         vierkant::BufferPtr mesh_draw_buffer;
         vierkant::BufferPtr mesh_entry_buffer;
         vierkant::BufferPtr material_buffer;
         vierkant::BufferPtr meshlet_visibility_buffer;
+
+        //! uniform-buffer holding a render_data_t
+        vierkant::BufferPtr render_data_ubo;
 
         // host visible keep-alive staging-buffer
         vierkant::BufferPtr staging_buffer;

--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -38,7 +38,6 @@ public:
     {
         BINDING_RENDER_DATA = 0,
         BINDING_TEXTURES = 5,
-        BINDING_JITTER_OFFSET = 9,
         BINDING_DEPTH_PYRAMID = 17,
     };
 
@@ -67,12 +66,16 @@ public:
     //! frame-global buffers, provided as device-addresses in a single UBO (set 0, binding 0)
     struct render_data_t
     {
+        //! address of a pair of camera_params_t: current and previous frame
+        VkDeviceAddress cameras = 0;
+
         VkDeviceAddress mesh_draws = 0;
         VkDeviceAddress materials = 0;
         VkDeviceAddress mesh_buffers = 0;
         VkDeviceAddress draw_commands = 0;
         VkDeviceAddress meshlet_visibilities = 0;
     };
+    static_assert(sizeof(render_data_t) == 48, "unexpected render_data_t size");
 
     struct mesh_entry_t
     {
@@ -218,6 +221,9 @@ public:
 
     //! optional cull-delegate
     indirect_draw_delegate_t draw_indirect_delegate;
+
+    //! address of a pair of camera-params (current/previous). provided by the caller, per frame.
+    VkDeviceAddress camera_buffer_address = 0;
 
     Rasterizer() = default;
 

--- a/include/vierkant/Rasterizer.hpp
+++ b/include/vierkant/Rasterizer.hpp
@@ -37,24 +37,16 @@ public:
     enum DescriptorBinding
     {
         BINDING_VERTICES = 0,
-        BINDING_INDICES = 1,
         BINDING_DRAW_COMMANDS = 2,
         BINDING_MESH_DRAWS = 3,
         BINDING_MATERIAL = 4,
         BINDING_TEXTURES = 5,
-        BINDING_BONE_VERTEX_DATA = 6,
-        BINDING_BONES = 7,
-        BINDING_PREVIOUS_BONES = 8,
         BINDING_JITTER_OFFSET = 9,
-        BINDING_MORPH_TARGETS = 10,
-        BINDING_MORPH_PARAMS = 11,
-        BINDING_PREVIOUS_MORPH_PARAMS = 12,
         BINDING_MESHLETS = 13,
         BINDING_MESHLET_VERTICES = 14,
         BINDING_MESHLET_TRIANGLES = 15,
         BINDING_MESHLET_VISIBILITY = 16,
         BINDING_DEPTH_PYRAMID = 17,
-        BINDING_MAX_RANGE
     };
 
     struct mesh_draw_t

--- a/include/vierkant/descriptor.hpp
+++ b/include/vierkant/descriptor.hpp
@@ -73,6 +73,15 @@ using descriptor_map_t = std::map<uint32_t, descriptor_t>;
 using descriptor_set_map_t = std::unordered_map<vierkant::descriptor_map_t, vierkant::DescriptorSetPtr>;
 
 /**
+ * @brief   descriptor-count used for a binding with 'descriptor_t::variable_count', clamped against device-limits.
+ *          useful to size descriptor-pools, which must reserve this many descriptors per variable-count set.
+ *
+ * @param   device  handle for a vierkant::Device
+ * @return  the maximum number of descriptors in a variable-count binding
+ */
+uint32_t max_bindless_resources(const vierkant::DevicePtr &device);
+
+/**
  * @brief   Create a shared VkDescriptorPool (DescriptorPoolPtr)
  *
  * @param   device  handle for the vierkant::Device to create the DescriptorPool
@@ -95,13 +104,14 @@ DescriptorSetLayoutPtr create_descriptor_set_layout(const vierkant::DevicePtr &d
 /**
  * @brief   Create a shared VkDescriptorSet (DescriptorSetPtr) for a provided set-layout.
  *
- * @param   device      handle for the vierkant::Device to create the DescriptorSet
- * @param   pool        handle for a shared VkDescriptorPool to allocate the DescriptorSet from
- * @param   set_layout  handle for a VkDescriptorSetLayout
+ * @param   device          handle for the vierkant::Device to create the DescriptorSet
+ * @param   pool            handle for a shared VkDescriptorPool to allocate the DescriptorSet from
+ * @param   set_layout      handle for a VkDescriptorSetLayout
+ * @param   variable_count  number of descriptors to allocate for a variable-count binding. 0: no such binding.
  * @return  the newly created DescriptorSetPtr
  */
 DescriptorSetPtr create_descriptor_set(const vierkant::DevicePtr &device, const DescriptorPoolPtr &pool,
-                                       VkDescriptorSetLayout set_layout, bool variable_count);
+                                       VkDescriptorSetLayout set_layout, uint32_t variable_count);
 
 /**
  * @brief   Update an existing shared VkDescriptorSet with a provided array of vierkant::descriptor_t.

--- a/include/vierkant/drawable.hpp
+++ b/include/vierkant/drawable.hpp
@@ -95,6 +95,9 @@ struct drawable_t
     //! a descriptormap
     descriptor_map_t descriptors;
 
+    //! material-textures, gathered into the bindless texture-array. indexed via material_struct_t::base_texture_index
+    std::vector<vierkant::ImagePtr> textures;
+
     //! binary blob for push-constants
     std::vector<uint8_t> push_constants;
 
@@ -133,7 +136,8 @@ struct create_mesh_drawables_params_t
 /**
  * @brief   Factory to create drawables from a provided mesh.
  *
- * @param   params  a struct containing a mesh and other params for drawable-creation.
+ * @param   mesh_component  a mesh-component
+ * @param   params          a struct containing a mesh and other params for drawable-creation.
  * @return  an array of drawables for the mesh-entries.
  */
 std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_component_t &mesh_component,

--- a/include/vierkant/drawable.hpp
+++ b/include/vierkant/drawable.hpp
@@ -63,7 +63,11 @@ struct alignas(16) material_struct_t
     uint32_t texture_type_flags = 0;
 
     uint32_t base_texture_index = 0;
+
+    //! explicit tail-padding, see renderer::material_t. keeps the array-stride at 128 on both sides
+    uint32_t pad[3] = {};
 };
+static_assert(sizeof(material_struct_t) == 128, "unexpected material_struct_t size");
 
 //! define a strong id-type for drawables
 DEFINE_NAMED_ID(DrawableId);

--- a/include/vierkant/drawable.hpp
+++ b/include/vierkant/drawable.hpp
@@ -95,9 +95,6 @@ struct drawable_t
     //! a descriptormap
     descriptor_map_t descriptors;
 
-    //! optional descriptor-set-layout
-    DescriptorSetLayoutPtr descriptor_set_layout;
-
     //! binary blob for push-constants
     std::vector<uint8_t> push_constants;
 

--- a/shaders/slang/fullscreen/ao_rayquery.slang
+++ b/shaders/slang/fullscreen/ao_rayquery.slang
@@ -20,7 +20,7 @@ struct params_t
 [[vk::binding(2, 0)]] StructuredBuffer<params_t> ubo;
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
 float raytraced_occlusion(float3 position, float3 world_normal, float max_distance, uint num_rays, uint rng_state)
 {
@@ -57,9 +57,9 @@ float fragment_main(float2 tex_coord : TexCoord0, float4 sv_position : SV_Positi
     float depth = u_textures[TextureIndex::DEPTH].Sample(tex_coord).x;
     float3 normal = u_textures[TextureIndex::NORMAL].Sample(tex_coord).xyz;
 
-    float3 clip_pos = float3(sv_position.xy / context.size, depth);
+    float3 clip_pos = float3(sv_position.xy / push_constants.size, depth);
     float4 viewspace_pos = mul(ubo[0].inverse_projection, float4(2.0 * clip_pos.xy - 1.0, clip_pos.z, 1.0));
     float3 position = utils::apply_transform(ubo[0].camera_transform, viewspace_pos.xyz / viewspace_pos.w);
 
-    return raytraced_occlusion(position, normal, ubo[0].max_distance, ubo[0].num_rays, context.random_seed);
+    return raytraced_occlusion(position, normal, ubo[0].max_distance, ubo[0].num_rays, push_constants.random_seed);
 }

--- a/shaders/slang/fullscreen/ao_screenspace.slang
+++ b/shaders/slang/fullscreen/ao_screenspace.slang
@@ -20,7 +20,7 @@ struct params_t
 [[vk::binding(1, 0)]] Sampler2D u_textures[2];
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
 float screenspace_occlusion(float2 coord, float3 eye_normal, float ssao_radius, uint rng_state)
 {
@@ -58,7 +58,7 @@ float screenspace_occlusion(float2 coord, float3 eye_normal, float ssao_radius, 
 float fragment_main(float2 tex_coord : TexCoord0, float4 sv_position : SV_Position) : SV_Target
 {
     uint rng_state = utils::xxhash32(ubo[0].random_seed,
-                                     uint(context.size.x * sv_position.y + sv_position.x));
+                                     uint(push_constants.size.x * sv_position.y + sv_position.x));
 
     float3 eye_normal = u_textures[TextureIndex::NORMAL].Sample(tex_coord).xyz;
     eye_normal = utils::apply_rotation(ubo[0].view_transform, eye_normal);

--- a/shaders/slang/fullscreen/dof.slang
+++ b/shaders/slang/fullscreen/dof.slang
@@ -6,9 +6,6 @@ enum TextureIndex { COLOR = 0, DEPTH = 1 };
 [[vk::binding(0, 0)]] Sampler2D u_textures[2];
 [[vk::binding(1, 0)]] ConstantBuffer<utils::dof_params_t> u_dof_params;
 
-[[vk::push_constant]]
-renderer::push_constants_t push_constants;
-
 struct FragOutput
 {
     float4 color : SV_Target;

--- a/shaders/slang/fullscreen/dof.slang
+++ b/shaders/slang/fullscreen/dof.slang
@@ -7,7 +7,7 @@ enum TextureIndex { COLOR = 0, DEPTH = 1 };
 [[vk::binding(1, 0)]] ConstantBuffer<utils::dof_params_t> u_dof_params;
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
 struct FragOutput
 {

--- a/shaders/slang/fullscreen/grid.slang
+++ b/shaders/slang/fullscreen/grid.slang
@@ -20,11 +20,11 @@ struct grid_params_t
 [[vk::binding(0, 0)]] ConstantBuffer<grid_params_t> grid_params;
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
 void camera_ray(float2 frag_coord, out float3 ray_origin, out float3 ray_direction)
 {
-    float2 uv = frag_coord / context.size;
+    float2 uv = frag_coord / push_constants.size;
     float2 d = uv * 2.0 - 1.0;
 
     if(grid_params.ortho)

--- a/shaders/slang/pbr/g_buffer_mesh.slang
+++ b/shaders/slang/pbr/g_buffer_mesh.slang
@@ -11,19 +11,10 @@ const uint mesh_workgroup_x = renderer::MAX_MESH_WORKGROUP_SIZE;
 // ---- shared bindings (set 0) -----------------------------------------------
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::DrawCommands, 0)]]
-StructuredBuffer<renderer::indexed_draw_command_t> draw_commands;
-
-[[vk::binding(renderer::ResourceBinding::Meshlets, 0)]]
-StructuredBuffer<renderer::meshlet_t> meshlets;
-
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
-
-[[vk::binding(renderer::ResourceBinding::MeshletVisibility, 0)]]
-RWStructuredBuffer<uint> meshlet_visibilities;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 struct camera_ubo_t
 {
@@ -34,15 +25,6 @@ struct camera_ubo_t
 ConstantBuffer<camera_ubo_t> camera_ubo;
 
 // mesh-shader-only bindings
-[[vk::binding(renderer::ResourceBinding::Vertices, 0)]]
-StructuredBuffer<Ptr<utils::packed_vertex_t, Access.Read>> vertex_buffers;
-
-[[vk::binding(renderer::ResourceBinding::MeshletVertices, 0)]]
-StructuredBuffer<uint> meshlet_vertices;
-
-[[vk::binding(renderer::ResourceBinding::MeshletTriangles, 0)]]
-StructuredBuffer<uint8_t> meshlet_triangles;
-
 // TODO: not really worth it? not sure ...
 #define CULLING 0
 
@@ -86,17 +68,20 @@ void mesh_main(uint ti: SV_GroupThreadID, uint wg_id: SV_GroupID, in payload ren
 {
     uint mi = task_payload.meshlet_base_index + uint(task_payload.meshlet_delta_indices[wg_id]);
 
-    uint vertex_count = uint(meshlets[mi].vertex_count);
-    uint primitive_count = uint(meshlets[mi].triangle_count);
+    renderer::mesh_draw_t draw = render_data.mesh_draws[task_payload.object_index];
+    renderer::mesh_buffers_t mesh_buffers = render_data.mesh_buffers[draw.mesh_buffer_index];
+
+    uint vertex_count = uint(mesh_buffers.meshlets[mi].vertex_count);
+    uint primitive_count = uint(mesh_buffers.meshlets[mi].triangle_count);
     SetMeshOutputCounts(vertex_count, primitive_count);
 
-    renderer::matrix_struct_t m = draws[task_payload.object_index].current_matrices;
-    renderer::matrix_struct_t m_last = draws[task_payload.object_index].last_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[task_payload.object_index].current_matrices;
+    renderer::matrix_struct_t m_last = render_data.mesh_draws[task_payload.object_index].last_matrices;
 
     for(uint i = ti; i < vertex_count; i += mesh_workgroup_x)
     {
-        uint vi = meshlet_vertices[meshlets[mi].vertex_offset + i];
-        utils::Vertex v = utils::unpack(vertex_buffers[draws[task_payload.object_index].vertex_buffer_index][vi]);
+        uint vi = mesh_buffers.meshlet_vertices[mesh_buffers.meshlets[mi].vertex_offset + i];
+        utils::Vertex v = utils::unpack(mesh_buffers.vertices[vi]);
 
         float3 world_pos = utils::apply_transform(m.transform, v.position);
         float4 cur_pos = mul(camera_ubo.camera.projection, mul(camera_ubo.camera.view, float4(world_pos, 1.0)));
@@ -109,10 +94,10 @@ void mesh_main(uint ti: SV_GroupThreadID, uint wg_id: SV_GroupID, in payload ren
         out_vertices[i].position = jittered_position;
 
         out_vertices[i].indices.mesh_draw_index = task_payload.object_index;
-        out_vertices[i].indices.material_index = draws[task_payload.object_index].material_index;
+        out_vertices[i].indices.material_index = render_data.mesh_draws[task_payload.object_index].material_index;
         out_vertices[i].indices.meshlet_index = mi;
-        out_vertices[i].indices.lod_index = uint(draws[task_payload.object_index].lod_index);
-        out_vertices[i].indices.lod_count = uint(draws[task_payload.object_index].lod_count);
+        out_vertices[i].indices.lod_index = uint(render_data.mesh_draws[task_payload.object_index].lod_index);
+        out_vertices[i].indices.lod_count = uint(render_data.mesh_draws[task_payload.object_index].lod_count);
 
         out_vertices[i].g_buffer_data.current_position = cur_pos;
         out_vertices[i].g_buffer_data.last_position = last_pos;
@@ -122,7 +107,7 @@ void mesh_main(uint ti: SV_GroupThreadID, uint wg_id: SV_GroupID, in payload ren
                 float4(utils::apply_rotation(m.transform, v.tangent.xyz), v.tangent.w);
 
 #if CULLING
-        vertex_clip[i] = float3((jittered_position.xy / jittered_position.w * 0.5 + float2(0.5)) * context.size,
+        vertex_clip[i] = float3((jittered_position.xy / jittered_position.w * 0.5 + float2(0.5)) * push_constants.size,
                                 jittered_position.w);
 #endif
     }
@@ -133,9 +118,10 @@ void mesh_main(uint ti: SV_GroupThreadID, uint wg_id: SV_GroupID, in payload ren
 
     for(uint i = ti; i < primitive_count; i += mesh_workgroup_x)
     {
-        uint base_index = meshlets[mi].triangle_offset + 3 * i;
-        uint a = uint(meshlet_triangles[base_index]), b = uint(meshlet_triangles[base_index + 1]),
-             c = uint(meshlet_triangles[base_index + 2]);
+        uint base_index = mesh_buffers.meshlets[mi].triangle_offset + 3 * i;
+        uint a = uint(mesh_buffers.meshlet_triangles[base_index]),
+             b = uint(mesh_buffers.meshlet_triangles[base_index + 1]),
+             c = uint(mesh_buffers.meshlet_triangles[base_index + 2]);
         out_indices[i] = uint3(a, b, c);
 
 #if CULLING

--- a/shaders/slang/pbr/g_buffer_mesh.slang
+++ b/shaders/slang/pbr/g_buffer_mesh.slang
@@ -16,14 +16,6 @@ renderer::push_constants_t push_constants;
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 
-struct camera_ubo_t
-{
-    utils::camera_t camera;
-    utils::camera_t last_camera;
-};
-[[vk::binding(renderer::ResourceBinding::JitterOffset, 0)]]
-ConstantBuffer<camera_ubo_t> camera_ubo;
-
 // mesh-shader-only bindings
 // TODO: not really worth it? not sure ...
 #define CULLING 0
@@ -84,13 +76,13 @@ void mesh_main(uint ti: SV_GroupThreadID, uint wg_id: SV_GroupID, in payload ren
         utils::Vertex v = utils::unpack(mesh_buffers.vertices[vi]);
 
         float3 world_pos = utils::apply_transform(m.transform, v.position);
-        float4 cur_pos = mul(camera_ubo.camera.projection, mul(camera_ubo.camera.view, float4(world_pos, 1.0)));
+        float4 cur_pos = mul(render_data.cameras->camera.projection, mul(render_data.cameras->camera.view, float4(world_pos, 1.0)));
         float4 last_pos = mul(
-                camera_ubo.last_camera.projection,
-                mul(camera_ubo.last_camera.view, float4(utils::apply_transform(m_last.transform, v.position), 1.0)));
+                render_data.cameras->last_camera.projection,
+                mul(render_data.cameras->last_camera.view, float4(utils::apply_transform(m_last.transform, v.position), 1.0)));
 
         float4 jittered_position = cur_pos;
-        jittered_position.xy += 2.0 * camera_ubo.camera.sample_offset * jittered_position.w;
+        jittered_position.xy += 2.0 * render_data.cameras->camera.sample_offset * jittered_position.w;
         out_vertices[i].position = jittered_position;
 
         out_vertices[i].indices.mesh_draw_index = task_payload.object_index;

--- a/shaders/slang/pbr/g_buffer_tangent.slang
+++ b/shaders/slang/pbr/g_buffer_tangent.slang
@@ -3,9 +3,6 @@ import "../utils/transform.slang";
 import "../utils/packed_vertex.slang";
 import "../utils/camera.slang";
 
-[[vk::push_constant]]
-renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/pbr/g_buffer_tangent.slang
+++ b/shaders/slang/pbr/g_buffer_tangent.slang
@@ -4,13 +4,10 @@ import "../utils/packed_vertex.slang";
 import "../utils/camera.slang";
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::Vertices, 0)]]
-StructuredBuffer<Ptr<utils::packed_vertex_t, Access.Read>> vertex_buffers;
-
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 struct camera_ubo_t
 {
@@ -27,16 +24,17 @@ renderer::g_buffer_vertex_data_t vertex_main(uint vertex_id: SV_VertexID, uint b
                                              out float4 sv_position: SV_Position)
 {
     indices.mesh_draw_index = instance_id;
-    indices.material_index = draws[instance_id].material_index;
+    indices.material_index = render_data.mesh_draws[instance_id].material_index;
     indices.meshlet_index = 0;
-    indices.lod_index = draws[instance_id].lod_index;
-    indices.lod_count = draws[instance_id].lod_count;
+    indices.lod_index = render_data.mesh_draws[instance_id].lod_index;
+    indices.lod_count = render_data.mesh_draws[instance_id].lod_count;
 
-    renderer::matrix_struct_t m = draws[indices.mesh_draw_index].current_matrices;
-    renderer::matrix_struct_t m_last = draws[indices.mesh_draw_index].last_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[indices.mesh_draw_index].current_matrices;
+    renderer::matrix_struct_t m_last = render_data.mesh_draws[indices.mesh_draw_index].last_matrices;
 
     utils::Vertex v =
-            utils::unpack(vertex_buffers[draws[indices.mesh_draw_index].vertex_buffer_index][vertex_id + base_vertex]);
+            utils::unpack(render_data.mesh_buffers[render_data.mesh_draws[indices.mesh_draw_index].mesh_buffer_index]
+                                  .vertices[vertex_id + base_vertex]);
 
     renderer::g_buffer_vertex_data_t vertex_out;
     float3 world_pos = utils::apply_transform(m.transform, v.position);

--- a/shaders/slang/pbr/g_buffer_tangent.slang
+++ b/shaders/slang/pbr/g_buffer_tangent.slang
@@ -6,14 +6,6 @@ import "../utils/camera.slang";
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 
-struct camera_ubo_t
-{
-    utils::camera_t camera;
-    utils::camera_t last_camera;
-};
-[[vk::binding(renderer::ResourceBinding::JitterOffset, 0)]]
-ConstantBuffer<camera_ubo_t> camera_ubo;
-
 [[shader("vertex")]]
 renderer::g_buffer_vertex_data_t vertex_main(uint vertex_id: SV_VertexID, uint base_vertex: SV_StartVertexLocation,
                                              uint instance_id: SV_StartInstanceLocation,
@@ -36,13 +28,13 @@ renderer::g_buffer_vertex_data_t vertex_main(uint vertex_id: SV_VertexID, uint b
     renderer::g_buffer_vertex_data_t vertex_out;
     float3 world_pos = utils::apply_transform(m.transform, v.position);
     vertex_out.current_position =
-            mul(camera_ubo.camera.projection, mul(camera_ubo.camera.view, float4(world_pos, 1.0)));
+            mul(render_data.cameras->camera.projection, mul(render_data.cameras->camera.view, float4(world_pos, 1.0)));
     float3 last_world_pos = utils::apply_transform(m_last.transform, v.position);
     vertex_out.last_position =
-            mul(camera_ubo.last_camera.projection, mul(camera_ubo.last_camera.view, float4(last_world_pos, 1.0)));
+            mul(render_data.cameras->last_camera.projection, mul(render_data.cameras->last_camera.view, float4(last_world_pos, 1.0)));
 
     float4 jittered_position = vertex_out.current_position;
-    jittered_position.xy += 2.0 * camera_ubo.camera.sample_offset * jittered_position.w;
+    jittered_position.xy += 2.0 * render_data.cameras->camera.sample_offset * jittered_position.w;
     sv_position = jittered_position;
 
     vertex_out.tex_coord = mul(m.texture, float4(v.tex_coord, 0, 1)).xy;

--- a/shaders/slang/pbr/g_buffer_task.slang
+++ b/shaders/slang/pbr/g_buffer_task.slang
@@ -17,14 +17,6 @@ renderer::push_constants_t push_constants;
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 
-struct camera_ubo_t
-{
-    utils::camera_t camera;
-    utils::camera_t last_camera;
-};
-[[vk::binding(renderer::ResourceBinding::JitterOffset, 0)]]
-ConstantBuffer<camera_ubo_t> camera_ubo;
-
 // task-shader-only bindings
 [[vk::binding(renderer::ResourceBinding::DepthPyramid, 0)]]
 Sampler2D u_depth_pyramid;
@@ -88,7 +80,7 @@ void task_main(uint3 dispatchThreadID: SV_DispatchThreadID, uint ti: SV_GroupThr
         {
             renderer::mesh_draw_t draw = render_data.mesh_draws[draw_command.object_index];
             renderer::mesh_buffers_t mesh_buffers = render_data.mesh_buffers[draw.mesh_buffer_index];
-            float4x4 m = mul(camera_ubo.camera.view, utils::mat4_cast(draw.current_matrices.transform));
+            float4x4 m = mul(render_data.cameras->camera.view, utils::mat4_cast(draw.current_matrices.transform));
 
             float3 cone_axis_raw = float3(mesh_buffers.meshlets[mi].cone_axis[0], mesh_buffers.meshlets[mi].cone_axis[1],
                                           mesh_buffers.meshlets[mi].cone_axis[2]) /
@@ -103,19 +95,19 @@ void task_main(uint3 dispatchThreadID: SV_DispatchThreadID, uint ti: SV_GroupThr
             visible = render_data.materials[draw.material_index].two_sided ||
                       !cone_cull(center, radius, cone_axis_raw, cone_cutoff, float3(0));
 
-            bool inside_frustum = camera_ubo.camera.ortho
-                                          ? !utils::frustum_cull_ortho(center, radius, camera_ubo.camera.frustum)
-                                          : !utils::frustum_cull(center, radius, camera_ubo.camera.frustum);
+            bool inside_frustum = render_data.cameras->camera.ortho
+                                          ? !utils::frustum_cull_ortho(center, radius, render_data.cameras->camera.frustum)
+                                          : !utils::frustum_cull(center, radius, render_data.cameras->camera.frustum);
             visible = visible && inside_frustum;
 
             float4 aabb;
             bool sphere_visible =
-                    !camera_ubo.camera.ortho &&
-                    utils::project_sphere(center, radius, camera_ubo.camera.near, camera_ubo.camera.projection[0][0],
-                                          camera_ubo.camera.projection[1][1], aabb);
-            if(camera_ubo.camera.ortho)
-                sphere_visible = utils::project_sphere_ortho(center, radius, camera_ubo.camera.near,
-                                                             camera_ubo.camera.frustum, aabb);
+                    !render_data.cameras->camera.ortho &&
+                    utils::project_sphere(center, radius, render_data.cameras->camera.near, render_data.cameras->camera.projection[0][0],
+                                          render_data.cameras->camera.projection[1][1], aabb);
+            if(render_data.cameras->camera.ortho)
+                sphere_visible = utils::project_sphere_ortho(center, radius, render_data.cameras->camera.near,
+                                                             render_data.cameras->camera.frustum, aabb);
 
             uint pw, ph;
             u_depth_pyramid.GetDimensions(pw, ph);
@@ -135,9 +127,9 @@ void task_main(uint3 dispatchThreadID: SV_DispatchThreadID, uint ti: SV_GroupThr
                 float level = floor(log2(max(width, height)));
 
                 float depth = u_depth_pyramid.SampleLevel((aabb.xy + aabb.zw) * 0.5, level).x;
-                depth = camera_ubo.camera.ortho
-                                ? lerp(camera_ubo.camera.far, camera_ubo.camera.near, depth)
-                                : clamp(camera_ubo.camera.near / depth, camera_ubo.camera.near, camera_ubo.camera.far);
+                depth = render_data.cameras->camera.ortho
+                                ? lerp(render_data.cameras->camera.far, render_data.cameras->camera.near, depth)
+                                : clamp(render_data.cameras->camera.near / depth, render_data.cameras->camera.near, render_data.cameras->camera.far);
                 visible = (-center.z - radius) <= depth;
             }
 

--- a/shaders/slang/pbr/g_buffer_task.slang
+++ b/shaders/slang/pbr/g_buffer_task.slang
@@ -12,19 +12,10 @@ const bool use_culling = false;
 const bool post_pass = false;
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::DrawCommands, 0)]]
-StructuredBuffer<renderer::indexed_draw_command_t> draw_commands;
-
-[[vk::binding(renderer::ResourceBinding::Meshlets, 0)]]
-StructuredBuffer<renderer::meshlet_t> meshlets;
-
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
-
-[[vk::binding(renderer::ResourceBinding::MeshletVisibility, 0)]]
-RWStructuredBuffer<uint> meshlet_visibilities;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 struct camera_ubo_t
 {
@@ -35,9 +26,6 @@ struct camera_ubo_t
 ConstantBuffer<camera_ubo_t> camera_ubo;
 
 // task-shader-only bindings
-[[vk::binding(renderer::ResourceBinding::Material, 0)]]
-StructuredBuffer<renderer::material_t> materials;
-
 [[vk::binding(renderer::ResourceBinding::DepthPyramid, 0)]]
 Sampler2D u_depth_pyramid;
 
@@ -47,17 +35,17 @@ bool cone_cull(float3 center, float radius, float3 cone_axis, float cone_cutoff,
 { return dot(center - camera_position, cone_axis) >= cone_cutoff * length(center - camera_position) + radius; }
 
 bool is_visible(uint visibility_base_index, uint meshlet_index)
-{ return (meshlet_visibilities[visibility_base_index + (meshlet_index >> 5u)] & (1u << (meshlet_index & 31u))) != 0; }
+{ return (render_data.meshlet_visibilities[visibility_base_index + (meshlet_index >> 5u)] & (1u << (meshlet_index & 31u))) != 0; }
 
 void set_visible(uint base, uint meshlet_index, bool visible)
 {
     uint bit = 1u << (meshlet_index & 31u);
     uint slot = base + (meshlet_index >> 5u);
 
-    if(visible) { InterlockedOr(meshlet_visibilities[slot], bit); }
+    if(visible) { InterlockedOr(render_data.meshlet_visibilities[slot], bit); }
     else
     {
-        InterlockedAnd(meshlet_visibilities[slot], ~bit);
+        InterlockedAnd(render_data.meshlet_visibilities[slot], ~bit);
     }
 }
 
@@ -77,7 +65,7 @@ void task_main(uint3 dispatchThreadID: SV_DispatchThreadID, uint ti: SV_GroupThr
     if(ti == 0) { visible_meshlets_count = 0; }
     GroupMemoryBarrierWithGroupSync();
 
-    renderer::indexed_draw_command_t draw_command = draw_commands[context.base_draw_index + draw_id];
+    renderer::indexed_draw_command_t draw_command = render_data.draw_commands[push_constants.base_draw_index + draw_id];
     bool valid = gid < draw_command.num_meshlets;
 
     uint meshlet_base_index = wg_id * WorkgroupSize().x + draw_command.base_meshlet;
@@ -98,19 +86,21 @@ void task_main(uint3 dispatchThreadID: SV_DispatchThreadID, uint ti: SV_GroupThr
 
         if(post_pass && valid)
         {
-            renderer::mesh_draw_t draw = draws[draw_command.object_index];
+            renderer::mesh_draw_t draw = render_data.mesh_draws[draw_command.object_index];
+            renderer::mesh_buffers_t mesh_buffers = render_data.mesh_buffers[draw.mesh_buffer_index];
             float4x4 m = mul(camera_ubo.camera.view, utils::mat4_cast(draw.current_matrices.transform));
 
-            float3 cone_axis_raw =
-                    float3(meshlets[mi].cone_axis[0], meshlets[mi].cone_axis[1], meshlets[mi].cone_axis[2]) / 127.0;
+            float3 cone_axis_raw = float3(mesh_buffers.meshlets[mi].cone_axis[0], mesh_buffers.meshlets[mi].cone_axis[1],
+                                          mesh_buffers.meshlets[mi].cone_axis[2]) /
+                                   127.0;
             cone_axis_raw = normalize(mul((float3x3) m, cone_axis_raw));
-            float cone_cutoff = float(meshlets[mi].cone_cutoff) / 127.0;
+            float cone_cutoff = float(mesh_buffers.meshlets[mi].cone_cutoff) / 127.0;
 
-            float3 center = mul(m, float4(meshlets[mi].sphere_center, 1.0)).xyz;
+            float3 center = mul(m, float4(mesh_buffers.meshlets[mi].sphere_center, 1.0)).xyz;
             float3 s = draw.current_matrices.transform.scale();
-            float radius = meshlets[mi].sphere_radius * max(max(abs(s.x), abs(s.y)), abs(s.z));
+            float radius = mesh_buffers.meshlets[mi].sphere_radius * max(max(abs(s.x), abs(s.y)), abs(s.z));
 
-            visible = materials[draw.material_index].two_sided ||
+            visible = render_data.materials[draw.material_index].two_sided ||
                       !cone_cull(center, radius, cone_axis_raw, cone_cutoff, float3(0));
 
             bool inside_frustum = camera_ubo.camera.ortho

--- a/shaders/slang/pbr/g_buffer_uber.slang
+++ b/shaders/slang/pbr/g_buffer_uber.slang
@@ -4,10 +4,10 @@ import "../utils/constants.slang";
 import "../utils/color.slang";
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::Material, 0)]]
-StructuredBuffer<renderer::material_t> materials;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[vk::binding(renderer::ResourceBinding::Textures, 1)]]
 Sampler2D textures[];
@@ -33,9 +33,9 @@ FragOutput fragment_main(nointerpolation in renderer::index_bundle_t indices,
 
     result.object_id = utils::MAX_UINT16 - indices.mesh_draw_index;
 
-    uint rng_state = utils::tea(context.random_seed, uint(context.size.x * sv_position.y + sv_position.x));
+    uint rng_state = utils::tea(push_constants.random_seed, uint(push_constants.size.x * sv_position.y + sv_position.x));
 
-    renderer::material_t material = materials[indices.material_index];
+    renderer::material_t material = render_data.materials[indices.material_index];
 
     float3 normal = (material.two_sided && !is_front_face) ? -vertex_in.normal : vertex_in.normal;
     result.normal = float4(normal, 1);
@@ -47,16 +47,16 @@ FragOutput fragment_main(nointerpolation in renderer::index_bundle_t indices,
     result.motion = 0.5 * (vertex_in.current_position.xy / vertex_in.current_position.w -
                            vertex_in.last_position.xy / vertex_in.last_position.w);
 
-    if(context.debug_flags != 0)
+    if(push_constants.debug_flags != 0)
     {
-        if(renderer::has_flag(context.debug_flags, (uint) renderer::DebugFlagBits::DRAW_ID))
+        if(renderer::has_flag(push_constants.debug_flags, (uint) renderer::DebugFlagBits::DRAW_ID))
         {
             uint obj_hash = utils::tea(indices.mesh_draw_index, indices.meshlet_index);
             result.color.rgb =
                     float3(float(obj_hash & 255), float((obj_hash >> 8) & 255), float((obj_hash >> 16) & 255)) / 255.0;
         }
 
-        if(renderer::has_flag(context.debug_flags, (uint) renderer::DebugFlagBits::LOD))
+        if(renderer::has_flag(push_constants.debug_flags, (uint) renderer::DebugFlagBits::LOD))
         {
             float lod_factor = 1.0 - (indices.lod_index / float(indices.lod_count));
             result.color.rgb = utils::jet(lod_factor);
@@ -71,7 +71,7 @@ FragOutput fragment_main(nointerpolation in renderer::index_bundle_t indices,
         return result;
     }
 
-    if(!context.disable_material)
+    if(!push_constants.disable_material)
     {
         result.color = material.color;
 

--- a/shaders/slang/pbr/lighting_environment.slang
+++ b/shaders/slang/pbr/lighting_environment.slang
@@ -3,7 +3,7 @@ import "../renderer/point_light.slang";
 import "../utils/bsdf.slang";
 import "../utils/constants.slang";
 
-[[vk::push_constant]] ConstantBuffer<renderer::context_t> context;
+[[vk::push_constant]] ConstantBuffer<renderer::push_constants_t> push_constants;
 
 struct ubo_t
 {
@@ -54,7 +54,7 @@ float4 fragment_main(float2 tex_coord : TexCoord0, float4 sv_position : SV_Posit
 {
     float depth = u_sampler_2D[GBufferIndex::DEPTH].Sample(tex_coord).x;
 
-    float3 clip_pos = float3(sv_position.xy / context.size, depth);
+    float3 clip_pos = float3(sv_position.xy / push_constants.size, depth);
     float4 viewspace_pos = mul(ubo.inverse_projection, float4(2.0 * clip_pos.xy - 1, clip_pos.z, 1));
     float3 position = mul(ubo.camera_transform, viewspace_pos / viewspace_pos.w).xyz;
 

--- a/shaders/slang/raypipeline.slang
+++ b/shaders/slang/raypipeline.slang
@@ -32,10 +32,11 @@ RaytracingAccelerationStructure topLevelAS;
 ConstantBuffer<ray::trace_data_t> trace_data;
 
 [[vk::binding(2, 0)]]
-Sampler2D u_textures[];
-
-[[vk::binding(3, 0)]]
 SamplerCube u_sampler_cube;
+
+// variable-count binding: must stay the highest binding-number in this set
+[[vk::binding(3, 0)]]
+Sampler2D u_textures[];
 
 //-----------------------------------------------------------------------------
 // ray-generation

--- a/shaders/slang/renderer/types.slang
+++ b/shaders/slang/renderer/types.slang
@@ -1,5 +1,6 @@
 import "../utils/transform.slang";
 import "../utils/packed_vertex.slang";
+import "../utils/camera.slang";
 
 module renderer;
 
@@ -164,7 +165,6 @@ public enum ResourceBinding : uint
 {
     RenderData = 0,
     Textures = 5,
-    JitterOffset = 9,
     DepthPyramid = 17
 };
 
@@ -249,9 +249,17 @@ public struct mesh_buffers_t
     public Ptr<uint8_t, Access.Read> meshlet_triangles;
 };
 
+// current and previous camera, uploaded as one pair
+public struct camera_data_t
+{
+    public utils::camera_t camera;
+    public utils::camera_t last_camera;
+};
+
 // frame-global buffers, provided as device-addresses in a single UBO (set 0, binding 0)
 public struct render_data_t
 {
+    public Ptr<camera_data_t, Access.Read> cameras;
     public Ptr<mesh_draw_t, Access.Read> mesh_draws;
     public Ptr<material_t, Access.Read> materials;
     public Ptr<mesh_buffers_t, Access.Read> mesh_buffers;

--- a/shaders/slang/renderer/types.slang
+++ b/shaders/slang/renderer/types.slang
@@ -158,18 +158,11 @@ public struct context_t
 public enum ResourceBinding : uint
 {
     Vertices = 0,
-    Indices = 1,
     DrawCommands = 2,
     MeshDraws = 3,
     Material = 4,
     Textures = 5,
-    BoneVertexData = 6,
-    Bones = 7,
-    PreviousBones = 8,
     JitterOffset = 9,
-    MorphTargets = 10,
-    MorphParams = 11,
-    PreviousMorphParams = 12,
     Meshlets = 13,
     MeshletVertices = 14,
     MeshletTriangles = 15,

--- a/shaders/slang/renderer/types.slang
+++ b/shaders/slang/renderer/types.slang
@@ -1,4 +1,5 @@
 import "../utils/transform.slang";
+import "../utils/packed_vertex.slang";
 
 module renderer;
 
@@ -21,7 +22,7 @@ public struct mesh_draw_t
     public matrix_struct_t last_matrices;
     public uint mesh_index;
     public uint material_index;
-    public uint vertex_buffer_index;
+    public uint mesh_buffer_index;
     public uint16_t lod_index;
     public uint16_t lod_count;
 };
@@ -134,6 +135,10 @@ public struct material_t
     public bool two_sided;
     public uint texture_type_flags;
     public uint base_texture_index;
+
+    //! explicit tail-padding: slang lays out buffer-reference structs naturally and does not round
+    //! up to the struct-alignment, the host does. keeps the array-stride at 128 on both sides.
+    private uint pad[3];
 };
 
 public enum DebugFlagBits
@@ -143,8 +148,8 @@ public enum DebugFlagBits
     LOD = 0x2
 };
 
-// Render-time context (e.g. passed via push constants)
-public struct context_t
+// push-constant payload, mirrors vierkant::Rasterizer::push_constants_t
+public struct push_constants_t
 {
     public float2 size;
     public float time;
@@ -157,16 +162,9 @@ public struct context_t
 // Shader resource bindings
 public enum ResourceBinding : uint
 {
-    Vertices = 0,
-    DrawCommands = 2,
-    MeshDraws = 3,
-    Material = 4,
+    RenderData = 0,
     Textures = 5,
     JitterOffset = 9,
-    Meshlets = 13,
-    MeshletVertices = 14,
-    MeshletTriangles = 15,
-    MeshletVisibility = 16,
     DepthPyramid = 17
 };
 
@@ -240,6 +238,27 @@ public struct mesh_task_payload_t
     public uint    meshlet_base_index;
     public uint8_t meshlet_delta_indices[MAX_MESH_WORKGROUP_SIZE];
     public uint    object_index;
+};
+
+// per-drawable buffer-addresses, indexed with mesh_draw_t::mesh_buffer_index
+public struct mesh_buffers_t
+{
+    public Ptr<utils::packed_vertex_t, Access.Read> vertices;
+    public Ptr<meshlet_t, Access.Read> meshlets;
+    public Ptr<uint, Access.Read> meshlet_vertices;
+    public Ptr<uint8_t, Access.Read> meshlet_triangles;
+};
+
+// frame-global buffers, provided as device-addresses in a single UBO (set 0, binding 0)
+public struct render_data_t
+{
+    public Ptr<mesh_draw_t, Access.Read> mesh_draws;
+    public Ptr<material_t, Access.Read> materials;
+    public Ptr<mesh_buffers_t, Access.Read> mesh_buffers;
+    public Ptr<indexed_draw_command_t, Access.Read> draw_commands;
+
+    //! meshlet-visibility bitfield, written from the task-shader
+    public uint *meshlet_visibilities;
 };
 
 }// namespace renderer

--- a/shaders/slang/unlit/color.slang
+++ b/shaders/slang/unlit/color.slang
@@ -1,9 +1,6 @@
 import "../renderer/types.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]]
-renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/color.slang
+++ b/shaders/slang/unlit/color.slang
@@ -2,13 +2,10 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
-
-[[vk::binding(renderer::ResourceBinding::Material, 0)]]
-StructuredBuffer<renderer::material_t> materials;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 struct VertexData
 {
@@ -21,9 +18,9 @@ VertexData vertex_main(float3 a_position: Position, float4 a_color: Color, uint 
 {
     VertexData vertex_out;
     indices.mesh_draw_index = instanceID;
-    indices.material_index = draws[instanceID].material_index;
+    indices.material_index = render_data.mesh_draws[instanceID].material_index;
 
-    renderer::matrix_struct_t m = draws[indices.mesh_draw_index].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[indices.mesh_draw_index].current_matrices;
     float3 world_pos = utils::apply_transform(m.transform, a_position);
     sv_position = mul(m.projection, float4(world_pos, 1.0));
     vertex_out.color = a_color;
@@ -34,5 +31,5 @@ VertexData vertex_main(float3 a_position: Position, float4 a_color: Color, uint 
 float4 fragment_main(nointerpolation in renderer::index_bundle_t indices, in VertexData vertex_in)
 {
     uint material_index = indices.material_index;
-    return materials[material_index].color * vertex_in.color;
+    return render_data.materials[material_index].color * vertex_in.color;
 }

--- a/shaders/slang/unlit/convolve_ggx.slang
+++ b/shaders/slang/unlit/convolve_ggx.slang
@@ -2,10 +2,10 @@ import "../renderer/types.slang";
 import "../renderer/importance_sampling.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]] renderer::context_t context;
+[[vk::push_constant]] renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 struct ubo_t { float u_roughness; };
 [[vk::binding(1, 0)]] ConstantBuffer<ubo_t> ubo;
@@ -16,7 +16,7 @@ struct ubo_t { float u_roughness; };
 void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceLocation,
                  out float3 eye_vec, out float4 sv_position: SV_Position)
 {
-    renderer::matrix_struct_t m = draws[instanceID].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[instanceID].current_matrices;
     eye_vec = a_position.xyz;
     sv_position = mul(m.projection, float4(utils::apply_transform(m.transform, a_position), 1.0));
 }

--- a/shaders/slang/unlit/convolve_ggx.slang
+++ b/shaders/slang/unlit/convolve_ggx.slang
@@ -2,8 +2,6 @@ import "../renderer/types.slang";
 import "../renderer/importance_sampling.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]] renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/convolve_lambert.slang
+++ b/shaders/slang/unlit/convolve_lambert.slang
@@ -2,10 +2,10 @@ import "../renderer/types.slang";
 import "../renderer/importance_sampling.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]] renderer::context_t context;
+[[vk::push_constant]] renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[vk::binding(1, 0)]] SamplerCube u_sampler_cube;
 
@@ -13,7 +13,7 @@ StructuredBuffer<renderer::mesh_draw_t> draws;
 void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceLocation,
                  out float3 eye_vec, out float4 sv_position: SV_Position)
 {
-    renderer::matrix_struct_t m = draws[instanceID].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[instanceID].current_matrices;
     eye_vec = a_position.xyz;
     sv_position = mul(m.projection, float4(utils::apply_transform(m.transform, a_position), 1.0));
 }

--- a/shaders/slang/unlit/convolve_lambert.slang
+++ b/shaders/slang/unlit/convolve_lambert.slang
@@ -2,8 +2,6 @@ import "../renderer/types.slang";
 import "../renderer/importance_sampling.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]] renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/cube.slang
+++ b/shaders/slang/unlit/cube.slang
@@ -1,13 +1,10 @@
 import "../renderer/types.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]] renderer::context_t context;
+[[vk::push_constant]] renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
-
-[[vk::binding(renderer::ResourceBinding::Material, 0)]]
-StructuredBuffer<renderer::material_t> materials;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[vk::binding(renderer::ResourceBinding::Textures, 0)]]
 SamplerCube u_sampler_cube[1];
@@ -16,14 +13,14 @@ SamplerCube u_sampler_cube[1];
 void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceLocation,
                  out float3 eye_vec, nointerpolation out uint material_index, out float4 sv_position: SV_Position)
 {
-    renderer::matrix_struct_t m = draws[instanceID].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[instanceID].current_matrices;
     eye_vec = a_position.xyz;
-    material_index = draws[instanceID].material_index;
+    material_index = render_data.mesh_draws[instanceID].material_index;
     sv_position = mul(m.projection, float4(utils::apply_transform(m.transform, a_position), 1.0));
 }
 
 [[shader("pixel")]]
 float4 fragment_main(in float3 eye_vec, nointerpolation in uint material_index) : SV_Target
 {
-    return u_sampler_cube[0].Sample(eye_vec) * materials[material_index].color;
+    return u_sampler_cube[0].Sample(eye_vec) * render_data.materials[material_index].color;
 }

--- a/shaders/slang/unlit/cube.slang
+++ b/shaders/slang/unlit/cube.slang
@@ -1,8 +1,6 @@
 import "../renderer/types.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]] renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/environment_white.slang
+++ b/shaders/slang/unlit/environment_white.slang
@@ -2,16 +2,16 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 import "../utils/procedural_environment.slang";
 
-[[vk::push_constant]] renderer::context_t context;
+[[vk::push_constant]] renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[shader("vertex")]]
 void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceLocation,
                  out float3 eye_vec, out float4 sv_position: SV_Position)
 {
-    renderer::matrix_struct_t m = draws[instanceID].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[instanceID].current_matrices;
     eye_vec = a_position.xyz;
     sv_position = mul(m.projection, float4(utils::apply_transform(m.transform, a_position), 1.0));
 }

--- a/shaders/slang/unlit/environment_white.slang
+++ b/shaders/slang/unlit/environment_white.slang
@@ -2,8 +2,6 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 import "../utils/procedural_environment.slang";
 
-[[vk::push_constant]] renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/panorama.slang
+++ b/shaders/slang/unlit/panorama.slang
@@ -2,10 +2,10 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 import "../utils/constants.slang";
 
-[[vk::push_constant]] renderer::context_t context;
+[[vk::push_constant]] renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[vk::binding(1, 0)]] Sampler2D u_sampler_2D[1];
 
@@ -18,7 +18,7 @@ float2 panorama(float3 ray)
 void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceLocation,
                  out float3 eye_vec, out float4 sv_position: SV_Position)
 {
-    renderer::matrix_struct_t m = draws[instanceID].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[instanceID].current_matrices;
     eye_vec = a_position.xyz;
     sv_position = mul(m.projection, float4(utils::apply_transform(m.transform, a_position), 1.0));
 }

--- a/shaders/slang/unlit/panorama.slang
+++ b/shaders/slang/unlit/panorama.slang
@@ -2,8 +2,6 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 import "../utils/constants.slang";
 
-[[vk::push_constant]] renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/texture.slang
+++ b/shaders/slang/unlit/texture.slang
@@ -1,9 +1,6 @@
 import "../renderer/types.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]]
-renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/shaders/slang/unlit/texture.slang
+++ b/shaders/slang/unlit/texture.slang
@@ -2,13 +2,10 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 
 [[vk::push_constant]]
-renderer::context_t context;
+renderer::push_constants_t push_constants;
 
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
-
-[[vk::binding(renderer::ResourceBinding::Material, 0)]]
-StructuredBuffer<renderer::material_t> materials;
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[vk::binding(renderer::ResourceBinding::Textures, 1)]]
 Sampler2D textures[];
@@ -27,9 +24,9 @@ VertexData vertex_main(
 {
     VertexData vertex_out;
     indices.mesh_draw_index = instanceID;
-    indices.material_index = draws[instanceID].material_index;
+    indices.material_index = render_data.mesh_draws[instanceID].material_index;
 
-    renderer::matrix_struct_t m = draws[indices.mesh_draw_index].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[indices.mesh_draw_index].current_matrices;
     float3 world_pos = utils::apply_transform(m.transform, a_position);
     sv_position = mul(m.projection, float4(world_pos, 1.0));
     vertex_out.color = a_color;
@@ -43,7 +40,7 @@ float4 fragment_main(nointerpolation in renderer::index_bundle_t indices,
 {
     uint material_index = indices.material_index;
 
-    uint texture_index = materials[material_index].base_texture_index;
+    uint texture_index = render_data.materials[material_index].base_texture_index;
     float4 tex_color = textures[NonUniformResourceIndex(texture_index)].Sample(vertex_in.tex_coord);
-    return tex_color * materials[material_index].color * vertex_in.color;
+    return tex_color * render_data.materials[material_index].color * vertex_in.color;
 }

--- a/shaders/slang/unlit/unlit.slang
+++ b/shaders/slang/unlit/unlit.slang
@@ -2,20 +2,19 @@ import "../renderer/types.slang";
 import "../utils/transform.slang";
 
 [[vk::push_constant]]
-renderer::context_t context;
-[[vk::binding(renderer::ResourceBinding::MeshDraws, 0)]]
-StructuredBuffer<renderer::mesh_draw_t> draws;
-[[vk::binding(renderer::ResourceBinding::Material, 0)]]
-StructuredBuffer<renderer::material_t> materials;
+renderer::push_constants_t push_constants;
+
+[[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
+ConstantBuffer<renderer::render_data_t> render_data;
 
 [[shader("vertex")]]
 void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceLocation,
                  nointerpolation out renderer::index_bundle_t indices, out float4 sv_position: SV_Position)
 {
     indices.mesh_draw_index = instanceID;
-    indices.material_index = draws[instanceID].material_index;
+    indices.material_index = render_data.mesh_draws[instanceID].material_index;
 
-    renderer::matrix_struct_t m = draws[indices.mesh_draw_index].current_matrices;
+    renderer::matrix_struct_t m = render_data.mesh_draws[indices.mesh_draw_index].current_matrices;
     float3 world_pos = utils::apply_transform(m.transform, a_position);
     sv_position = mul(m.projection, float4(world_pos, 1.0));
 }
@@ -23,5 +22,5 @@ void vertex_main(float3 a_position: Position, uint instanceID: SV_StartInstanceL
 [[shader("pixel")]]
 float4 fragment_main(nointerpolation in renderer::index_bundle_t indices, in float4 sv_position: SV_Position)
 {
-    return materials[indices.material_index].color;
+    return render_data.materials[indices.material_index].color;
 }

--- a/shaders/slang/unlit/unlit.slang
+++ b/shaders/slang/unlit/unlit.slang
@@ -1,9 +1,6 @@
 import "../renderer/types.slang";
 import "../utils/transform.slang";
 
-[[vk::push_constant]]
-renderer::push_constants_t push_constants;
-
 [[vk::binding(renderer::ResourceBinding::RenderData, 0)]]
 ConstantBuffer<renderer::render_data_t> render_data;
 

--- a/src/Device.cpp
+++ b/src/Device.cpp
@@ -167,13 +167,15 @@ Device::Device(const create_info_t &create_info) : m_physical_device(create_info
     {
         VkPhysicalDeviceProperties2 physical_device_properties = {};
         physical_device_properties.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_PROPERTIES_2;
+        m_properties.vulkan12.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_2_PROPERTIES;
         m_properties.vulkan13.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_VULKAN_1_3_PROPERTIES;
         m_properties.acceleration_structure.sType =
                 VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_ACCELERATION_STRUCTURE_PROPERTIES_KHR;
         m_properties.ray_pipeline.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_RAY_TRACING_PIPELINE_PROPERTIES_KHR;
         m_properties.mesh_shader.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_MESH_SHADER_PROPERTIES_EXT;
         m_properties.micromap_opacity.sType = VK_STRUCTURE_TYPE_PHYSICAL_DEVICE_OPACITY_MICROMAP_PROPERTIES_EXT;
-        physical_device_properties.pNext = &m_properties.vulkan13;
+        physical_device_properties.pNext = &m_properties.vulkan12;
+        m_properties.vulkan12.pNext = &m_properties.vulkan13;
         m_properties.vulkan13.pNext = &m_properties.acceleration_structure;
         m_properties.acceleration_structure.pNext = &m_properties.ray_pipeline;
         m_properties.ray_pipeline.pNext = &m_properties.mesh_shader;

--- a/src/DrawContext.cpp
+++ b/src/DrawContext.cpp
@@ -38,17 +38,6 @@ DrawContext::DrawContext(vierkant::DevicePtr device) : m_device(std::move(device
         fmt.attribute_descriptions = vierkant::create_attribute_descriptions(mesh->vertex_attribs);
         fmt.primitive_topology = entry.primitive_type;
 
-        // descriptors
-        vierkant::descriptor_t desc_matrix = {};
-        desc_matrix.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_matrix.stage_flags = VK_SHADER_STAGE_VERTEX_BIT;
-        m_drawable_rect.descriptors[vierkant::Rasterizer::BINDING_MESH_DRAWS] = desc_matrix;
-
-        vierkant::descriptor_t desc_material = {};
-        desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-        m_drawable_rect.descriptors[vierkant::Rasterizer::BINDING_MATERIAL] = desc_material;
-
         m_drawable_rect.mesh = mesh;
         m_drawable_rect.share_material = false;
         m_drawable_rect.num_indices = lod.num_indices;
@@ -324,17 +313,6 @@ void DrawContext::draw_lines(vierkant::Rasterizer &renderer, const std::vector<g
         fmt.shader_stages = m_pipeline_cache->shader_stages(vierkant::ShaderType::UNLIT);
         fmt.primitive_topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
 
-        // descriptors
-        vierkant::descriptor_t desc_matrix = {};
-        desc_matrix.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_matrix.stage_flags = VK_SHADER_STAGE_VERTEX_BIT;
-        drawable.descriptors[vierkant::Rasterizer::BINDING_MESH_DRAWS] = desc_matrix;
-
-        vierkant::descriptor_t desc_material = {};
-        desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-        drawable.descriptors[vierkant::Rasterizer::BINDING_MATERIAL] = desc_material;
-
         auto mesh = vierkant::Mesh::create();
 
         // vertex attrib -> position
@@ -393,17 +371,6 @@ void DrawContext::draw_lines(vierkant::Rasterizer &renderer, const std::vector<g
         fmt.depth_write = false;
         fmt.shader_stages = m_pipeline_cache->shader_stages(vierkant::ShaderType::UNLIT_COLOR);
         fmt.primitive_topology = VK_PRIMITIVE_TOPOLOGY_LINE_LIST;
-
-        // descriptors
-        vierkant::descriptor_t desc_matrix = {};
-        desc_matrix.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_matrix.stage_flags = VK_SHADER_STAGE_VERTEX_BIT;
-        drawable.descriptors[vierkant::Rasterizer::BINDING_MESH_DRAWS] = desc_matrix;
-
-        vierkant::descriptor_t desc_material = {};
-        desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-        desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-        drawable.descriptors[vierkant::Rasterizer::BINDING_MATERIAL] = desc_material;
 
         auto mesh = vierkant::Mesh::create();
 

--- a/src/DrawContext.cpp
+++ b/src/DrawContext.cpp
@@ -57,10 +57,6 @@ DrawContext::DrawContext(vierkant::DevicePtr device) : m_device(std::move(device
         m_drawable_image = m_drawable_rect;
         m_drawable_image.pipeline_format.shader_stages =
                 m_pipeline_cache->shader_stages(vierkant::ShaderType::UNLIT_TEXTURE);
-        vierkant::descriptor_t desc_texture = {};
-        desc_texture.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-        desc_texture.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-        m_drawable_image.descriptors[vierkant::Rasterizer::BINDING_TEXTURES] = desc_texture;
     }
 
     graphics_pipeline_info_t fmt = {};
@@ -249,7 +245,7 @@ void DrawContext::draw_text(vierkant::Rasterizer &renderer, const std::string &t
     drawable.matrices.projection =
             glm::orthoRH(0.f, renderer.viewport.width, 0.f, renderer.viewport.height, 0.0f, 1.0f);
     drawable.matrices.transform.translation = {pos.x, pos.y, 0};
-    drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES].images = {font->glyph_texture()};
+    drawable.textures = {font->glyph_texture()};
     drawable.num_indices = lod_0.num_indices;
     drawable.num_vertices = entry.num_vertices;
     renderer.stage_drawable(std::move(drawable));
@@ -300,7 +296,7 @@ void DrawContext::draw_image(vierkant::Rasterizer &renderer, const vierkant::Ima
     drawable.material.color = color;
 
     // set image
-    drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES].images = {image};
+    drawable.textures = {image};
 
     // stage image drawable
     renderer.stage_drawable(std::move(drawable));
@@ -588,7 +584,11 @@ void DrawContext::draw_skybox(vierkant::Rasterizer &renderer, const vierkant::Im
     auto drawable = m_drawable_skybox;
     drawable.matrices.transform = t;
     drawable.matrices.projection = camera::projection_matrix(cam.get());
-    drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES].images = {environment};
+    // skybox samples a SamplerCube from set 0, not the bindless 2D-array
+    auto &desc_cube = drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES];
+    desc_cube.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    desc_cube.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    desc_cube.images = {environment};
     drawable.pipeline_format.shader_stages = m_pipeline_cache->shader_stages(vierkant::ShaderType::UNLIT_CUBE);
     drawable.material.color = glm::vec4(glm::vec3(environment_factor), 1.f);
     drawable.share_material = false;

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -77,8 +77,14 @@ PBRDeferred::PBRDeferred(const DevicePtr &device, const create_info_t &create_in
 
         resize_storage(frame_context, create_info.settings.resolution, create_info.settings.output_resolution);
 
-        frame_context.g_buffer_camera_ubo = vierkant::Buffer::create(
-                m_device, nullptr, sizeof(glm::vec2), VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT, VMA_MEMORY_USAGE_CPU_TO_GPU);
+        // must match renderer::camera_data_t, which the g-buffer shaders read via device-address
+        static_assert(sizeof(camera_params_t) == 176, "unexpected camera_params_t size");
+
+        // sized for the current/previous pair up front, so the device-address never moves
+        frame_context.g_buffer_camera_ubo =
+                vierkant::Buffer::create(m_device, nullptr, 2 * sizeof(camera_params_t),
+                                         VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT | VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
+                                         VMA_MEMORY_USAGE_CPU_TO_GPU);
 
         frame_context.lighting_param_ubo =
                 vierkant::Buffer::create(device, nullptr, sizeof(environment_lighting_ubo_t),
@@ -479,10 +485,10 @@ SceneRenderer::render_result_t PBRDeferred::render_scene(Rasterizer &renderer, c
 
     // create g-buffer
     auto &g_buffer = geometry_pass(frame_context.cull_result);
-    auto albedo_map = g_buffer.color_attachment(G_BUFFER_ALBEDO);
+    auto albedo_img = g_buffer.color_attachment(G_BUFFER_ALBEDO);
 
     // default to color image
-    auto out_img = albedo_map;
+    auto out_img = albedo_img;
     auto depth_img = frame_context.g_buffer_main.depth_attachment();
 
     // lighting-pass
@@ -496,7 +502,8 @@ SceneRenderer::render_result_t PBRDeferred::render_scene(Rasterizer &renderer, c
     out_img = post_fx_pass(cam, out_img, depth_img);
 
     // draw final color+depth with provided renderer
-    m_draw_context.draw_image_fullscreen(renderer, out_img, depth_img, true);
+    m_draw_context.draw_image_fullscreen(renderer, frame_context.settings.debug_draw_flags ? albedo_img : out_img,
+                                         depth_img, true);
 
     // end debug label
     {
@@ -657,11 +664,6 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
 
     if(!frame_context.recycle_commands)
     {
-        vierkant::descriptor_t camera_desc = {};
-        camera_desc.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-        camera_desc.stage_flags = VK_SHADER_STAGE_VERTEX_BIT;
-        camera_desc.buffers = {frame_context.g_buffer_camera_ubo};
-
         // draw all geometry
         for(auto &drawable: cull_result.drawables)
         {
@@ -675,7 +677,6 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             if(drawable.mesh->meshlets && frame_context.settings.use_meshlet_pipeline)
             {
                 shader_flags |= PROP_MESHLETS;
-                camera_desc.stage_flags |= VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
 
                 auto &mesh_shader_props = m_device->properties().mesh_shader;
                 vierkant::pipeline_specialization pipeline_specialization;
@@ -718,9 +719,6 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             drawable.pipeline_format.polygon_mode =
                     frame_context.settings.wireframe ? VK_POLYGON_MODE_LINE : VK_POLYGON_MODE_FILL;
 
-            // add descriptor for a jitter-offset
-            drawable.descriptors[Rasterizer::BINDING_JITTER_OFFSET] = camera_desc;
-
             // stage drawables
             m_g_renderer_main.stage_drawable(drawable);
             if(use_gpu_culling)
@@ -740,6 +738,8 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
     m_g_renderer_main.disable_material = m_g_renderer_post.disable_material = frame_context.settings.disable_material;
     m_g_renderer_main.debug_draw_flags = m_g_renderer_post.debug_draw_flags = frame_context.settings.debug_draw_flags;
     m_g_renderer_main.indirect_draw = m_g_renderer_post.indirect_draw = frame_context.settings.indirect_draw;
+    m_g_renderer_main.camera_buffer_address = m_g_renderer_post.camera_buffer_address =
+            frame_context.g_buffer_camera_ubo->device_address();
     m_g_renderer_main.use_mesh_shader = m_g_renderer_post.use_mesh_shader = frame_context.settings.use_meshlet_pipeline;
 
     // draw last visible objects

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -688,10 +688,9 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
                 pipeline_specialization.set(2, VkBool32(use_gpu_culling && !drawable.vertex_buffer));
                 drawable.pipeline_format.specialization = std::move(pipeline_specialization);
 
-                auto &desc_depth_pyramid = drawable.descriptors[Rasterizer::BINDING_DEPTH_PYRAMID];
-                desc_depth_pyramid.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-                desc_depth_pyramid.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT;
-                desc_depth_pyramid.images = {vierkant::get_depth_pyramid(frame_context.gpu_cull_context)};
+                // only the image, the rasterizer declares type and stage-flags for every drawable
+                drawable.descriptors[Rasterizer::BINDING_DEPTH_PYRAMID].images = {
+                        vierkant::get_depth_pyramid(frame_context.gpu_cull_context)};
             }
 
             // select shader-stages from cache

--- a/src/PBRDeferred.cpp
+++ b/src/PBRDeferred.cpp
@@ -755,7 +755,7 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
         frame_context.indirect_draw_params_main.draws_out = params.draws_out;
         frame_context.indirect_draw_params_main.mesh_draws = params.mesh_draws;
         frame_context.indirect_draw_params_main.materials = params.materials;
-        frame_context.indirect_draw_params_main.vertex_buffer_addresses = params.vertex_buffer_addresses;
+        frame_context.indirect_draw_params_main.mesh_buffers = params.mesh_buffers;
         frame_context.indirect_draw_params_main.mesh_entries = params.mesh_entries;
         frame_context.indirect_draw_params_main.meshlet_visibilities = params.meshlet_visibilities;
 
@@ -857,19 +857,22 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
 
                     for(uint32_t idx: frame_context.cull_result.object_id_to_drawable_indices[obj_id])
                     {
-                        uint32_t vertex_buffer_index = params.mesh_draws_host[idx].vertex_buffer_index;
+                        uint32_t mesh_buffer_index = params.mesh_draws_host[idx].mesh_buffer_index;
 
-                        if(!mesh_indices.contains(vertex_buffer_index))
+                        if(!mesh_indices.contains(mesh_buffer_index))
                         {
+                            // patch only the 'vertices' member of the addressed mesh_buffers_t
                             vierkant::staging_copy_info_t copy_vertex_address = {};
                             copy_vertex_address.num_bytes = sizeof(VkDeviceAddress);
                             copy_vertex_address.data = &address;
-                            copy_vertex_address.dst_buffer = params.vertex_buffer_addresses;
-                            copy_vertex_address.dst_offset = sizeof(VkDeviceAddress) * vertex_buffer_index;
+                            copy_vertex_address.dst_buffer = params.mesh_buffers;
+                            copy_vertex_address.dst_offset =
+                                    sizeof(vierkant::Rasterizer::mesh_buffers_t) * mesh_buffer_index +
+                                    offsetof(vierkant::Rasterizer::mesh_buffers_t, vertices);
                             copy_vertex_address.dst_access = VK_ACCESS_2_SHADER_READ_BIT;
                             copy_vertex_address.dst_stage = VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT;
                             staging_copies.push_back(copy_vertex_address);
-                            mesh_indices.insert(vertex_buffer_index);
+                            mesh_indices.insert(mesh_buffer_index);
                         }
                     }
                 }
@@ -930,7 +933,7 @@ vierkant::Framebuffer &PBRDeferred::geometry_pass(cull_result_t &cull_result)
             // re-use mesh-draws/vertex-buffers/transforms/visibilities from main-pass
             params.mesh_draws = frame_context.indirect_draw_params_main.mesh_draws;
             params.materials = frame_context.indirect_draw_params_main.materials;
-            params.vertex_buffer_addresses = frame_context.indirect_draw_params_main.vertex_buffer_addresses;
+            params.mesh_buffers = frame_context.indirect_draw_params_main.mesh_buffers;
             params.mesh_entries = frame_context.indirect_draw_params_main.mesh_entries;
             params.meshlet_visibilities = frame_context.indirect_draw_params_main.meshlet_visibilities;
 

--- a/src/PBRPathTracer.cpp
+++ b/src/PBRPathTracer.cpp
@@ -562,18 +562,20 @@ void PBRPathTracer::update_trace_descriptors(frame_context_t &frame_context, con
     desc_trace_data.stage_flags = VK_SHADER_STAGE_ALL;
     desc_trace_data.buffers = {frame_context.trace_data_ubo};
 
-    // images are assigned during the light-gather below: scene-textures plus any projector-cookies
-    vierkant::descriptor_t &desc_textures = frame_context.tracable.descriptors[2];
-    desc_textures.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-    desc_textures.stage_flags = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR | VK_SHADER_STAGE_ANY_HIT_BIT_KHR;
-
     if(m_environment)
     {
-        vierkant::descriptor_t &desc_environment = frame_context.tracable.descriptors[3];
+        vierkant::descriptor_t &desc_environment = frame_context.tracable.descriptors[2];
         desc_environment.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
         desc_environment.stage_flags = VK_SHADER_STAGE_MISS_BIT_KHR;
         desc_environment.images = {m_environment};
     }
+
+    // images are assigned during the light-gather below: scene-textures plus any projector-cookies.
+    // variable-count -> must stay the highest binding in this set
+    vierkant::descriptor_t &desc_textures = frame_context.tracable.descriptors[3];
+    desc_textures.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+    desc_textures.stage_flags = VK_SHADER_STAGE_CLOSEST_HIT_BIT_KHR | VK_SHADER_STAGE_ANY_HIT_BIT_KHR;
+    desc_textures.variable_count = true;
 
     camera_params_t camera_params = {};
     camera_params.projection_view = projection_view(cam);

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -97,6 +97,14 @@ Rasterizer::Rasterizer(DevicePtr device, const create_info_t &create_info)
     debug_label = create_info.debug_label;
     use_gpu_timestamps = create_info.use_gpu_timestamps;
 
+    // 1x1 stand-in for an absent depth-pyramid
+    uint32_t v = 0xFFFFFFFF;
+    vierkant::Image::Format placeholder_fmt = {};
+    placeholder_fmt.extent = {1, 1, 1};
+    placeholder_fmt.format = VK_FORMAT_R8G8B8A8_UNORM;
+    placeholder_fmt.name = "Rasterizer: placeholder_image";
+    m_placeholder_image = vierkant::Image::create(m_device, &v, placeholder_fmt);
+
     // push constant range
     m_push_constant_range.offset = 0;
     m_push_constant_range.size = sizeof(push_constants_t);
@@ -147,6 +155,7 @@ void swap(Rasterizer &lhs, Rasterizer &rhs) noexcept
     std::swap(lhs.use_mesh_shader, rhs.use_mesh_shader);
     std::swap(lhs.use_gpu_timestamps, rhs.use_gpu_timestamps);
     std::swap(lhs.m_mesh_task_count, rhs.m_mesh_task_count);
+    std::swap(lhs.m_placeholder_image, rhs.m_placeholder_image);
 }
 
 ////////////////////////////////////////////////////////////////////////////////////////////////////////////////////////
@@ -357,9 +366,15 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
         if(!drawable.use_own_buffers)
         {
             // all frame-global buffers arrive as device-addresses in one uniform-buffer
-            auto &desc_render_context = drawable.descriptors[Rasterizer::BINDING_RENDER_DATA];
-            desc_render_context.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
-            desc_render_context.stage_flags = VK_SHADER_STAGE_ALL;
+            auto &desc_render_data = drawable.descriptors[Rasterizer::BINDING_RENDER_DATA];
+            desc_render_data.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            desc_render_data.stage_flags = VK_SHADER_STAGE_ALL;
+
+            // always declared, so the set-0 layout does not depend on gpu-culling being on
+            auto &desc_depth_pyramid = drawable.descriptors[Rasterizer::BINDING_DEPTH_PYRAMID];
+            desc_depth_pyramid.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            desc_depth_pyramid.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT;
+            if(desc_depth_pyramid.images.empty()) { desc_depth_pyramid.images = {m_placeholder_image}; }
         }
 
         indexed_drawable.descriptor_set_layout = vierkant::find_or_create_set_layout(

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -358,51 +358,44 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
         indexed_drawable.object_index = i;
         indexed_drawable.drawable = &drawable;
 
-        if(!drawable.descriptor_set_layout)
+        if(!drawable.use_own_buffers)
         {
-            if(!drawable.use_own_buffers)
+            // descriptors
+            auto &desc_vertices = drawable.descriptors[Rasterizer::BINDING_VERTICES];
+            desc_vertices.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            desc_vertices.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
+
+            auto &desc_draws = drawable.descriptors[Rasterizer::BINDING_DRAW_COMMANDS];
+            desc_draws.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            desc_draws.stage_flags =
+                    VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
+
+            auto &desc_mesh_draws = drawable.descriptors[Rasterizer::BINDING_MESH_DRAWS];
+            desc_mesh_draws.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            desc_mesh_draws.stage_flags =
+                    VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
+
+            auto &desc_material = drawable.descriptors[Rasterizer::BINDING_MATERIAL];
+            desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+            desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_TASK_BIT_EXT;
+
+            auto &desc_texture = drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES];
+            desc_texture.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
+            desc_texture.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
+
+            if(vkCmdDrawMeshTasksEXT && use_mesh_shader && drawable.mesh && drawable.mesh->meshlets)
             {
-                // descriptors
-                auto &desc_vertices = drawable.descriptors[Rasterizer::BINDING_VERTICES];
-                desc_vertices.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_vertices.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
-
-                auto &desc_draws = drawable.descriptors[Rasterizer::BINDING_DRAW_COMMANDS];
-                desc_draws.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_draws.stage_flags =
-                        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
-
-                auto &desc_mesh_draws = drawable.descriptors[Rasterizer::BINDING_MESH_DRAWS];
-                desc_mesh_draws.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_mesh_draws.stage_flags =
-                        VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
-
-                auto &desc_material = drawable.descriptors[Rasterizer::BINDING_MATERIAL];
-                desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_TASK_BIT_EXT;
-
-                auto &desc_texture = drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES];
-                desc_texture.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-                desc_texture.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-
-                if(vkCmdDrawMeshTasksEXT && use_mesh_shader && drawable.mesh && drawable.mesh->meshlets)
-                {
-                    auto &desc_meshlet_vis = drawable.descriptors[Rasterizer::BINDING_MESHLET_VISIBILITY];
-                    desc_meshlet_vis.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                    desc_meshlet_vis.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT;
-                }
+                auto &desc_meshlet_vis = drawable.descriptors[Rasterizer::BINDING_MESHLET_VISIBILITY];
+                desc_meshlet_vis.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
+                desc_meshlet_vis.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT;
             }
-            // only provide a global texture-array for indirect draws
-            if(indirect_draw) { drawable.descriptors.erase(BINDING_TEXTURES); }
+        }
+        // only provide a global texture-array for indirect draws
+        if(indirect_draw) { drawable.descriptors.erase(BINDING_TEXTURES); }
 
-            indexed_drawable.descriptor_set_layout = vierkant::find_or_create_set_layout(
-                    m_device, drawable.descriptors, frame_assets.descriptor_set_layouts, next_set_layouts);
-            pipeline_format.descriptor_set_layouts = {indexed_drawable.descriptor_set_layout.get()};
-        }
-        else
-        {
-            indexed_drawable.descriptor_set_layout = std::move(drawable.descriptor_set_layout);
-        }
+        indexed_drawable.descriptor_set_layout = vierkant::find_or_create_set_layout(
+                m_device, drawable.descriptors, frame_assets.descriptor_set_layouts, next_set_layouts);
+        pipeline_format.descriptor_set_layouts = {indexed_drawable.descriptor_set_layout.get()};
 
         // bindless texture-array
         pipeline_format.descriptor_set_layouts.push_back(bindless_texture_layout.get());

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -314,6 +314,7 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
     auto &desc_all_textures = bindless_texture_desc[BINDING_TEXTURES];
     desc_all_textures.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
     desc_all_textures.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
+    desc_all_textures.variable_count = true;
     desc_all_textures.images = textures;
 
     auto bindless_texture_layout = vierkant::find_or_create_set_layout(
@@ -537,7 +538,7 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
                     frame_assets.descriptor_sets, next_descriptor_sets, false);
             auto bindless_texture_set = vierkant::find_or_create_descriptor_set(
                     m_device, bindless_texture_layout.get(), bindless_texture_desc, m_descriptor_pool,
-                    frame_assets.descriptor_sets, next_descriptor_sets, false);
+                    frame_assets.descriptor_sets, next_descriptor_sets, true);
 
             draw_asset.descriptor_set_handles = {descriptor_set.get(), bindless_texture_set.get()};
         }

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -284,10 +284,8 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
     };
 
     auto create_mesh_key = [create_texture_hash](const drawable_t &drawable) -> texture_index_key_t {
-        const auto it = drawable.descriptors.find(BINDING_TEXTURES);
-        if(it == drawable.descriptors.end() || it->second.images.empty()) { return {drawable.mesh.get(), {}}; }
-        const auto &drawable_textures = it->second.images;
-        return {drawable.mesh.get(), create_texture_hash(drawable_textures)};
+        if(drawable.textures.empty()) { return {drawable.mesh.get(), {}}; }
+        return {drawable.mesh.get(), create_texture_hash(drawable.textures)};
     };
 
     texture_index_map_t texture_base_index_map;
@@ -295,17 +293,14 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
     // swoop all texture-indices
     for(const auto &drawable: frame_assets.drawables)
     {
-        auto it = drawable.descriptors.find(BINDING_TEXTURES);
-        if(it == drawable.descriptors.end() || it->second.images.empty()) { continue; }
-
-        const auto &drawable_textures = it->second.images;
+        if(drawable.textures.empty()) { continue; }
 
         // insert other textures from drawables
-        if(texture_index_key_t key = {drawable.mesh.get(), create_texture_hash(drawable_textures)};
+        if(texture_index_key_t key = {drawable.mesh.get(), create_texture_hash(drawable.textures)};
            !texture_base_index_map.contains(key))
         {
             texture_base_index_map[key] = textures.size();
-            textures.insert(textures.end(), drawable_textures.begin(), drawable_textures.end());
+            textures.insert(textures.end(), drawable.textures.begin(), drawable.textures.end());
         }
     }
 
@@ -379,10 +374,6 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
             desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
             desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_TASK_BIT_EXT;
 
-            auto &desc_texture = drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES];
-            desc_texture.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-            desc_texture.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-
             if(vkCmdDrawMeshTasksEXT && use_mesh_shader && drawable.mesh && drawable.mesh->meshlets)
             {
                 auto &desc_meshlet_vis = drawable.descriptors[Rasterizer::BINDING_MESHLET_VISIBILITY];
@@ -390,8 +381,6 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
                 desc_meshlet_vis.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT;
             }
         }
-        // only provide a global texture-array for indirect draws
-        if(indirect_draw) { drawable.descriptors.erase(BINDING_TEXTURES); }
 
         indexed_drawable.descriptor_set_layout = vierkant::find_or_create_set_layout(
                 m_device, drawable.descriptors, frame_assets.descriptor_set_layouts, next_set_layouts);

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -355,31 +355,10 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
 
         if(!drawable.use_own_buffers)
         {
-            // descriptors
-            auto &desc_vertices = drawable.descriptors[Rasterizer::BINDING_VERTICES];
-            desc_vertices.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_vertices.stage_flags = VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_MESH_BIT_EXT;
-
-            auto &desc_draws = drawable.descriptors[Rasterizer::BINDING_DRAW_COMMANDS];
-            desc_draws.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_draws.stage_flags =
-                    VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
-
-            auto &desc_mesh_draws = drawable.descriptors[Rasterizer::BINDING_MESH_DRAWS];
-            desc_mesh_draws.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_mesh_draws.stage_flags =
-                    VK_SHADER_STAGE_VERTEX_BIT | VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
-
-            auto &desc_material = drawable.descriptors[Rasterizer::BINDING_MATERIAL];
-            desc_material.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-            desc_material.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT | VK_SHADER_STAGE_TASK_BIT_EXT;
-
-            if(vkCmdDrawMeshTasksEXT && use_mesh_shader && drawable.mesh && drawable.mesh->meshlets)
-            {
-                auto &desc_meshlet_vis = drawable.descriptors[Rasterizer::BINDING_MESHLET_VISIBILITY];
-                desc_meshlet_vis.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_meshlet_vis.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT;
-            }
+            // all frame-global buffers arrive as device-addresses in one uniform-buffer
+            auto &desc_render_context = drawable.descriptors[Rasterizer::BINDING_RENDER_DATA];
+            desc_render_context.type = VK_DESCRIPTOR_TYPE_UNIFORM_BUFFER;
+            desc_render_context.stage_flags = VK_SHADER_STAGE_ALL;
         }
 
         indexed_drawable.descriptor_set_layout = vierkant::find_or_create_set_layout(
@@ -490,6 +469,30 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
         draw_buffer_indexed = frame_assets.indirect_indexed_bundle.draws_out;
     }
 
+    // the draw-command buffer is only known after the delegate -> fill the render-data here
+    {
+        const auto &bundle = frame_assets.indirect_indexed_bundle;
+        render_data_t render_data = {};
+        render_data.mesh_draws = bundle.mesh_draws ? bundle.mesh_draws->device_address() : 0;
+        render_data.materials = bundle.materials ? bundle.materials->device_address() : 0;
+        render_data.mesh_buffers = bundle.mesh_buffers ? bundle.mesh_buffers->device_address() : 0;
+        render_data.draw_commands = draw_buffer_indexed ? draw_buffer_indexed->device_address() : 0;
+        render_data.meshlet_visibilities =
+                bundle.meshlet_visibilities ? bundle.meshlet_visibilities->device_address() : 0;
+
+        if(!frame_assets.render_data_ubo)
+        {
+            vierkant::Buffer::create_info_t buffer_info = {};
+            buffer_info.device = m_device;
+            buffer_info.num_bytes = sizeof(render_data_t);
+            buffer_info.usage = VK_BUFFER_USAGE_UNIFORM_BUFFER_BIT;
+            buffer_info.mem_usage = VMA_MEMORY_USAGE_CPU_TO_GPU;
+            buffer_info.name = "Rasterizer: render_data_ubo";
+            frame_assets.render_data_ubo = vierkant::Buffer::create(buffer_info);
+        }
+        frame_assets.render_data_ubo->set_data(&render_data, sizeof(render_data_t));
+    }
+
     // set buffer-descriptors after delegate
     for(const auto &[pipe_fmt, indexed_drawables]: pipeline_drawables)
     {
@@ -503,16 +506,7 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
             // predefined buffers
             if(!draw_asset.drawable->use_own_buffers)
             {
-                descriptors[BINDING_VERTICES].buffers = {frame_assets.indirect_indexed_bundle.vertex_buffer_addresses};
-                descriptors[BINDING_MESH_DRAWS].buffers = {frame_assets.indirect_indexed_bundle.mesh_draws};
-                descriptors[BINDING_MATERIAL].buffers = {frame_assets.indirect_indexed_bundle.materials};
-                descriptors[BINDING_DRAW_COMMANDS].buffers = {draw_buffer_indexed};
-
-                if(descriptors.contains(BINDING_MESHLET_VISIBILITY))
-                {
-                    descriptors[BINDING_MESHLET_VISIBILITY].buffers = {
-                            frame_assets.indirect_indexed_bundle.meshlet_visibilities};
-                }
+                descriptors[BINDING_RENDER_DATA].buffers = {frame_assets.render_data_ubo};
             }
 
             auto descriptor_set = vierkant::find_or_create_descriptor_set(
@@ -713,7 +707,7 @@ void Rasterizer::reset()
 
 void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_assets_t &frame_asset)
 {
-    std::vector<VkDeviceAddress> vertex_buffer_refs;
+    std::vector<mesh_buffers_t> mesh_buffers;
     std::vector<mesh_entry_t> mesh_entries;
     std::map<std::pair<const vierkant::Mesh *, uint32_t>, uint32_t> mesh_entry_map;
 
@@ -731,7 +725,7 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
     {
         const auto &drawable = drawables[i];
         uint32_t mesh_index = 0;
-        uint32_t vertex_buffer_index = vertex_buffer_refs.size();
+        uint32_t mesh_buffer_index = mesh_buffers.size();
         uint32_t material_index = material_data.size();
 
         if(drawable.mesh && !drawable.mesh->entries.empty())
@@ -758,9 +752,13 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
                 mesh_index = mesh_entry_it->second;
             }
 
-            VkDeviceAddress vertex_buffer_address =
-                    drawable.vertex_buffer ? drawable.vertex_buffer : drawable.mesh->vertex_buffer->device_address();
-            vertex_buffer_refs.push_back(vertex_buffer_address);
+            const auto &mesh = drawable.mesh;
+            mesh_buffers_t buffers = {};
+            buffers.vertices = drawable.vertex_buffer ? drawable.vertex_buffer : mesh->vertex_buffer->device_address();
+            if(mesh->meshlets) { buffers.meshlets = mesh->meshlets->device_address(); }
+            if(mesh->meshlet_vertices) { buffers.meshlet_vertices = mesh->meshlet_vertices->device_address(); }
+            if(mesh->meshlet_triangles) { buffers.meshlet_triangles = mesh->meshlet_triangles->device_address(); }
+            mesh_buffers.push_back(buffers);
 
             // only dedup materials that are shared via a valid material-id
             bool share_material = drawable.share_material && drawable.material_id;
@@ -786,7 +784,7 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
         frame_asset.mesh_draws[i].current_matrices = drawable.matrices;
         frame_asset.mesh_draws[i].mesh_index = mesh_index;
         frame_asset.mesh_draws[i].material_index = material_index;
-        frame_asset.mesh_draws[i].vertex_buffer_index = vertex_buffer_index;
+        frame_asset.mesh_draws[i].mesh_buffer_index = mesh_buffer_index;
 
         if(drawable.last_matrices) { frame_asset.mesh_draws[i].last_matrices = *drawable.last_matrices; }
         else
@@ -800,7 +798,9 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
         if(!out_buffer)
         {
             out_buffer = vierkant::Buffer::create(device, array,
-                                                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT | VK_BUFFER_USAGE_TRANSFER_SRC_BIT,
+                                                  VK_BUFFER_USAGE_STORAGE_BUFFER_BIT |
+                                                          VK_BUFFER_USAGE_TRANSFER_SRC_BIT |
+                                                          VK_BUFFER_USAGE_SHADER_DEVICE_ADDRESS_BIT,
                                                   VMA_MEMORY_USAGE_CPU_TO_GPU);
         }
         else
@@ -861,8 +861,9 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
         frame_asset.staging_command_buffer.begin();
         if(debug_label) { vierkant::begin_label(frame_asset.staging_command_buffer.handle(), *debug_label); }
 
-        add_staging_copy(vertex_buffer_refs, frame_asset.vertex_buffer_refs, VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
-                         VK_ACCESS_2_SHADER_READ_BIT, "Rasterizer: vertex_buffer_refs");
+        add_staging_copy(mesh_buffers, frame_asset.mesh_buffers,
+                         VK_PIPELINE_STAGE_2_PRE_RASTERIZATION_SHADERS_BIT | VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
+                         VK_ACCESS_2_SHADER_READ_BIT, "Rasterizer: mesh_buffers");
         add_staging_copy(mesh_entries, frame_asset.mesh_entry_buffer, VK_PIPELINE_STAGE_2_COMPUTE_SHADER_BIT,
                          VK_ACCESS_2_SHADER_READ_BIT, "Rasterizer: mesh_entries");
         add_staging_copy(frame_asset.mesh_draws, frame_asset.mesh_draw_buffer,
@@ -884,7 +885,7 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
     else
     {
         // create/upload joined buffers
-        copy_to_buffer(vertex_buffer_refs, frame_asset.vertex_buffer_refs);
+        copy_to_buffer(mesh_buffers, frame_asset.mesh_buffers);
         copy_to_buffer(mesh_entries, frame_asset.mesh_entry_buffer);
         copy_to_buffer(frame_asset.mesh_draws, frame_asset.mesh_draw_buffer);
         copy_to_buffer(material_data, frame_asset.material_buffer);
@@ -893,7 +894,7 @@ void Rasterizer::update_buffers(const std::vector<drawable_t> &drawables, frame_
 
     frame_asset.indirect_indexed_bundle.mesh_draws = frame_asset.mesh_draw_buffer;
     frame_asset.indirect_indexed_bundle.mesh_draws_host = frame_asset.mesh_draws.data();
-    frame_asset.indirect_indexed_bundle.vertex_buffer_addresses = frame_asset.vertex_buffer_refs;
+    frame_asset.indirect_indexed_bundle.mesh_buffers = frame_asset.mesh_buffers;
     frame_asset.indirect_indexed_bundle.mesh_entries = frame_asset.mesh_entry_buffer;
     frame_asset.indirect_indexed_bundle.materials = frame_asset.material_buffer;
     frame_asset.indirect_indexed_bundle.meshlet_visibilities = frame_asset.meshlet_visibility_buffer;

--- a/src/Rasterizer.cpp
+++ b/src/Rasterizer.cpp
@@ -142,6 +142,7 @@ void swap(Rasterizer &lhs, Rasterizer &rhs) noexcept
     std::swap(lhs.m_current_index, rhs.m_current_index);
     std::swap(lhs.m_push_constant_range, rhs.m_push_constant_range);
     std::swap(lhs.m_start_time, rhs.m_start_time);
+    std::swap(lhs.camera_buffer_address, rhs.camera_buffer_address);
 
     std::swap(lhs.use_mesh_shader, rhs.use_mesh_shader);
     std::swap(lhs.use_gpu_timestamps, rhs.use_gpu_timestamps);
@@ -479,6 +480,7 @@ void Rasterizer::render(VkCommandBuffer command_buffer, frame_assets_t &frame_as
         render_data.draw_commands = draw_buffer_indexed ? draw_buffer_indexed->device_address() : 0;
         render_data.meshlet_visibilities =
                 bundle.meshlet_visibilities ? bundle.meshlet_visibilities->device_address() : 0;
+        render_data.cameras = camera_buffer_address;
 
         if(!frame_assets.render_data_ubo)
         {

--- a/src/RayTracer.cpp
+++ b/src/RayTracer.cpp
@@ -1,3 +1,4 @@
+#include <ranges>
 #include <vierkant/RayTracer.hpp>
 
 namespace vierkant
@@ -74,6 +75,9 @@ void RayTracer::trace_rays(tracable_t tracable, VkCommandBuffer commandbuffer)
             m_device, tracable.descriptors, trace_asset.descriptor_layout_cache, next_layout_cache);
     tracable.pipeline_info.descriptor_set_layouts = {descriptor_set_layout.get()};
 
+    bool variable_count = std::ranges::any_of(tracable.descriptors,
+                                              [](const auto &pair) { return pair.second.variable_count; });
+
     // push constant range
     if(!tracable.push_constants.empty())
     {
@@ -103,7 +107,7 @@ void RayTracer::trace_rays(tracable_t tracable, VkCommandBuffer commandbuffer)
     // fetch descriptor set
     auto descriptor_set = vierkant::find_or_create_descriptor_set(
             m_device, descriptor_set_layout.get(), tracable.descriptors, m_descriptor_pool,
-            trace_asset.descriptor_set_cache, next_descriptor_set_cache, false, true);
+            trace_asset.descriptor_set_cache, next_descriptor_set_cache, variable_count, true);
 
     // update descriptor-set with actual descriptors
     vierkant::update_descriptor_set(m_device, tracable.descriptors, descriptor_set);

--- a/src/UnlitForward.cpp
+++ b/src/UnlitForward.cpp
@@ -26,8 +26,7 @@ SceneRenderer::render_result_t UnlitForward::render_scene(vierkant::Rasterizer &
         vierkant::ShaderType shader_type;
 
         // check for presence of a color-texture
-        auto it = drawable.descriptors.find(vierkant::Rasterizer::BINDING_TEXTURES);
-        bool has_texture = it != drawable.descriptors.end() && !it->second.images.empty();
+        bool has_texture = !drawable.textures.empty();
 
         // check if vertex-skinning is required
         bool has_bones = static_cast<bool>(drawable.mesh->root_bone);

--- a/src/descriptor.cpp
+++ b/src/descriptor.cpp
@@ -5,6 +5,14 @@ namespace vierkant
 {
 
 constexpr uint32_t g_max_bindless_resources = 512;
+
+uint32_t max_bindless_resources(const vierkant::DevicePtr &device)
+{
+    const auto &limits = device->properties().vulkan12;
+    return std::min({g_max_bindless_resources, limits.maxDescriptorSetUpdateAfterBindSampledImages,
+                     limits.maxPerStageDescriptorUpdateAfterBindSampledImages});
+}
+
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 DescriptorPoolPtr create_descriptor_pool(const vierkant::DevicePtr &device, const descriptor_count_t &counts,
@@ -62,7 +70,7 @@ DescriptorSetLayoutPtr create_descriptor_set_layout(const vierkant::DevicePtr &d
         layout_binding.descriptorCount = std::max<uint32_t>(layout_binding.descriptorCount,
                                                             static_cast<uint32_t>(desc.inline_uniform_block.size()));
         layout_binding.descriptorCount =
-                desc.variable_count ? g_max_bindless_resources : layout_binding.descriptorCount;
+                desc.variable_count ? max_bindless_resources(device) : layout_binding.descriptorCount;
         layout_binding.descriptorType = desc.type;
         layout_binding.pImmutableSamplers = nullptr;
         layout_binding.stageFlags = desc.stage_flags;
@@ -93,17 +101,17 @@ DescriptorSetLayoutPtr create_descriptor_set_layout(const vierkant::DevicePtr &d
 ///////////////////////////////////////////////////////////////////////////////////////////////////
 
 DescriptorSetPtr create_descriptor_set(const vierkant::DevicePtr &device, const DescriptorPoolPtr &pool,
-                                       VkDescriptorSetLayout set_layout, bool variable_count)
+                                       VkDescriptorSetLayout set_layout, uint32_t variable_count)
 {
     VkDescriptorSet descriptor_set;
 
-    // max allocatable count
-    uint32_t max_binding = g_max_bindless_resources - 1;
+    // only allocate what is actually in use, the layout still declares max_bindless_resources
+    uint32_t num_descriptors = std::min(variable_count, max_bindless_resources(device));
 
     VkDescriptorSetVariableDescriptorCountAllocateInfo descriptor_count_allocate_info = {};
     descriptor_count_allocate_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_VARIABLE_DESCRIPTOR_COUNT_ALLOCATE_INFO;
     descriptor_count_allocate_info.descriptorSetCount = 1;
-    descriptor_count_allocate_info.pDescriptorCounts = &max_binding;
+    descriptor_count_allocate_info.pDescriptorCounts = &num_descriptors;
 
     VkDescriptorSetAllocateInfo alloc_info = {};
     alloc_info.sType = VK_STRUCTURE_TYPE_DESCRIPTOR_SET_ALLOCATE_INFO;
@@ -278,6 +286,14 @@ DescriptorSetLayoutPtr find_or_create_set_layout(const vierkant::DevicePtr &devi
     // clean descriptor-map to enable sharing
     for(auto &[binding, descriptor]: descriptors)
     {
+        // a variable-count binding is sized by device-limits, not by the array -> drop it from the key
+        if(descriptor.variable_count)
+        {
+            descriptor.images.clear();
+            descriptor.buffers.clear();
+            descriptor.acceleration_structures.clear();
+            continue;
+        }
         for(auto &img: descriptor.images) { img.reset(); }
         for(auto &buf: descriptor.buffers) { buf.reset(); }
         for(auto &as: descriptor.acceleration_structures) { as.reset(); }
@@ -316,6 +332,22 @@ DescriptorSetPtr find_or_create_descriptor_set(const vierkant::DevicePtr &device
 {
     auto descriptors_copy = descriptors;
 
+    // number of descriptors to allocate for a variable-count binding. the set-cache keys on array-sizes,
+    // so a set is only ever reused for an identical count.
+    uint32_t num_variable_descriptors = 0;
+
+    if(variable_count)
+    {
+        for(const auto &[binding, descriptor]: descriptors)
+        {
+            if(descriptor.variable_count)
+            {
+                num_variable_descriptors = std::max<uint32_t>(descriptor.images.size(), descriptor.buffers.size());
+            }
+        }
+        num_variable_descriptors = std::max(1u, num_variable_descriptors);
+    }
+
     if(relax_reuse)
     {
         // clean descriptor-map to enable sharing
@@ -346,7 +378,7 @@ DescriptorSetPtr find_or_create_descriptor_set(const vierkant::DevicePtr &device
         if(current_assets_it == last.end())
         {
             // create a new descriptor set
-            ret = vierkant::create_descriptor_set(device, pool, set_layout, variable_count);
+            ret = vierkant::create_descriptor_set(device, pool, set_layout, num_variable_descriptors);
         }
         else
         {

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -153,16 +153,12 @@ std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_com
         // textures
         if(material && !material->texture_data.empty())
         {
-            vierkant::descriptor_t &desc_texture = drawable.descriptors[Rasterizer::BINDING_TEXTURES];
-            desc_texture.type = VK_DESCRIPTOR_TYPE_COMBINED_IMAGE_SAMPLER;
-            desc_texture.stage_flags = VK_SHADER_STAGE_FRAGMENT_BIT;
-
             for(auto &[type_flag, tex_data]: material->texture_data)
             {
                 if(auto tex = params.assets->texture({tex_data.texture_id, tex_data.sampler_id}))
                 {
                     drawable.material.texture_type_flags |= static_cast<uint32_t>(type_flag);
-                    desc_texture.images.push_back(tex);
+                    drawable.textures.push_back(tex);
                 }
             }
         }

--- a/src/drawable.cpp
+++ b/src/drawable.cpp
@@ -61,8 +61,6 @@ std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_com
                                                  params.interpolation_mode, node_morph_weights);
     }
 
-    bool use_meshlets = mesh->meshlets && mesh->meshlet_vertices && mesh->meshlet_triangles;
-
     for(uint32_t i = 0; i < mesh->entries.size(); ++i)
     {
         if(mesh_component.entry_indices && !mesh_component.entry_indices->contains(i)) { continue; }
@@ -124,27 +122,6 @@ std::vector<vierkant::drawable_t> create_mesh_drawables(const vierkant::mesh_com
         drawable.pipeline_format.blend_state.blendEnable =
                 material && material->blend_mode == vierkant::BlendMode::Blend;
         drawable.pipeline_format.cull_mode = material && material->twosided ? VK_CULL_MODE_NONE : VK_CULL_MODE_BACK_BIT;
-
-        if(!drawable.use_own_buffers)
-        {
-            if(use_meshlets)
-            {
-                auto &desc_meshlets = drawable.descriptors[Rasterizer::BINDING_MESHLETS];
-                desc_meshlets.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_meshlets.stage_flags = VK_SHADER_STAGE_TASK_BIT_EXT | VK_SHADER_STAGE_MESH_BIT_EXT;
-                desc_meshlets.buffers = {mesh->meshlets};
-
-                auto &desc_meshlet_vertices = drawable.descriptors[Rasterizer::BINDING_MESHLET_VERTICES];
-                desc_meshlet_vertices.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_meshlet_vertices.stage_flags = VK_SHADER_STAGE_MESH_BIT_EXT;
-                desc_meshlet_vertices.buffers = {mesh->meshlet_vertices};
-
-                auto &desc_meshlet_triangles = drawable.descriptors[Rasterizer::BINDING_MESHLET_TRIANGLES];
-                desc_meshlet_triangles.type = VK_DESCRIPTOR_TYPE_STORAGE_BUFFER;
-                desc_meshlet_triangles.stage_flags = VK_SHADER_STAGE_MESH_BIT_EXT;
-                desc_meshlet_triangles.buffers = {mesh->meshlet_triangles};
-            }
-        }
 
         // NOTE: not used anymore by most pipelines
         drawable.pipeline_format.binding_descriptions = binding_descriptions;

--- a/src/imgui/imgui_integration.cpp
+++ b/src/imgui/imgui_integration.cpp
@@ -327,7 +327,7 @@ void Context::draw_gui(vierkant::Rasterizer &renderer)
                 auto drawable = m_imgui_assets.drawable;
                 drawable.mesh = mesh_assets[n].mesh;
                 drawable.matrices = matrices;
-                drawable.descriptors[vierkant::Rasterizer::BINDING_TEXTURES].images = {tex};
+                drawable.textures = {tex};
                 drawable.vertex_offset = static_cast<int32_t>(pcmd->VtxOffset);
                 drawable.base_index = base_index;
                 drawable.num_indices = pcmd->ElemCount;

--- a/tests/TestMesh.cpp
+++ b/tests/TestMesh.cpp
@@ -114,7 +114,7 @@ TEST(Mesh, basic)
 
     // use the pool to allocate the actual descriptor-set
     auto descriptor_set =
-            vierkant::create_descriptor_set(test_context.device, pool, descriptor_set_layout.get(), false);
+            vierkant::create_descriptor_set(test_context.device, pool, descriptor_set_layout.get(), 0);
 
     // update the descriptor set
     vierkant::update_descriptor_set(test_context.device, descriptors, descriptor_set);

--- a/tests/TestPBRDeferred.cpp
+++ b/tests/TestPBRDeferred.cpp
@@ -1,5 +1,6 @@
 #include "test_context.hpp"
 #include "vierkant/PBRDeferred.hpp"
+#include "vierkant/cubemap_utils.hpp"
 #include "vierkant/model/model_loading.hpp"
 #include "vierkant/vierkant.hpp"
 
@@ -50,6 +51,14 @@ TEST(TestPBRDeferred, basic)
     scene->add_object(mesh_node);
     EXPECT_TRUE(scene);
 
+    // an environment plus both convolutions enable the lighting-pass and with it the skybox-pass,
+    // which binds a SamplerCube in set 0
+    constexpr auto hdr_format = VK_FORMAT_R16G16B16A16_SFLOAT;
+    auto env_img = vierkant::cubemap_neutral_environment(test_context.device, 256, test_context.device->queue(), true,
+                                                         hdr_format);
+    scene->set_environment(env_img);
+    EXPECT_TRUE(scene->environment());
+
     // create PBR scene-renderer
     vierkant::PBRDeferred::create_info_t pbr_render_info = {};
 
@@ -58,6 +67,15 @@ TEST(TestPBRDeferred, basic)
     pbr_render_info.pipeline_cache = nullptr;
     pbr_render_info.settings.resolution = res;
     pbr_render_info.settings.indirect_draw = false;
+    pbr_render_info.conv_lambert =
+            vierkant::create_convolution_lambert(test_context.device, env_img, 64, hdr_format,
+                                                 test_context.device->queue());
+    pbr_render_info.conv_ggx = vierkant::create_convolution_ggx(test_context.device, env_img, env_img->width(), hdr_format,
+                                                                test_context.device->queue());
+    // NOTE: both convolutions come back in VK_IMAGE_LAYOUT_TRANSFER_DST_OPTIMAL, sampling them needs this
+    pbr_render_info.conv_lambert->transition_layout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+    pbr_render_info.conv_ggx->transition_layout(VK_IMAGE_LAYOUT_SHADER_READ_ONLY_OPTIMAL);
+
     auto pbr_renderer = vierkant::PBRDeferred::create(test_context.device, pbr_render_info);
     EXPECT_TRUE(pbr_renderer);
 


### PR DESCRIPTION
replace most `Rasterizer::DescriptorBinding` slots with device-addresses.
